### PR TITLE
Fix field type for delimited messages in buf.validate.FieldPath

### DIFF
--- a/packages/protovalidate/src/error.ts
+++ b/packages/protovalidate/src/error.ts
@@ -281,11 +281,8 @@ function pathToProto(path: Path): FieldPath {
           create(FieldPathElementSchema, {
             fieldName: e.name,
             fieldNumber: e.number,
-            fieldType: e.proto.type,
-            keyType:
-              e.fieldKind == "map"
-                ? (e.mapKey as number as FieldDescriptorProto_Type)
-                : undefined,
+            fieldType: fieldType(e),
+            keyType: mapKeyType(e),
             valueType: mapValueType(e),
           }),
         );
@@ -326,6 +323,20 @@ function pathToProto(path: Path): FieldPath {
     }
   }
   return create(FieldPathSchema, { elements });
+}
+
+function fieldType(field: DescField): FieldDescriptorProto_Type {
+  if (field.fieldKind == "message" && field.delimitedEncoding) {
+    return FieldDescriptorProto_Type.GROUP;
+  }
+  return field.proto.type;
+}
+
+function mapKeyType(field: DescField): FieldDescriptorProto_Type | undefined {
+  if (field.fieldKind == "map") {
+    return field.mapKey as number as FieldDescriptorProto_Type;
+  }
+  return undefined;
 }
 
 function mapValueType(field: DescField): FieldDescriptorProto_Type | undefined {


### PR DESCRIPTION
When creating a FieldPathElement, we set `FieldPathElement.field_type` to the corresponding FieldDescriptorProto's type.

But because `buf.validate.FieldPath` is designed to traverse unknown fields through wire data, this is incorrect for message fields with delimited encoding. For such a field, `FieldPathElement.field_type` should actually be TYPE_GROUP, even though `FieldDescriptorProto.type` is TYPE_MESSAGE. This allows clients without schema knowledge to traverse wire data.

This PR updates the function `pathToProto`, and adds a test.