### PR TITLE
Don't build for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,8 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
-/.tmp
 /packages/*/dist
 node_modules
-*.local
 .antlr/
 .turbo
 

--- a/packages/cel-antlr/.npmignore
+++ b/packages/cel-antlr/.npmignore
@@ -1,5 +1,9 @@
-/src
-/*.json
-/dist/**/*.test.js
-/dist/**/*.test.d.ts
-/scripts/*
+src
+scripts
+tsconfig.json
+tsconfig.*.json
+turbo.json
+dist/**/*.test.js
+dist/**/*.test.d.ts
+dist/*/testing.js
+dist/*/testing.d.ts

--- a/packages/cel-antlr/package.json
+++ b/packages/cel-antlr/package.json
@@ -35,8 +35,5 @@
     "@bufbuild/cel-spec": "0.0.1",
     "antlr4ts": "^0.5.0-alpha.4",
     "date-fns-tz": "^2.0.0"
-  },
-  "files": [
-    "dist/**"
-  ]
+  }
 }

--- a/packages/cel-peggy/.npmignore
+++ b/packages/cel-peggy/.npmignore
@@ -1,5 +1,9 @@
-/src
-/*.json
-/dist/**/*.test.js
-/dist/**/*.test.d.ts
-/scripts/*
+src
+scripts
+tsconfig.json
+tsconfig.*.json
+turbo.json
+dist/**/*.test.js
+dist/**/*.test.d.ts
+dist/*/testing.js
+dist/*/testing.d.ts

--- a/packages/cel-peggy/package.json
+++ b/packages/cel-peggy/package.json
@@ -39,8 +39,5 @@
   },
   "devDependencies": {
     "peggy": "^4.2.0"
-  },
-  "files": [
-    "dist/**"
-  ]
+  }
 }

--- a/packages/cel-spec/.npmignore
+++ b/packages/cel-spec/.npmignore
@@ -1,0 +1,7 @@
+src
+scripts
+proto
+tsconfig.json
+tsconfig.*.json
+turbo.json
+buf.*

--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,7 @@
       "outputs": ["src/gen/**"]
     },
     "test": {
-      "dependsOn": ["build"],
+      "dependsOn": ["^build"],
       "cache": false
     },
     "format": {},


### PR DESCRIPTION
With the current turbo.json, we build before running tests. It's not necessary, and CI should be more useful without that.

Also fixes removes test files from artifacts published to npmjs.com.