### PR TITLE
Allow clearing variables from the CEL environment

### DIFF
--- a/packages/cel/src/celenv.ts
+++ b/packages/cel/src/celenv.ts
@@ -148,8 +148,15 @@ export class CelEnv {
     return this.eval(this.plan(this.parse(expr)));
   }
 
+  /**
+   * Define a variable.
+   *
+   * Passing `undefined` as a value removes any previous definition.
+   */
   public set(name: string, value: unknown): void {
-    if (
+    if (value === undefined) {
+      delete this.data[name];
+    } else if (
       isCelVal(value) ||
       value instanceof CelError ||
       value instanceof CelUnknown

--- a/packages/protovalidate/src/cel.ts
+++ b/packages/protovalidate/src/cel.ts
@@ -264,11 +264,6 @@ export class CelManager {
     this.now.nanos = n2.nanos;
   }
 
-  clearEnv(key: "this" | "rules" | "rule"): void {
-    // TODO should clear, not set `null` - support clearing in CEL, or refactor this code
-    this.env.set(key, null);
-  }
-
   setEnv(key: "this" | "rules" | "rule", value: unknown): void {
     this.env.set(key, value);
   }
@@ -400,8 +395,8 @@ export class EvalCustomCel implements Eval<ReflectMessageGet> {
 
   eval(val: ReflectMessageGet, cursor: Cursor): void {
     this.celMan.setEnv("this", reflectToCel(val));
-    this.celMan.clearEnv("rules");
-    this.celMan.clearEnv("rule");
+    this.celMan.setEnv("rules", undefined);
+    this.celMan.setEnv("rule", undefined);
     for (const child of this.children) {
       const vio = this.celMan.eval(child.compiled);
       if (vio) {
@@ -492,7 +487,7 @@ export class EvalStandardRulesCel implements Eval<ReflectMessageGet> {
   eval(val: ReflectMessageGet, cursor: Cursor): void {
     this.celMan.setEnv("this", reflectToCel(val));
     this.celMan.setEnv("rules", this.rules);
-    this.celMan.clearEnv("rule");
+    this.celMan.setEnv("rule", undefined);
     for (const child of this.children) {
       const vio = this.celMan.eval(child.compiled);
       if (vio) {


### PR DESCRIPTION
While we can define a CEL variable on the CEL environment with `set()`, we can't clear it.

This adds support for passing `undefined` to remove a variable, and updates the protovalidate implementation to use this feature.