### PR TITLE
Fix misleading field not found error message

### DIFF
--- a/packages/cel/src/adapter/proto.ts
+++ b/packages/cel/src/adapter/proto.ts
@@ -212,11 +212,7 @@ export class ProtoValAdapter implements CelValAdapter {
       const schema = this.getSchema(obj.$typeName);
       const field = schema.fields.find((f) => f.name === name);
       if (!field) {
-        return CelErrors.fieldNotFound(
-          id,
-          name,
-          schema.fields.map((f) => f.name),
-        );
+        return CelErrors.fieldNotFound(id, name, schema.toString());
       }
       return isFieldSet(obj, field);
     }
@@ -232,11 +228,7 @@ export class ProtoValAdapter implements CelValAdapter {
       const schema = this.getSchema(obj.$typeName);
       const field = schema.fields.find((f) => f.name === name);
       if (!field) {
-        return CelErrors.fieldNotFound(
-          id,
-          name,
-          schema.fields.map((f) => f.name),
-        );
+        return CelErrors.fieldNotFound(id, name, schema.toString());
       }
       const r = reflect(schema, obj);
       switch (field.fieldKind) {
@@ -564,7 +556,7 @@ export class ProtoValAdapter implements CelValAdapter {
     for (const key of keys) {
       const field = fields.get(key as string);
       if (!field) {
-        return CelErrors.fieldNotFound(id, key, Array.from(fields.keys()));
+        return CelErrors.fieldNotFound(id, key, messageSchema.toString());
       }
       // TODO(tstamm) what does accessByName return? why don't we use the adapter?
       const val = obj.accessByName(id, key);

--- a/packages/cel/src/value/value.ts
+++ b/packages/cel/src/value/value.ts
@@ -689,12 +689,12 @@ export class CelErrors {
   static fieldNotFound(
     id: number,
     name: unknown,
-    fields: unknown = undefined,
+    container?: string,
   ): CelError {
-    if (fields !== undefined) {
+    if (container !== undefined) {
       return new CelError(
         id,
-        `field not found: ${String(name)} in ${String(fields)}`,
+        `field not found: ${String(name)} in ${container}`,
       );
     }
     return new CelError(id, `field not found: ${String(name)}`);


### PR DESCRIPTION
```proto
message Person {
  string first_name = 1;
}
```

The CEL expression `p.firstName` will raise the error "field not found: firstName in first_name", which is misleading.

This PR changes the error message to "field not found: firstName in message Person".