### PR TITLE
Populate FieldPathElement.key_type and value_type only for map subscripts

### DIFF
--- a/packages/protovalidate/src/error.test.ts
+++ b/packages/protovalidate/src/error.test.ts
@@ -27,10 +27,11 @@ import { buildPath, parsePath, type Path } from "./path.js";
 import {
   FieldConstraintsSchema,
   type FieldPath,
+  FieldPathElementSchema,
   ViolationSchema,
   ViolationsSchema,
 } from "./gen/buf/validate/validate_pb.js";
-import { isMessage } from "@bufbuild/protobuf";
+import { isFieldSet, isMessage } from "@bufbuild/protobuf";
 import { assertPathsEqual, getTestDataForPaths } from "./path.testdata.js";
 import { compileMessage } from "@bufbuild/protocompile";
 import { FieldDescriptorProto_Type } from "@bufbuild/protobuf/wkt";
@@ -119,6 +120,64 @@ void suite("violationToProto", () => {
     assert.equal(
       proto.field.elements[0].fieldType,
       FieldDescriptorProto_Type.GROUP,
+    );
+  });
+  void test("does not populate FieldPathElement.key_type and value_type for map field without subscript", () => {
+    const descMessage = compileMessage(`
+      syntax="proto3";
+      message M {
+        map<int32, int32> m = 1;
+      }
+    `);
+    const violation = new Violation(
+      "failure-message",
+      "constraint-id",
+      buildPath(descMessage).field(descMessage.field.m).toPath(),
+      [],
+      false,
+    );
+    const proto = violationToProto(violation);
+    assert.ok(proto.field);
+    assert.equal(proto.field.elements.length, 1);
+    assert.equal(
+      isFieldSet(proto.field.elements[0], FieldPathElementSchema.field.keyType),
+      false,
+    );
+    assert.equal(
+      isFieldSet(
+        proto.field.elements[0],
+        FieldPathElementSchema.field.valueType,
+      ),
+      false,
+    );
+  });
+  void test("populates FieldPathElement.key_type and value_type for map field with subscript", () => {
+    const descMessage = compileMessage(`
+      syntax="proto3";
+      message M {
+        map<int32, int32> m = 1;
+      }
+    `);
+    const violation = new Violation(
+      "failure-message",
+      "constraint-id",
+      buildPath(descMessage).field(descMessage.field.m).mapKey(123).toPath(),
+      [],
+      false,
+    );
+    const proto = violationToProto(violation);
+    assert.ok(proto.field);
+    assert.equal(proto.field.elements.length, 1);
+    assert.equal(
+      isFieldSet(proto.field.elements[0], FieldPathElementSchema.field.keyType),
+      true,
+    );
+    assert.equal(
+      isFieldSet(
+        proto.field.elements[0],
+        FieldPathElementSchema.field.valueType,
+      ),
+      true,
     );
   });
   void test("violationsToProto", () => {


### PR DESCRIPTION
Following the Go implementation, do not populate `key_type` and `value_type` of `buf.validate.FieldPathElement` for map fields, unless one of the `subscript` fields is set.