### PR TITLE
DVRL-367 - updating links

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Offered under the [Apache 2 license][license].
 [license]: LICENSE
 [contributing]: .github/CONTRIBUTING.md
 [protoc-gen-validate]: https://github.com/bufbuild/protoc-gen-validate
-[protovalidate]: https://buf.build/docs/protovalidate/overview/
+[protovalidate]: https://buf.build/docs/protovalidate
 [quickstart]: https://buf.build/docs/protovalidate/quickstart/
 [conformance-executable]: ./packages/protovalidate-testing/README.md
 [validate-proto]: https://buf.build/bufbuild/protovalidate/docs/main:buf.validate

--- a/packages/protovalidate/README.md
+++ b/packages/protovalidate/README.md
@@ -49,6 +49,6 @@ try {
 }
 ```
 
-[protovalidate]: https://buf.build/docs/protovalidate/overview/
+[protovalidate]: https://buf.build/docs/protovalidate
 [cel]: https://cel.dev
 [protoc-gen-validate]: https://github.com/bufbuild/protoc-gen-validate


### PR DESCRIPTION
This PR fixes two links to docs that have gone 404 due to a docs-side change.