### PR TITLE
Add basic CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: ci
+on:
+  push:
+    branches: [main, "v*"]
+    tags: ["v*"]
+  pull_request:
+    branches: [main, "v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # https://consoledonottrack.com/
+  DO_NOT_TRACK: 1
+
+jobs:
+  all:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x]
+    name: "Node.js ${{ matrix.node-version }}"
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: protobuf-es/test/${{ github.sha }}
+          restore-keys: protobuf-es/test
+      - run: npm ci
+      - run: npm run all
+      - run: node scripts/gh-diffcheck.js

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "packages/cel-peggy",
     "packages/cel-antlr"
   ],
+  "type": "module",
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.16.4",
     "@bufbuild/buf": "^1.47.2",

--- a/scripts/gh-diffcheck.js
+++ b/scripts/gh-diffcheck.js
@@ -1,0 +1,22 @@
+import { execSync } from "node:child_process";
+
+if (gitUncommitted()) {
+  process.stdout.write(
+    "::error::Uncommitted changes found. Please make sure this branch is up to date, and run the command locally (for example `npx turbo format`). " +
+      "Verify the changes are what you want and commit them.\n",
+  );
+  execSync("git --no-pager diff", {
+    stdio: "inherit",
+  });
+  process.exit(1);
+}
+
+/**
+ * @returns {boolean}
+ */
+function gitUncommitted() {
+  const out = execSync("git status --porcelain", {
+    encoding: "utf-8",
+  });
+  return out.trim().length > 0;
+}


### PR DESCRIPTION
The workflow simply runs `npm run all` for Node.js v20 and v22.

`npm run all` runs scripts for every package, but currently _does not run lint_. We'll figure out lint later.

Afterwards, it checks for a git diff, to ensure that everything is formatted, and that generated code is up-to-date.