### PR TITLE
Support extensions in buf.validate.FieldPath

### DIFF
--- a/packages/protovalidate/src/error.test.ts
+++ b/packages/protovalidate/src/error.test.ts
@@ -196,12 +196,12 @@ void suite("pathFromViolationProto", () => {
     return violationsToProto([new Violation("message", "id", path, [], false)])
       .violations[0].field;
   }
-  const cases = getTestDataForPaths().cases.filter((c) => !c.usesExtension);
+  const { cases, registry } = getTestDataForPaths();
   for (const { string, golden, schema } of cases) {
     const proto = toProto(golden);
     if (proto !== undefined) {
       void test(string, () => {
-        const path = pathFromViolationProto(schema, proto);
+        const path = pathFromViolationProto(schema, proto, registry);
         assertPathsEqual(path, golden);
       });
     }

--- a/packages/protovalidate/src/path.testdata.ts
+++ b/packages/protovalidate/src/path.testdata.ts
@@ -14,7 +14,11 @@
 
 import * as assert from "node:assert/strict";
 import { compileFile } from "@bufbuild/protocompile";
-import { type DescExtension, type DescMessage } from "@bufbuild/protobuf";
+import {
+  createRegistry,
+  type DescExtension,
+  type DescMessage,
+} from "@bufbuild/protobuf";
 import { type Path } from "./path.js";
 
 export function assertPathsEqual(got: Path, want: Path) {
@@ -219,5 +223,5 @@ export function getTestDataForPaths() {
       error: `Invalid map key at column 9`,
     },
   ];
-  return { cases, invalid, schema };
+  return { cases, invalid, schema, registry: createRegistry(file) };
 }


### PR DESCRIPTION
This updates `pathToProto()` and `pathFromViolationProto()` to support extensions in the path, and adds tests.