### PR TITLE
Add standard workflows

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -1,0 +1,21 @@
+name: Add issues and PRs to project
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - transferred
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  call-workflow-add-to-project:
+    name: Call workflow to add issue to project
+    uses: bufbuild/base-workflows/.github/workflows/add-to-project.yaml@main
+    secrets: inherit

--- a/.github/workflows/emergency-review-bypass.yaml
+++ b/.github/workflows/emergency-review-bypass.yaml
@@ -1,0 +1,12 @@
+name: Bypass review in case of emergency
+on:
+  pull_request:
+    types:
+      - labeled
+permissions:
+  pull-requests: write
+jobs:
+  approve:
+    if: github.event.label.name == 'Emergency Bypass Review'
+    uses: bufbuild/base-workflows/.github/workflows/emergency-review-bypass.yaml@main
+    secrets: inherit

--- a/.github/workflows/notify-approval-bypass.yaml
+++ b/.github/workflows/notify-approval-bypass.yaml
@@ -1,0 +1,12 @@
+name: PR Approval Bypass Notifier
+on:
+  pull_request:
+    types:
+      - closed
+    branches: [main, v2]
+permissions:
+  pull-requests: read
+jobs:
+  approval:
+    uses: bufbuild/base-workflows/.github/workflows/notify-approval-bypass.yaml@main
+    secrets: inherit

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,18 @@
+name: Lint PR Title
+# Prevent writing to the repository using the CI token.
+# Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
+permissions:
+  pull-requests: read
+on:
+  pull_request:
+    # By default, a workflow only runs when a pull_request's activity type is opened,
+    # synchronize, or reopened. We explicity override here so that PR titles are
+    # re-linted when the PR text content is edited.
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+jobs:
+  lint:
+    uses: bufbuild/base-workflows/.github/workflows/pr-title.yaml@main


### PR DESCRIPTION
Adds standard GH workflows such as the PR title linter, see https://github.com/bufbuild/protobuf-es/tree/main/.github/workflows