### PR TITLE
Prepare for protobuf-es v2

### DIFF
--- a/packages/cel-antlr/src/adapter/cel.ts
+++ b/packages/cel-antlr/src/adapter/cel.ts
@@ -53,7 +53,7 @@ export class CelAdapter implements CelValAdapter<CelVal> {
       return lhs instanceof ProtoNull;
     } else if (lhs instanceof ProtoNull) {
       if (rhs instanceof ProtoNull) {
-        return lhs.messageType === rhs.messageType;
+        return lhs.messageTypeName === rhs.messageTypeName;
       }
       return false;
     }
@@ -101,6 +101,10 @@ export class CelAdapter implements CelValAdapter<CelVal> {
       } else if (lhs instanceof Uint8Array && rhs instanceof Uint8Array) {
         return compareBytes(lhs, rhs) === 0;
       } else if (isMessage(lhs) && isMessage(rhs)) {
+        // TODO(tstamm) will need registry to check equality for protobuf messages efficiently
+        // - class CelAdapter is only used through singleton CEL_ADAPTER
+        // - const CEL_ADAPTER is widely used
+
         // TODO(afuller): Figure out why this is needed.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-argument
         return lhs.getType() === rhs.getType() && lhs.equals(rhs as any);
@@ -109,7 +113,7 @@ export class CelAdapter implements CelValAdapter<CelVal> {
     return false;
   }
 
-  equalsObject(id: number, lhs: CelObject, rhs: CelObject) {
+  private equalsObject(id: number, lhs: CelObject, rhs: CelObject) {
     if (!lhs.type_.equals(rhs.type_)) {
       return false;
     }

--- a/packages/cel-antlr/src/adapter/native.ts
+++ b/packages/cel-antlr/src/adapter/native.ts
@@ -16,7 +16,7 @@ import {
 import { type CelResult, isCelResult } from "../value/value.js";
 import { CEL_ADAPTER } from "./cel.js";
 
-export class NativeValAdapter implements CelValAdapter {
+class NativeValAdapter implements CelValAdapter {
   unwrap(val: CelVal): CelVal {
     return CEL_ADAPTER.unwrap(val);
   }

--- a/packages/cel-antlr/src/value/empty.ts
+++ b/packages/cel-antlr/src/value/empty.ts
@@ -3,9 +3,13 @@ import {
   BoolValue,
   BytesValue,
   DoubleValue,
+  FloatValue,
+  Int32Value,
   Int64Value,
   StringValue,
+  UInt32Value,
   UInt64Value,
+  Value,
 } from "@bufbuild/protobuf";
 
 import { CEL_ADAPTER } from "../adapter/cel.js";
@@ -30,7 +34,7 @@ import {
 export const EMPTY_LIST = new CelList([], CEL_ADAPTER, type.LIST);
 export const EMPTY_MAP = new CelMap(new Map(), CEL_ADAPTER, type.DYN_MAP);
 
-export class EmptyProvider implements CelValProvider {
+class EmptyProvider implements CelValProvider {
   public readonly adapter: CelValAdapter = CEL_ADAPTER;
 
   newValue(
@@ -39,52 +43,52 @@ export class EmptyProvider implements CelValProvider {
     obj: CelObject | CelMap,
   ): CelResult | undefined {
     switch (typeName) {
-      case "google.protobuf.BoolValue": {
+      case BoolValue.typeName: {
         const val = coerceToBool(id, obj.accessByName(id, "value"));
         if (val instanceof CelError || val instanceof CelUnknown) {
           return val;
         }
         return new BoolValue({ value: val });
       }
-      case "google.protobuf.UInt32Value":
-      case "google.protobuf.UInt64Value": {
+      case UInt32Value.typeName:
+      case UInt64Value.typeName: {
         const val = coerceToBigInt(id, obj.accessByName(id, "value"));
         if (val instanceof CelError || val instanceof CelUnknown) {
           return val;
         }
         return new UInt64Value({ value: val.valueOf() });
       }
-      case "google.protobuf.Int32Value":
-      case "google.protobuf.Int64Value": {
+      case Int32Value.typeName:
+      case Int64Value.typeName: {
         const val = coerceToBigInt(id, obj.accessByName(id, "value"));
         if (val instanceof CelError || val instanceof CelUnknown) {
           return val;
         }
         return new Int64Value({ value: val.valueOf() });
       }
-      case "google.protobuf.FloatValue":
-      case "google.protobuf.DoubleValue": {
+      case FloatValue.typeName:
+      case DoubleValue.typeName: {
         const val = coerceToNumber(id, obj.accessByName(id, "value"));
         if (val instanceof CelError || val instanceof CelUnknown) {
           return val;
         }
         return new DoubleValue({ value: val });
       }
-      case "google.protobuf.StringValue": {
+      case StringValue.typeName: {
         const val = coerceToString(id, obj.accessByName(id, "value"));
         if (val instanceof CelError || val instanceof CelUnknown) {
           return val;
         }
         return new StringValue({ value: val });
       }
-      case "google.protobuf.BytesValue": {
+      case BytesValue.typeName: {
         const val = coerceToBytes(id, obj.accessByName(id, "value"));
         if (val instanceof CelError || val instanceof CelUnknown) {
           return val;
         }
         return new BytesValue({ value: val });
       }
-      case "google.protobuf.Value":
+      case Value.typeName:
         if (obj instanceof CelObject) {
           for (const key in obj.getFields()) {
             switch (key) {

--- a/packages/cel-antlr/src/value/value.ts
+++ b/packages/cel-antlr/src/value/value.ts
@@ -7,7 +7,6 @@ import {
   Int64Value,
   isMessage,
   Message,
-  type MessageType,
   StringValue,
   Timestamp,
   UInt64Value,
@@ -219,7 +218,7 @@ export type StructAccess<K = unknown> = IterAccess &
 // proto3 has typed nulls.
 export class ProtoNull {
   constructor(
-    public readonly messageType: MessageType,
+    public readonly messageTypeName: string,
     public readonly defaultValue: CelVal,
     public value: CelVal = null,
   ) {}

--- a/packages/cel-peggy/src/adapter/cel.ts
+++ b/packages/cel-peggy/src/adapter/cel.ts
@@ -53,7 +53,7 @@ export class CelAdapter implements CelValAdapter<CelVal> {
       return lhs instanceof ProtoNull;
     } else if (lhs instanceof ProtoNull) {
       if (rhs instanceof ProtoNull) {
-        return lhs.messageType === rhs.messageType;
+        return lhs.messageTypeName === rhs.messageTypeName;
       }
       return false;
     }
@@ -101,6 +101,10 @@ export class CelAdapter implements CelValAdapter<CelVal> {
       } else if (lhs instanceof Uint8Array && rhs instanceof Uint8Array) {
         return compareBytes(lhs, rhs) === 0;
       } else if (isMessage(lhs) && isMessage(rhs)) {
+        // TODO(tstamm) will need registry to check equality for protobuf messages efficiently
+        // - class CelAdapter is only used through singleton CEL_ADAPTER
+        // - const CEL_ADAPTER is widely used
+
         // TODO(afuller): Figure out why this is needed.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-argument
         return lhs.getType() === rhs.getType() && lhs.equals(rhs as any);
@@ -109,7 +113,7 @@ export class CelAdapter implements CelValAdapter<CelVal> {
     return false;
   }
 
-  equalsObject(id: number, lhs: CelObject, rhs: CelObject) {
+  private equalsObject(id: number, lhs: CelObject, rhs: CelObject) {
     if (!lhs.type_.equals(rhs.type_)) {
       return false;
     }

--- a/packages/cel-peggy/src/adapter/native.ts
+++ b/packages/cel-peggy/src/adapter/native.ts
@@ -16,7 +16,7 @@ import {
 import { type CelResult, isCelResult } from "../value/value.js";
 import { CEL_ADAPTER } from "./cel.js";
 
-export class NativeValAdapter implements CelValAdapter {
+class NativeValAdapter implements CelValAdapter {
   unwrap(val: CelVal): CelVal {
     return CEL_ADAPTER.unwrap(val);
   }

--- a/packages/cel-peggy/src/value/empty.ts
+++ b/packages/cel-peggy/src/value/empty.ts
@@ -3,9 +3,13 @@ import {
   BoolValue,
   BytesValue,
   DoubleValue,
+  FloatValue,
+  Int32Value,
   Int64Value,
   StringValue,
+  UInt32Value,
   UInt64Value,
+  Value,
 } from "@bufbuild/protobuf";
 
 import { CEL_ADAPTER } from "../adapter/cel.js";
@@ -30,7 +34,7 @@ import {
 export const EMPTY_LIST = new CelList([], CEL_ADAPTER, type.LIST);
 export const EMPTY_MAP = new CelMap(new Map(), CEL_ADAPTER, type.DYN_MAP);
 
-export class EmptyProvider implements CelValProvider {
+class EmptyProvider implements CelValProvider {
   public readonly adapter: CelValAdapter = CEL_ADAPTER;
 
   newValue(
@@ -39,52 +43,52 @@ export class EmptyProvider implements CelValProvider {
     obj: CelObject | CelMap,
   ): CelResult | undefined {
     switch (typeName) {
-      case "google.protobuf.BoolValue": {
+      case BoolValue.typeName: {
         const val = coerceToBool(id, obj.accessByName(id, "value"));
         if (val instanceof CelError || val instanceof CelUnknown) {
           return val;
         }
         return new BoolValue({ value: val });
       }
-      case "google.protobuf.UInt32Value":
-      case "google.protobuf.UInt64Value": {
+      case UInt32Value.typeName:
+      case UInt64Value.typeName: {
         const val = coerceToBigInt(id, obj.accessByName(id, "value"));
         if (val instanceof CelError || val instanceof CelUnknown) {
           return val;
         }
         return new UInt64Value({ value: val.valueOf() });
       }
-      case "google.protobuf.Int32Value":
-      case "google.protobuf.Int64Value": {
+      case Int32Value.typeName:
+      case Int64Value.typeName: {
         const val = coerceToBigInt(id, obj.accessByName(id, "value"));
         if (val instanceof CelError || val instanceof CelUnknown) {
           return val;
         }
         return new Int64Value({ value: val.valueOf() });
       }
-      case "google.protobuf.FloatValue":
-      case "google.protobuf.DoubleValue": {
+      case FloatValue.typeName:
+      case DoubleValue.typeName: {
         const val = coerceToNumber(id, obj.accessByName(id, "value"));
         if (val instanceof CelError || val instanceof CelUnknown) {
           return val;
         }
         return new DoubleValue({ value: val });
       }
-      case "google.protobuf.StringValue": {
+      case StringValue.typeName: {
         const val = coerceToString(id, obj.accessByName(id, "value"));
         if (val instanceof CelError || val instanceof CelUnknown) {
           return val;
         }
         return new StringValue({ value: val });
       }
-      case "google.protobuf.BytesValue": {
+      case BytesValue.typeName: {
         const val = coerceToBytes(id, obj.accessByName(id, "value"));
         if (val instanceof CelError || val instanceof CelUnknown) {
           return val;
         }
         return new BytesValue({ value: val });
       }
-      case "google.protobuf.Value":
+      case Value.typeName:
         if (obj instanceof CelObject) {
           for (const key in obj.getFields()) {
             switch (key) {

--- a/packages/cel-peggy/src/value/value.ts
+++ b/packages/cel-peggy/src/value/value.ts
@@ -7,7 +7,6 @@ import {
   Int64Value,
   isMessage,
   Message,
-  type MessageType,
   StringValue,
   Timestamp,
   UInt64Value,
@@ -219,7 +218,7 @@ export type StructAccess<K = unknown> = IterAccess &
 // proto3 has typed nulls.
 export class ProtoNull {
   constructor(
-    public readonly messageType: MessageType,
+    public readonly messageTypeName: string,
     public readonly defaultValue: CelVal,
     public value: CelVal = null,
   ) {}


### PR DESCRIPTION
Avoid Message.getType because it will be unavailable. Update some switch statements switching on message type to switch on type name instead.

There is one usage of getType left in CelAdapter. It's used to implement CelValAdapter.equals, and still needs to be replaced.

Also: Reduce visibility for some classes and methods to help refactoring.