### PR TITLE
Update to protovalidate v0.10.4

### DIFF
--- a/packages/protovalidate-testing/expected-failures.yaml
+++ b/packages/protovalidate-testing/expected-failures.yaml
@@ -1,3 +1,241 @@
+library/is_ip:
+  - version/omitted/invalid/ipv6/g
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.IsIp]:{val:":0::0"}
+  #        want: validation error (1 violation)
+  #          1. constraint_id: "library.is_ip"
+  #         got: valid
+  - version/omitted/invalid/ipv6/h
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.IsIp]:{val:"0::0:"}
+  #        want: validation error (1 violation)
+  #          1. constraint_id: "library.is_ip"
+  #         got: valid
+  - version/omitted/invalid/ipv6/i
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.IsIp]:{val:"0::0:"}
+  #        want: validation error (1 violation)
+  #          1. constraint_id: "library.is_ip"
+  #         got: valid
+  - version/omitted/invalid/ipv6/j
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.IsIp]:{val:"::0000ffff"}
+  #        want: validation error (1 violation)
+  #          1. constraint_id: "library.is_ip"
+  #         got: valid
+standard_constraints/required:
+  - proto/2023/map/empty/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredEditionsMapIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_MESSAGE}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto/2023/message/explicit_presence/delimited/unset/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_GROUP}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto/2023/message/explicit_presence/length_prefixed/unset/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_MESSAGE}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto/2023/oneof/other_member/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredEditionsOneofIgnoreAlways]:{b:"foo"}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "a" elements:{field_number:1 field_name:"a" field_type:TYPE_STRING}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto/2023/oneof/unset/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredEditionsOneofIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "a" elements:{field_number:1 field_name:"a" field_type:TYPE_STRING}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto/2023/repeated/compact/empty/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredEditionsRepeatedIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_STRING}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto/2023/repeated/expanded/empty/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredEditionsRepeatedExpandedIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_STRING}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto/2023/scalar/explicit_presence/unset/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredEditionsScalarExplicitPresenceIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_STRING}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto/2023/scalar/explicit_presence_with_default/unset/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_STRING}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto/2023/scalar/implicit_presence/zero/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredEditionsScalarImplicitPresenceIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_STRING}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto2/map/empty/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredProto2MapIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_MESSAGE}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto2/message/unset/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredProto2MessageIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_MESSAGE}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto2/oneof/other_member/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredProto2OneofIgnoreAlways]:{b:"foo"}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "a" elements:{field_number:1 field_name:"a" field_type:TYPE_STRING}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto2/oneof/unset/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredProto2OneofIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "a" elements:{field_number:1 field_name:"a" field_type:TYPE_STRING}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto2/repeated/empty/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredProto2RepeatedIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_STRING}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto2/scalar/optional/unset/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredProto2ScalarOptionalIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_STRING}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto2/scalar/optional_with_default/unset/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredProto2ScalarOptionalDefaultIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_STRING}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto3/map/empty/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredProto3MapIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_MESSAGE}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto3/message/unset/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_MESSAGE}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto3/oneof/other_member/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredProto3OneOfIgnoreAlways]:{b:"foo"}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "a" elements:{field_number:1 field_name:"a" field_type:TYPE_STRING}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto3/oneof/unset/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredProto3OneOfIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "a" elements:{field_number:1 field_name:"a" field_type:TYPE_STRING}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto3/repeated/empty/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredProto3RepeatedIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_STRING}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto3/scalar/optional/unset/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredProto3OptionalScalarIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_STRING}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
+  - proto3/scalar/zero/ignore_always
+  #       input: [type.googleapis.com/buf.validate.conformance.cases.RequiredProto3ScalarIgnoreAlways]:{}
+  #        want: valid
+  #         got: validation error (1 violation)
+  #          1. constraint_id: "required"
+  #             message: "value is required"
+  #             field: "val" elements:{field_number:1 field_name:"val" field_type:TYPE_STRING}
+  #             for_key: false
+  #             rule: "required" elements:{field_number:25 field_name:"required" field_type:TYPE_BOOL}
 custom_constraints:
   - compilation/incorrect_type
   #       input: [type.googleapis.com/buf.validate.conformance.cases.custom_constraints.IncorrectType]:{a:123}

--- a/packages/protovalidate-testing/package.json
+++ b/packages/protovalidate-testing/package.json
@@ -6,7 +6,7 @@
   },
   "scripts": {
     "install-protovalidate-conformance": "node scripts/install-protovalidate-conformance.js",
-    "generate": "buf generate buf.build/bufbuild/protovalidate-testing:v0.10.3",
+    "generate": "buf generate buf.build/bufbuild/protovalidate-testing:v0.10.4",
     "postgenerate": "license-header src/gen",
     "test": "protovalidate-conformance --strict_message --strict_error --expected_failures=expected-failures.yaml -- tsx src/executor.ts",
     "format": "prettier --write --ignore-unknown '.' '!dist' '!src/gen'",

--- a/packages/protovalidate-testing/src/gen/buf/validate/conformance/cases/required_field_proto2_pb.ts
+++ b/packages/protovalidate-testing/src/gen/buf/validate/conformance/cases/required_field_proto2_pb.ts
@@ -25,7 +25,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file buf/validate/conformance/cases/required_field_proto2.proto.
  */
 export const file_buf_validate_conformance_cases_required_field_proto2: GenFile = /*@__PURE__*/
-  fileDesc("CjpidWYvdmFsaWRhdGUvY29uZm9ybWFuY2UvY2FzZXMvcmVxdWlyZWRfZmllbGRfcHJvdG8yLnByb3RvEh5idWYudmFsaWRhdGUuY29uZm9ybWFuY2UuY2FzZXMiNgocUmVxdWlyZWRQcm90bzJTY2FsYXJPcHRpb25hbBIWCgN2YWwYASABKAlCCbpIBsgBAdgBAyJCCiNSZXF1aXJlZFByb3RvMlNjYWxhck9wdGlvbmFsRGVmYXVsdBIbCgN2YWwYASABKAk6A2Zvb0IJukgGyAEB2AEDIjMKHFJlcXVpcmVkUHJvdG8yU2NhbGFyUmVxdWlyZWQSEwoDdmFsGAEgAigJQga6SAPIAQEiewoVUmVxdWlyZWRQcm90bzJNZXNzYWdlEk4KA3ZhbBgBIAEoCzI5LmJ1Zi52YWxpZGF0ZS5jb25mb3JtYW5jZS5jYXNlcy5SZXF1aXJlZFByb3RvMk1lc3NhZ2UuTXNnQga6SAPIAQEaEgoDTXNnEgsKA3ZhbBgBIAEoCSI+ChNSZXF1aXJlZFByb3RvMk9uZW9mEhMKAWEYASABKAlCBrpIA8gBAUgAEgsKAWIYAiABKAlIAEIFCgN2YWwiLQoWUmVxdWlyZWRQcm90bzJSZXBlYXRlZBITCgN2YWwYASADKAlCBrpIA8gBASKQAQoRUmVxdWlyZWRQcm90bzJNYXASTwoDdmFsGAEgAygLMjouYnVmLnZhbGlkYXRlLmNvbmZvcm1hbmNlLmNhc2VzLlJlcXVpcmVkUHJvdG8yTWFwLlZhbEVudHJ5Qga6SAPIAQEaKgoIVmFsRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4AQ", [file_buf_validate_validate]);
+  fileDesc("CjpidWYvdmFsaWRhdGUvY29uZm9ybWFuY2UvY2FzZXMvcmVxdWlyZWRfZmllbGRfcHJvdG8yLnByb3RvEh5idWYudmFsaWRhdGUuY29uZm9ybWFuY2UuY2FzZXMiMwocUmVxdWlyZWRQcm90bzJTY2FsYXJPcHRpb25hbBITCgN2YWwYASABKAlCBrpIA8gBASJCCihSZXF1aXJlZFByb3RvMlNjYWxhck9wdGlvbmFsSWdub3JlQWx3YXlzEhYKA3ZhbBgBIAEoCUIJukgGyAEB2AEDIj8KI1JlcXVpcmVkUHJvdG8yU2NhbGFyT3B0aW9uYWxEZWZhdWx0EhgKA3ZhbBgBIAEoCToDZm9vQga6SAPIAQEiTgovUmVxdWlyZWRQcm90bzJTY2FsYXJPcHRpb25hbERlZmF1bHRJZ25vcmVBbHdheXMSGwoDdmFsGAEgASgJOgNmb29CCbpIBsgBAdgBAyIzChxSZXF1aXJlZFByb3RvMlNjYWxhclJlcXVpcmVkEhMKA3ZhbBgBIAIoCUIGukgDyAEBInsKFVJlcXVpcmVkUHJvdG8yTWVzc2FnZRJOCgN2YWwYASABKAsyOS5idWYudmFsaWRhdGUuY29uZm9ybWFuY2UuY2FzZXMuUmVxdWlyZWRQcm90bzJNZXNzYWdlLk1zZ0IGukgDyAEBGhIKA01zZxILCgN2YWwYASABKAkilgEKIVJlcXVpcmVkUHJvdG8yTWVzc2FnZUlnbm9yZUFsd2F5cxJdCgN2YWwYASABKAsyRS5idWYudmFsaWRhdGUuY29uZm9ybWFuY2UuY2FzZXMuUmVxdWlyZWRQcm90bzJNZXNzYWdlSWdub3JlQWx3YXlzLk1zZ0IJukgGyAEB2AEDGhIKA01zZxILCgN2YWwYASABKAkiPgoTUmVxdWlyZWRQcm90bzJPbmVvZhITCgFhGAEgASgJQga6SAPIAQFIABILCgFiGAIgASgJSABCBQoDdmFsIk0KH1JlcXVpcmVkUHJvdG8yT25lb2ZJZ25vcmVBbHdheXMSFgoBYRgBIAEoCUIJukgGyAEB2AEDSAASCwoBYhgCIAEoCUgAQgUKA3ZhbCItChZSZXF1aXJlZFByb3RvMlJlcGVhdGVkEhMKA3ZhbBgBIAMoCUIGukgDyAEBIjwKIlJlcXVpcmVkUHJvdG8yUmVwZWF0ZWRJZ25vcmVBbHdheXMSFgoDdmFsGAEgAygJQgm6SAbIAQHYAQMikAEKEVJlcXVpcmVkUHJvdG8yTWFwEk8KA3ZhbBgBIAMoCzI6LmJ1Zi52YWxpZGF0ZS5jb25mb3JtYW5jZS5jYXNlcy5SZXF1aXJlZFByb3RvMk1hcC5WYWxFbnRyeUIGukgDyAEBGioKCFZhbEVudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiqwEKHVJlcXVpcmVkUHJvdG8yTWFwSWdub3JlQWx3YXlzEl4KA3ZhbBgBIAMoCzJGLmJ1Zi52YWxpZGF0ZS5jb25mb3JtYW5jZS5jYXNlcy5SZXF1aXJlZFByb3RvMk1hcElnbm9yZUFsd2F5cy5WYWxFbnRyeUIJukgGyAEB2AEDGioKCFZhbEVudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAE", [file_buf_validate_validate]);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredProto2ScalarOptional
@@ -45,6 +45,23 @@ export const RequiredProto2ScalarOptionalSchema: GenMessage<RequiredProto2Scalar
   messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 0);
 
 /**
+ * @generated from message buf.validate.conformance.cases.RequiredProto2ScalarOptionalIgnoreAlways
+ */
+export type RequiredProto2ScalarOptionalIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredProto2ScalarOptionalIgnoreAlways"> & {
+  /**
+   * @generated from field: optional string val = 1;
+   */
+  val: string;
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredProto2ScalarOptionalIgnoreAlways.
+ * Use `create(RequiredProto2ScalarOptionalIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredProto2ScalarOptionalIgnoreAlwaysSchema: GenMessage<RequiredProto2ScalarOptionalIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 1);
+
+/**
  * @generated from message buf.validate.conformance.cases.RequiredProto2ScalarOptionalDefault
  */
 export type RequiredProto2ScalarOptionalDefault = Message<"buf.validate.conformance.cases.RequiredProto2ScalarOptionalDefault"> & {
@@ -59,7 +76,24 @@ export type RequiredProto2ScalarOptionalDefault = Message<"buf.validate.conforma
  * Use `create(RequiredProto2ScalarOptionalDefaultSchema)` to create a new message.
  */
 export const RequiredProto2ScalarOptionalDefaultSchema: GenMessage<RequiredProto2ScalarOptionalDefault> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 1);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 2);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredProto2ScalarOptionalDefaultIgnoreAlways
+ */
+export type RequiredProto2ScalarOptionalDefaultIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredProto2ScalarOptionalDefaultIgnoreAlways"> & {
+  /**
+   * @generated from field: optional string val = 1 [default = "foo"];
+   */
+  val: string;
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredProto2ScalarOptionalDefaultIgnoreAlways.
+ * Use `create(RequiredProto2ScalarOptionalDefaultIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredProto2ScalarOptionalDefaultIgnoreAlwaysSchema: GenMessage<RequiredProto2ScalarOptionalDefaultIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 3);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredProto2ScalarRequired
@@ -76,7 +110,7 @@ export type RequiredProto2ScalarRequired = Message<"buf.validate.conformance.cas
  * Use `create(RequiredProto2ScalarRequiredSchema)` to create a new message.
  */
 export const RequiredProto2ScalarRequiredSchema: GenMessage<RequiredProto2ScalarRequired> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 2);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 4);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredProto2Message
@@ -93,7 +127,7 @@ export type RequiredProto2Message = Message<"buf.validate.conformance.cases.Requ
  * Use `create(RequiredProto2MessageSchema)` to create a new message.
  */
 export const RequiredProto2MessageSchema: GenMessage<RequiredProto2Message> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 3);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 5);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredProto2Message.Msg
@@ -110,7 +144,41 @@ export type RequiredProto2Message_Msg = Message<"buf.validate.conformance.cases.
  * Use `create(RequiredProto2Message_MsgSchema)` to create a new message.
  */
 export const RequiredProto2Message_MsgSchema: GenMessage<RequiredProto2Message_Msg> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 3, 0);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 5, 0);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredProto2MessageIgnoreAlways
+ */
+export type RequiredProto2MessageIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredProto2MessageIgnoreAlways"> & {
+  /**
+   * @generated from field: optional buf.validate.conformance.cases.RequiredProto2MessageIgnoreAlways.Msg val = 1;
+   */
+  val?: RequiredProto2MessageIgnoreAlways_Msg;
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredProto2MessageIgnoreAlways.
+ * Use `create(RequiredProto2MessageIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredProto2MessageIgnoreAlwaysSchema: GenMessage<RequiredProto2MessageIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 6);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredProto2MessageIgnoreAlways.Msg
+ */
+export type RequiredProto2MessageIgnoreAlways_Msg = Message<"buf.validate.conformance.cases.RequiredProto2MessageIgnoreAlways.Msg"> & {
+  /**
+   * @generated from field: optional string val = 1;
+   */
+  val: string;
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredProto2MessageIgnoreAlways.Msg.
+ * Use `create(RequiredProto2MessageIgnoreAlways_MsgSchema)` to create a new message.
+ */
+export const RequiredProto2MessageIgnoreAlways_MsgSchema: GenMessage<RequiredProto2MessageIgnoreAlways_Msg> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 6, 0);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredProto2Oneof
@@ -139,7 +207,36 @@ export type RequiredProto2Oneof = Message<"buf.validate.conformance.cases.Requir
  * Use `create(RequiredProto2OneofSchema)` to create a new message.
  */
 export const RequiredProto2OneofSchema: GenMessage<RequiredProto2Oneof> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 4);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 7);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredProto2OneofIgnoreAlways
+ */
+export type RequiredProto2OneofIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredProto2OneofIgnoreAlways"> & {
+  /**
+   * @generated from oneof buf.validate.conformance.cases.RequiredProto2OneofIgnoreAlways.val
+   */
+  val: {
+    /**
+     * @generated from field: string a = 1;
+     */
+    value: string;
+    case: "a";
+  } | {
+    /**
+     * @generated from field: string b = 2;
+     */
+    value: string;
+    case: "b";
+  } | { case: undefined; value?: undefined };
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredProto2OneofIgnoreAlways.
+ * Use `create(RequiredProto2OneofIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredProto2OneofIgnoreAlwaysSchema: GenMessage<RequiredProto2OneofIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 8);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredProto2Repeated
@@ -156,7 +253,24 @@ export type RequiredProto2Repeated = Message<"buf.validate.conformance.cases.Req
  * Use `create(RequiredProto2RepeatedSchema)` to create a new message.
  */
 export const RequiredProto2RepeatedSchema: GenMessage<RequiredProto2Repeated> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 5);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 9);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredProto2RepeatedIgnoreAlways
+ */
+export type RequiredProto2RepeatedIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredProto2RepeatedIgnoreAlways"> & {
+  /**
+   * @generated from field: repeated string val = 1;
+   */
+  val: string[];
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredProto2RepeatedIgnoreAlways.
+ * Use `create(RequiredProto2RepeatedIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredProto2RepeatedIgnoreAlwaysSchema: GenMessage<RequiredProto2RepeatedIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 10);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredProto2Map
@@ -173,5 +287,22 @@ export type RequiredProto2Map = Message<"buf.validate.conformance.cases.Required
  * Use `create(RequiredProto2MapSchema)` to create a new message.
  */
 export const RequiredProto2MapSchema: GenMessage<RequiredProto2Map> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 6);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 11);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredProto2MapIgnoreAlways
+ */
+export type RequiredProto2MapIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredProto2MapIgnoreAlways"> & {
+  /**
+   * @generated from field: map<string, string> val = 1;
+   */
+  val: { [key: string]: string };
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredProto2MapIgnoreAlways.
+ * Use `create(RequiredProto2MapIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredProto2MapIgnoreAlwaysSchema: GenMessage<RequiredProto2MapIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto2, 12);
 

--- a/packages/protovalidate-testing/src/gen/buf/validate/conformance/cases/required_field_proto3_pb.ts
+++ b/packages/protovalidate-testing/src/gen/buf/validate/conformance/cases/required_field_proto3_pb.ts
@@ -25,7 +25,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file buf/validate/conformance/cases/required_field_proto3.proto.
  */
 export const file_buf_validate_conformance_cases_required_field_proto3: GenFile = /*@__PURE__*/
-  fileDesc("CjpidWYvdmFsaWRhdGUvY29uZm9ybWFuY2UvY2FzZXMvcmVxdWlyZWRfZmllbGRfcHJvdG8zLnByb3RvEh5idWYudmFsaWRhdGUuY29uZm9ybWFuY2UuY2FzZXMiKwoUUmVxdWlyZWRQcm90bzNTY2FsYXISEwoDdmFsGAEgASgJQga6SAPIAQEiQAocUmVxdWlyZWRQcm90bzNPcHRpb25hbFNjYWxhchIYCgN2YWwYASABKAlCBrpIA8gBAUgAiAEBQgYKBF92YWwiewoVUmVxdWlyZWRQcm90bzNNZXNzYWdlEk4KA3ZhbBgBIAEoCzI5LmJ1Zi52YWxpZGF0ZS5jb25mb3JtYW5jZS5jYXNlcy5SZXF1aXJlZFByb3RvM01lc3NhZ2UuTXNnQga6SAPIAQEaEgoDTXNnEgsKA3ZhbBgBIAEoCSI+ChNSZXF1aXJlZFByb3RvM09uZU9mEhMKAWEYASABKAlCBrpIA8gBAUgAEgsKAWIYAiABKAlIAEIFCgN2YWwiLQoWUmVxdWlyZWRQcm90bzNSZXBlYXRlZBITCgN2YWwYASADKAlCBrpIA8gBASKQAQoRUmVxdWlyZWRQcm90bzNNYXASTwoDdmFsGAEgAygLMjouYnVmLnZhbGlkYXRlLmNvbmZvcm1hbmNlLmNhc2VzLlJlcXVpcmVkUHJvdG8zTWFwLlZhbEVudHJ5Qga6SAPIAQEaKgoIVmFsRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4AWIGcHJvdG8z", [file_buf_validate_validate]);
+  fileDesc("CjpidWYvdmFsaWRhdGUvY29uZm9ybWFuY2UvY2FzZXMvcmVxdWlyZWRfZmllbGRfcHJvdG8zLnByb3RvEh5idWYudmFsaWRhdGUuY29uZm9ybWFuY2UuY2FzZXMiKwoUUmVxdWlyZWRQcm90bzNTY2FsYXISEwoDdmFsGAEgASgJQga6SAPIAQEiOgogUmVxdWlyZWRQcm90bzNTY2FsYXJJZ25vcmVBbHdheXMSFgoDdmFsGAEgASgJQgm6SAbIAQHYAQMiQAocUmVxdWlyZWRQcm90bzNPcHRpb25hbFNjYWxhchIYCgN2YWwYASABKAlCBrpIA8gBAUgAiAEBQgYKBF92YWwiTwooUmVxdWlyZWRQcm90bzNPcHRpb25hbFNjYWxhcklnbm9yZUFsd2F5cxIbCgN2YWwYASABKAlCCbpIBsgBAdgBA0gAiAEBQgYKBF92YWwiewoVUmVxdWlyZWRQcm90bzNNZXNzYWdlEk4KA3ZhbBgBIAEoCzI5LmJ1Zi52YWxpZGF0ZS5jb25mb3JtYW5jZS5jYXNlcy5SZXF1aXJlZFByb3RvM01lc3NhZ2UuTXNnQga6SAPIAQEaEgoDTXNnEgsKA3ZhbBgBIAEoCSKWAQohUmVxdWlyZWRQcm90bzNNZXNzYWdlSWdub3JlQWx3YXlzEl0KA3ZhbBgBIAEoCzJFLmJ1Zi52YWxpZGF0ZS5jb25mb3JtYW5jZS5jYXNlcy5SZXF1aXJlZFByb3RvM01lc3NhZ2VJZ25vcmVBbHdheXMuTXNnQgm6SAbIAQHYAQMaEgoDTXNnEgsKA3ZhbBgBIAEoCSI+ChNSZXF1aXJlZFByb3RvM09uZU9mEhMKAWEYASABKAlCBrpIA8gBAUgAEgsKAWIYAiABKAlIAEIFCgN2YWwiTQofUmVxdWlyZWRQcm90bzNPbmVPZklnbm9yZUFsd2F5cxIWCgFhGAEgASgJQgm6SAbIAQHYAQNIABILCgFiGAIgASgJSABCBQoDdmFsIi0KFlJlcXVpcmVkUHJvdG8zUmVwZWF0ZWQSEwoDdmFsGAEgAygJQga6SAPIAQEiPAoiUmVxdWlyZWRQcm90bzNSZXBlYXRlZElnbm9yZUFsd2F5cxIWCgN2YWwYASADKAlCCbpIBsgBAdgBAyKQAQoRUmVxdWlyZWRQcm90bzNNYXASTwoDdmFsGAEgAygLMjouYnVmLnZhbGlkYXRlLmNvbmZvcm1hbmNlLmNhc2VzLlJlcXVpcmVkUHJvdG8zTWFwLlZhbEVudHJ5Qga6SAPIAQEaKgoIVmFsRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASKrAQodUmVxdWlyZWRQcm90bzNNYXBJZ25vcmVBbHdheXMSXgoDdmFsGAEgAygLMkYuYnVmLnZhbGlkYXRlLmNvbmZvcm1hbmNlLmNhc2VzLlJlcXVpcmVkUHJvdG8zTWFwSWdub3JlQWx3YXlzLlZhbEVudHJ5Qgm6SAbIAQHYAQMaKgoIVmFsRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4AWIGcHJvdG8z", [file_buf_validate_validate]);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredProto3Scalar
@@ -45,6 +45,23 @@ export const RequiredProto3ScalarSchema: GenMessage<RequiredProto3Scalar> = /*@_
   messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 0);
 
 /**
+ * @generated from message buf.validate.conformance.cases.RequiredProto3ScalarIgnoreAlways
+ */
+export type RequiredProto3ScalarIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredProto3ScalarIgnoreAlways"> & {
+  /**
+   * @generated from field: string val = 1;
+   */
+  val: string;
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredProto3ScalarIgnoreAlways.
+ * Use `create(RequiredProto3ScalarIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredProto3ScalarIgnoreAlwaysSchema: GenMessage<RequiredProto3ScalarIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 1);
+
+/**
  * @generated from message buf.validate.conformance.cases.RequiredProto3OptionalScalar
  */
 export type RequiredProto3OptionalScalar = Message<"buf.validate.conformance.cases.RequiredProto3OptionalScalar"> & {
@@ -59,7 +76,24 @@ export type RequiredProto3OptionalScalar = Message<"buf.validate.conformance.cas
  * Use `create(RequiredProto3OptionalScalarSchema)` to create a new message.
  */
 export const RequiredProto3OptionalScalarSchema: GenMessage<RequiredProto3OptionalScalar> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 1);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 2);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredProto3OptionalScalarIgnoreAlways
+ */
+export type RequiredProto3OptionalScalarIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredProto3OptionalScalarIgnoreAlways"> & {
+  /**
+   * @generated from field: optional string val = 1;
+   */
+  val?: string;
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredProto3OptionalScalarIgnoreAlways.
+ * Use `create(RequiredProto3OptionalScalarIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredProto3OptionalScalarIgnoreAlwaysSchema: GenMessage<RequiredProto3OptionalScalarIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 3);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredProto3Message
@@ -76,7 +110,7 @@ export type RequiredProto3Message = Message<"buf.validate.conformance.cases.Requ
  * Use `create(RequiredProto3MessageSchema)` to create a new message.
  */
 export const RequiredProto3MessageSchema: GenMessage<RequiredProto3Message> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 2);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 4);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredProto3Message.Msg
@@ -93,7 +127,41 @@ export type RequiredProto3Message_Msg = Message<"buf.validate.conformance.cases.
  * Use `create(RequiredProto3Message_MsgSchema)` to create a new message.
  */
 export const RequiredProto3Message_MsgSchema: GenMessage<RequiredProto3Message_Msg> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 2, 0);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 4, 0);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways
+ */
+export type RequiredProto3MessageIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways"> & {
+  /**
+   * @generated from field: buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways.Msg val = 1;
+   */
+  val?: RequiredProto3MessageIgnoreAlways_Msg;
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways.
+ * Use `create(RequiredProto3MessageIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredProto3MessageIgnoreAlwaysSchema: GenMessage<RequiredProto3MessageIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 5);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways.Msg
+ */
+export type RequiredProto3MessageIgnoreAlways_Msg = Message<"buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways.Msg"> & {
+  /**
+   * @generated from field: string val = 1;
+   */
+  val: string;
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways.Msg.
+ * Use `create(RequiredProto3MessageIgnoreAlways_MsgSchema)` to create a new message.
+ */
+export const RequiredProto3MessageIgnoreAlways_MsgSchema: GenMessage<RequiredProto3MessageIgnoreAlways_Msg> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 5, 0);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredProto3OneOf
@@ -122,7 +190,36 @@ export type RequiredProto3OneOf = Message<"buf.validate.conformance.cases.Requir
  * Use `create(RequiredProto3OneOfSchema)` to create a new message.
  */
 export const RequiredProto3OneOfSchema: GenMessage<RequiredProto3OneOf> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 3);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 6);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredProto3OneOfIgnoreAlways
+ */
+export type RequiredProto3OneOfIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredProto3OneOfIgnoreAlways"> & {
+  /**
+   * @generated from oneof buf.validate.conformance.cases.RequiredProto3OneOfIgnoreAlways.val
+   */
+  val: {
+    /**
+     * @generated from field: string a = 1;
+     */
+    value: string;
+    case: "a";
+  } | {
+    /**
+     * @generated from field: string b = 2;
+     */
+    value: string;
+    case: "b";
+  } | { case: undefined; value?: undefined };
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredProto3OneOfIgnoreAlways.
+ * Use `create(RequiredProto3OneOfIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredProto3OneOfIgnoreAlwaysSchema: GenMessage<RequiredProto3OneOfIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 7);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredProto3Repeated
@@ -139,7 +236,24 @@ export type RequiredProto3Repeated = Message<"buf.validate.conformance.cases.Req
  * Use `create(RequiredProto3RepeatedSchema)` to create a new message.
  */
 export const RequiredProto3RepeatedSchema: GenMessage<RequiredProto3Repeated> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 4);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 8);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredProto3RepeatedIgnoreAlways
+ */
+export type RequiredProto3RepeatedIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredProto3RepeatedIgnoreAlways"> & {
+  /**
+   * @generated from field: repeated string val = 1;
+   */
+  val: string[];
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredProto3RepeatedIgnoreAlways.
+ * Use `create(RequiredProto3RepeatedIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredProto3RepeatedIgnoreAlwaysSchema: GenMessage<RequiredProto3RepeatedIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 9);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredProto3Map
@@ -156,5 +270,22 @@ export type RequiredProto3Map = Message<"buf.validate.conformance.cases.Required
  * Use `create(RequiredProto3MapSchema)` to create a new message.
  */
 export const RequiredProto3MapSchema: GenMessage<RequiredProto3Map> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 5);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 10);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredProto3MapIgnoreAlways
+ */
+export type RequiredProto3MapIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredProto3MapIgnoreAlways"> & {
+  /**
+   * @generated from field: map<string, string> val = 1;
+   */
+  val: { [key: string]: string };
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredProto3MapIgnoreAlways.
+ * Use `create(RequiredProto3MapIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredProto3MapIgnoreAlwaysSchema: GenMessage<RequiredProto3MapIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto3, 11);
 

--- a/packages/protovalidate-testing/src/gen/buf/validate/conformance/cases/required_field_proto_editions_pb.ts
+++ b/packages/protovalidate-testing/src/gen/buf/validate/conformance/cases/required_field_proto_editions_pb.ts
@@ -25,7 +25,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file buf/validate/conformance/cases/required_field_proto_editions.proto.
  */
 export const file_buf_validate_conformance_cases_required_field_proto_editions: GenFile = /*@__PURE__*/
-  fileDesc("CkJidWYvdmFsaWRhdGUvY29uZm9ybWFuY2UvY2FzZXMvcmVxdWlyZWRfZmllbGRfcHJvdG9fZWRpdGlvbnMucHJvdG8SHmJ1Zi52YWxpZGF0ZS5jb25mb3JtYW5jZS5jYXNlcyI9CiZSZXF1aXJlZEVkaXRpb25zU2NhbGFyRXhwbGljaXRQcmVzZW5jZRITCgN2YWwYASABKAlCBrpIA8gBASJJCi1SZXF1aXJlZEVkaXRpb25zU2NhbGFyRXhwbGljaXRQcmVzZW5jZURlZmF1bHQSGAoDdmFsGAEgASgJOgNmb29CBrpIA8gBASJCCiZSZXF1aXJlZEVkaXRpb25zU2NhbGFySW1wbGljaXRQcmVzZW5jZRIYCgN2YWwYASABKAlCC6oBAggCukgDyAEBIkAKJFJlcXVpcmVkRWRpdGlvbnNTY2FsYXJMZWdhY3lSZXF1aXJlZBIYCgN2YWwYASABKAlCC6oBAggDukgDyAEBIp8BCidSZXF1aXJlZEVkaXRpb25zTWVzc2FnZUV4cGxpY2l0UHJlc2VuY2USYAoDdmFsGAEgASgLMksuYnVmLnZhbGlkYXRlLmNvbmZvcm1hbmNlLmNhc2VzLlJlcXVpcmVkRWRpdGlvbnNNZXNzYWdlRXhwbGljaXRQcmVzZW5jZS5Nc2dCBrpIA8gBARoSCgNNc2cSCwoDdmFsGAEgASgJIrYBCjBSZXF1aXJlZEVkaXRpb25zTWVzc2FnZUV4cGxpY2l0UHJlc2VuY2VEZWxpbWl0ZWQSbgoDdmFsGAEgASgLMlQuYnVmLnZhbGlkYXRlLmNvbmZvcm1hbmNlLmNhc2VzLlJlcXVpcmVkRWRpdGlvbnNNZXNzYWdlRXhwbGljaXRQcmVzZW5jZURlbGltaXRlZC5Nc2dCC6oBAigCukgDyAEBGhIKA01zZxILCgN2YWwYASABKAkioAEKJVJlcXVpcmVkRWRpdGlvbnNNZXNzYWdlTGVnYWN5UmVxdWlyZWQSYwoDdmFsGAEgASgLMkkuYnVmLnZhbGlkYXRlLmNvbmZvcm1hbmNlLmNhc2VzLlJlcXVpcmVkRWRpdGlvbnNNZXNzYWdlTGVnYWN5UmVxdWlyZWQuTXNnQguqAQIIA7pIA8gBARoSCgNNc2cSCwoDdmFsGAEgASgJIrQBCi5SZXF1aXJlZEVkaXRpb25zTWVzc2FnZUxlZ2FjeVJlcXVpcmVkRGVsaW1pdGVkEm4KA3ZhbBgBIAEoCzJSLmJ1Zi52YWxpZGF0ZS5jb25mb3JtYW5jZS5jYXNlcy5SZXF1aXJlZEVkaXRpb25zTWVzc2FnZUxlZ2FjeVJlcXVpcmVkRGVsaW1pdGVkLk1zZ0INqgEECAMoArpIA8gBARoSCgNNc2cSCwoDdmFsGAEgASgJIkAKFVJlcXVpcmVkRWRpdGlvbnNPbmVvZhITCgFhGAEgASgJQga6SAPIAQFIABILCgFiGAIgASgJSABCBQoDdmFsIi8KGFJlcXVpcmVkRWRpdGlvbnNSZXBlYXRlZBITCgN2YWwYASADKAlCBrpIA8gBASI8CiBSZXF1aXJlZEVkaXRpb25zUmVwZWF0ZWRFeHBhbmRlZBIYCgN2YWwYASADKAlCC6oBAhgCukgDyAEBIpQBChNSZXF1aXJlZEVkaXRpb25zTWFwElEKA3ZhbBgBIAMoCzI8LmJ1Zi52YWxpZGF0ZS5jb25mb3JtYW5jZS5jYXNlcy5SZXF1aXJlZEVkaXRpb25zTWFwLlZhbEVudHJ5Qga6SAPIAQEaKgoIVmFsRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4AWIIZWRpdGlvbnNw6Ac", [file_buf_validate_validate]);
+  fileDesc("CkJidWYvdmFsaWRhdGUvY29uZm9ybWFuY2UvY2FzZXMvcmVxdWlyZWRfZmllbGRfcHJvdG9fZWRpdGlvbnMucHJvdG8SHmJ1Zi52YWxpZGF0ZS5jb25mb3JtYW5jZS5jYXNlcyI9CiZSZXF1aXJlZEVkaXRpb25zU2NhbGFyRXhwbGljaXRQcmVzZW5jZRITCgN2YWwYASABKAlCBrpIA8gBASJMCjJSZXF1aXJlZEVkaXRpb25zU2NhbGFyRXhwbGljaXRQcmVzZW5jZUlnbm9yZUFsd2F5cxIWCgN2YWwYASABKAlCCbpIBsgBAdgBAyJJCi1SZXF1aXJlZEVkaXRpb25zU2NhbGFyRXhwbGljaXRQcmVzZW5jZURlZmF1bHQSGAoDdmFsGAEgASgJOgNmb29CBrpIA8gBASJYCjlSZXF1aXJlZEVkaXRpb25zU2NhbGFyRXhwbGljaXRQcmVzZW5jZURlZmF1bHRJZ25vcmVBbHdheXMSGwoDdmFsGAEgASgJOgNmb29CCbpIBsgBAdgBAyJCCiZSZXF1aXJlZEVkaXRpb25zU2NhbGFySW1wbGljaXRQcmVzZW5jZRIYCgN2YWwYASABKAlCC6oBAggCukgDyAEBIlEKMlJlcXVpcmVkRWRpdGlvbnNTY2FsYXJJbXBsaWNpdFByZXNlbmNlSWdub3JlQWx3YXlzEhsKA3ZhbBgBIAEoCUIOqgECCAK6SAbIAQHYAQMiQAokUmVxdWlyZWRFZGl0aW9uc1NjYWxhckxlZ2FjeVJlcXVpcmVkEhgKA3ZhbBgBIAEoCUILqgECCAO6SAPIAQEinwEKJ1JlcXVpcmVkRWRpdGlvbnNNZXNzYWdlRXhwbGljaXRQcmVzZW5jZRJgCgN2YWwYASABKAsySy5idWYudmFsaWRhdGUuY29uZm9ybWFuY2UuY2FzZXMuUmVxdWlyZWRFZGl0aW9uc01lc3NhZ2VFeHBsaWNpdFByZXNlbmNlLk1zZ0IGukgDyAEBGhIKA01zZxILCgN2YWwYASABKAkiugEKM1JlcXVpcmVkRWRpdGlvbnNNZXNzYWdlRXhwbGljaXRQcmVzZW5jZUlnbm9yZUFsd2F5cxJvCgN2YWwYASABKAsyVy5idWYudmFsaWRhdGUuY29uZm9ybWFuY2UuY2FzZXMuUmVxdWlyZWRFZGl0aW9uc01lc3NhZ2VFeHBsaWNpdFByZXNlbmNlSWdub3JlQWx3YXlzLk1zZ0IJukgGyAEB2AEDGhIKA01zZxILCgN2YWwYASABKAkitgEKMFJlcXVpcmVkRWRpdGlvbnNNZXNzYWdlRXhwbGljaXRQcmVzZW5jZURlbGltaXRlZBJuCgN2YWwYASABKAsyVC5idWYudmFsaWRhdGUuY29uZm9ybWFuY2UuY2FzZXMuUmVxdWlyZWRFZGl0aW9uc01lc3NhZ2VFeHBsaWNpdFByZXNlbmNlRGVsaW1pdGVkLk1zZ0ILqgECKAK6SAPIAQEaEgoDTXNnEgsKA3ZhbBgBIAEoCSLRAQo8UmVxdWlyZWRFZGl0aW9uc01lc3NhZ2VFeHBsaWNpdFByZXNlbmNlRGVsaW1pdGVkSWdub3JlQWx3YXlzEn0KA3ZhbBgBIAEoCzJgLmJ1Zi52YWxpZGF0ZS5jb25mb3JtYW5jZS5jYXNlcy5SZXF1aXJlZEVkaXRpb25zTWVzc2FnZUV4cGxpY2l0UHJlc2VuY2VEZWxpbWl0ZWRJZ25vcmVBbHdheXMuTXNnQg6qAQIoArpIBsgBAdgBAxoSCgNNc2cSCwoDdmFsGAEgASgJIqABCiVSZXF1aXJlZEVkaXRpb25zTWVzc2FnZUxlZ2FjeVJlcXVpcmVkEmMKA3ZhbBgBIAEoCzJJLmJ1Zi52YWxpZGF0ZS5jb25mb3JtYW5jZS5jYXNlcy5SZXF1aXJlZEVkaXRpb25zTWVzc2FnZUxlZ2FjeVJlcXVpcmVkLk1zZ0ILqgECCAO6SAPIAQEaEgoDTXNnEgsKA3ZhbBgBIAEoCSK0AQouUmVxdWlyZWRFZGl0aW9uc01lc3NhZ2VMZWdhY3lSZXF1aXJlZERlbGltaXRlZBJuCgN2YWwYASABKAsyUi5idWYudmFsaWRhdGUuY29uZm9ybWFuY2UuY2FzZXMuUmVxdWlyZWRFZGl0aW9uc01lc3NhZ2VMZWdhY3lSZXF1aXJlZERlbGltaXRlZC5Nc2dCDaoBBAgDKAK6SAPIAQEaEgoDTXNnEgsKA3ZhbBgBIAEoCSJAChVSZXF1aXJlZEVkaXRpb25zT25lb2YSEwoBYRgBIAEoCUIGukgDyAEBSAASCwoBYhgCIAEoCUgAQgUKA3ZhbCJPCiFSZXF1aXJlZEVkaXRpb25zT25lb2ZJZ25vcmVBbHdheXMSFgoBYRgBIAEoCUIJukgGyAEB2AEDSAASCwoBYhgCIAEoCUgAQgUKA3ZhbCIvChhSZXF1aXJlZEVkaXRpb25zUmVwZWF0ZWQSEwoDdmFsGAEgAygJQga6SAPIAQEiPgokUmVxdWlyZWRFZGl0aW9uc1JlcGVhdGVkSWdub3JlQWx3YXlzEhYKA3ZhbBgBIAMoCUIJukgGyAEB2AEDIjwKIFJlcXVpcmVkRWRpdGlvbnNSZXBlYXRlZEV4cGFuZGVkEhgKA3ZhbBgBIAMoCUILqgECGAK6SAPIAQEiSwosUmVxdWlyZWRFZGl0aW9uc1JlcGVhdGVkRXhwYW5kZWRJZ25vcmVBbHdheXMSGwoDdmFsGAEgAygJQg6qAQIYArpIBsgBAdgBAyKUAQoTUmVxdWlyZWRFZGl0aW9uc01hcBJRCgN2YWwYASADKAsyPC5idWYudmFsaWRhdGUuY29uZm9ybWFuY2UuY2FzZXMuUmVxdWlyZWRFZGl0aW9uc01hcC5WYWxFbnRyeUIGukgDyAEBGioKCFZhbEVudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEirwEKH1JlcXVpcmVkRWRpdGlvbnNNYXBJZ25vcmVBbHdheXMSYAoDdmFsGAEgAygLMkguYnVmLnZhbGlkYXRlLmNvbmZvcm1hbmNlLmNhc2VzLlJlcXVpcmVkRWRpdGlvbnNNYXBJZ25vcmVBbHdheXMuVmFsRW50cnlCCbpIBsgBAdgBAxoqCghWYWxFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBYghlZGl0aW9uc3DoBw", [file_buf_validate_validate]);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredEditionsScalarExplicitPresence
@@ -45,6 +45,23 @@ export const RequiredEditionsScalarExplicitPresenceSchema: GenMessage<RequiredEd
   messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 0);
 
 /**
+ * @generated from message buf.validate.conformance.cases.RequiredEditionsScalarExplicitPresenceIgnoreAlways
+ */
+export type RequiredEditionsScalarExplicitPresenceIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredEditionsScalarExplicitPresenceIgnoreAlways"> & {
+  /**
+   * @generated from field: string val = 1;
+   */
+  val: string;
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredEditionsScalarExplicitPresenceIgnoreAlways.
+ * Use `create(RequiredEditionsScalarExplicitPresenceIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredEditionsScalarExplicitPresenceIgnoreAlwaysSchema: GenMessage<RequiredEditionsScalarExplicitPresenceIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 1);
+
+/**
  * @generated from message buf.validate.conformance.cases.RequiredEditionsScalarExplicitPresenceDefault
  */
 export type RequiredEditionsScalarExplicitPresenceDefault = Message<"buf.validate.conformance.cases.RequiredEditionsScalarExplicitPresenceDefault"> & {
@@ -59,7 +76,24 @@ export type RequiredEditionsScalarExplicitPresenceDefault = Message<"buf.validat
  * Use `create(RequiredEditionsScalarExplicitPresenceDefaultSchema)` to create a new message.
  */
 export const RequiredEditionsScalarExplicitPresenceDefaultSchema: GenMessage<RequiredEditionsScalarExplicitPresenceDefault> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 1);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 2);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways
+ */
+export type RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways"> & {
+  /**
+   * @generated from field: string val = 1 [default = "foo"];
+   */
+  val: string;
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways.
+ * Use `create(RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlwaysSchema: GenMessage<RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 3);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredEditionsScalarImplicitPresence
@@ -76,7 +110,24 @@ export type RequiredEditionsScalarImplicitPresence = Message<"buf.validate.confo
  * Use `create(RequiredEditionsScalarImplicitPresenceSchema)` to create a new message.
  */
 export const RequiredEditionsScalarImplicitPresenceSchema: GenMessage<RequiredEditionsScalarImplicitPresence> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 2);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 4);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredEditionsScalarImplicitPresenceIgnoreAlways
+ */
+export type RequiredEditionsScalarImplicitPresenceIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredEditionsScalarImplicitPresenceIgnoreAlways"> & {
+  /**
+   * @generated from field: string val = 1 [features.field_presence = IMPLICIT];
+   */
+  val: string;
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredEditionsScalarImplicitPresenceIgnoreAlways.
+ * Use `create(RequiredEditionsScalarImplicitPresenceIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredEditionsScalarImplicitPresenceIgnoreAlwaysSchema: GenMessage<RequiredEditionsScalarImplicitPresenceIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 5);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredEditionsScalarLegacyRequired
@@ -93,7 +144,7 @@ export type RequiredEditionsScalarLegacyRequired = Message<"buf.validate.conform
  * Use `create(RequiredEditionsScalarLegacyRequiredSchema)` to create a new message.
  */
 export const RequiredEditionsScalarLegacyRequiredSchema: GenMessage<RequiredEditionsScalarLegacyRequired> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 3);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 6);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresence
@@ -110,7 +161,7 @@ export type RequiredEditionsMessageExplicitPresence = Message<"buf.validate.conf
  * Use `create(RequiredEditionsMessageExplicitPresenceSchema)` to create a new message.
  */
 export const RequiredEditionsMessageExplicitPresenceSchema: GenMessage<RequiredEditionsMessageExplicitPresence> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 4);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 7);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresence.Msg
@@ -127,7 +178,41 @@ export type RequiredEditionsMessageExplicitPresence_Msg = Message<"buf.validate.
  * Use `create(RequiredEditionsMessageExplicitPresence_MsgSchema)` to create a new message.
  */
 export const RequiredEditionsMessageExplicitPresence_MsgSchema: GenMessage<RequiredEditionsMessageExplicitPresence_Msg> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 4, 0);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 7, 0);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceIgnoreAlways
+ */
+export type RequiredEditionsMessageExplicitPresenceIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceIgnoreAlways"> & {
+  /**
+   * @generated from field: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceIgnoreAlways.Msg val = 1;
+   */
+  val?: RequiredEditionsMessageExplicitPresenceIgnoreAlways_Msg;
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceIgnoreAlways.
+ * Use `create(RequiredEditionsMessageExplicitPresenceIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredEditionsMessageExplicitPresenceIgnoreAlwaysSchema: GenMessage<RequiredEditionsMessageExplicitPresenceIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 8);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceIgnoreAlways.Msg
+ */
+export type RequiredEditionsMessageExplicitPresenceIgnoreAlways_Msg = Message<"buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceIgnoreAlways.Msg"> & {
+  /**
+   * @generated from field: string val = 1;
+   */
+  val: string;
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceIgnoreAlways.Msg.
+ * Use `create(RequiredEditionsMessageExplicitPresenceIgnoreAlways_MsgSchema)` to create a new message.
+ */
+export const RequiredEditionsMessageExplicitPresenceIgnoreAlways_MsgSchema: GenMessage<RequiredEditionsMessageExplicitPresenceIgnoreAlways_Msg> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 8, 0);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimited
@@ -144,7 +229,7 @@ export type RequiredEditionsMessageExplicitPresenceDelimited = Message<"buf.vali
  * Use `create(RequiredEditionsMessageExplicitPresenceDelimitedSchema)` to create a new message.
  */
 export const RequiredEditionsMessageExplicitPresenceDelimitedSchema: GenMessage<RequiredEditionsMessageExplicitPresenceDelimited> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 5);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 9);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimited.Msg
@@ -161,7 +246,41 @@ export type RequiredEditionsMessageExplicitPresenceDelimited_Msg = Message<"buf.
  * Use `create(RequiredEditionsMessageExplicitPresenceDelimited_MsgSchema)` to create a new message.
  */
 export const RequiredEditionsMessageExplicitPresenceDelimited_MsgSchema: GenMessage<RequiredEditionsMessageExplicitPresenceDelimited_Msg> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 5, 0);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 9, 0);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways
+ */
+export type RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways"> & {
+  /**
+   * @generated from field: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways.Msg val = 1 [features.message_encoding = DELIMITED];
+   */
+  val?: RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways_Msg;
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways.
+ * Use `create(RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlwaysSchema: GenMessage<RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 10);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways.Msg
+ */
+export type RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways_Msg = Message<"buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways.Msg"> & {
+  /**
+   * @generated from field: string val = 1;
+   */
+  val: string;
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways.Msg.
+ * Use `create(RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways_MsgSchema)` to create a new message.
+ */
+export const RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways_MsgSchema: GenMessage<RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways_Msg> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 10, 0);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequired
@@ -178,7 +297,7 @@ export type RequiredEditionsMessageLegacyRequired = Message<"buf.validate.confor
  * Use `create(RequiredEditionsMessageLegacyRequiredSchema)` to create a new message.
  */
 export const RequiredEditionsMessageLegacyRequiredSchema: GenMessage<RequiredEditionsMessageLegacyRequired> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 6);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 11);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequired.Msg
@@ -195,7 +314,7 @@ export type RequiredEditionsMessageLegacyRequired_Msg = Message<"buf.validate.co
  * Use `create(RequiredEditionsMessageLegacyRequired_MsgSchema)` to create a new message.
  */
 export const RequiredEditionsMessageLegacyRequired_MsgSchema: GenMessage<RequiredEditionsMessageLegacyRequired_Msg> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 6, 0);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 11, 0);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequiredDelimited
@@ -212,7 +331,7 @@ export type RequiredEditionsMessageLegacyRequiredDelimited = Message<"buf.valida
  * Use `create(RequiredEditionsMessageLegacyRequiredDelimitedSchema)` to create a new message.
  */
 export const RequiredEditionsMessageLegacyRequiredDelimitedSchema: GenMessage<RequiredEditionsMessageLegacyRequiredDelimited> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 7);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 12);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequiredDelimited.Msg
@@ -229,7 +348,7 @@ export type RequiredEditionsMessageLegacyRequiredDelimited_Msg = Message<"buf.va
  * Use `create(RequiredEditionsMessageLegacyRequiredDelimited_MsgSchema)` to create a new message.
  */
 export const RequiredEditionsMessageLegacyRequiredDelimited_MsgSchema: GenMessage<RequiredEditionsMessageLegacyRequiredDelimited_Msg> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 7, 0);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 12, 0);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredEditionsOneof
@@ -258,7 +377,36 @@ export type RequiredEditionsOneof = Message<"buf.validate.conformance.cases.Requ
  * Use `create(RequiredEditionsOneofSchema)` to create a new message.
  */
 export const RequiredEditionsOneofSchema: GenMessage<RequiredEditionsOneof> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 8);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 13);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredEditionsOneofIgnoreAlways
+ */
+export type RequiredEditionsOneofIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredEditionsOneofIgnoreAlways"> & {
+  /**
+   * @generated from oneof buf.validate.conformance.cases.RequiredEditionsOneofIgnoreAlways.val
+   */
+  val: {
+    /**
+     * @generated from field: string a = 1;
+     */
+    value: string;
+    case: "a";
+  } | {
+    /**
+     * @generated from field: string b = 2;
+     */
+    value: string;
+    case: "b";
+  } | { case: undefined; value?: undefined };
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredEditionsOneofIgnoreAlways.
+ * Use `create(RequiredEditionsOneofIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredEditionsOneofIgnoreAlwaysSchema: GenMessage<RequiredEditionsOneofIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 14);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredEditionsRepeated
@@ -275,7 +423,24 @@ export type RequiredEditionsRepeated = Message<"buf.validate.conformance.cases.R
  * Use `create(RequiredEditionsRepeatedSchema)` to create a new message.
  */
 export const RequiredEditionsRepeatedSchema: GenMessage<RequiredEditionsRepeated> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 9);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 15);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredEditionsRepeatedIgnoreAlways
+ */
+export type RequiredEditionsRepeatedIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredEditionsRepeatedIgnoreAlways"> & {
+  /**
+   * @generated from field: repeated string val = 1;
+   */
+  val: string[];
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredEditionsRepeatedIgnoreAlways.
+ * Use `create(RequiredEditionsRepeatedIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredEditionsRepeatedIgnoreAlwaysSchema: GenMessage<RequiredEditionsRepeatedIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 16);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredEditionsRepeatedExpanded
@@ -292,7 +457,24 @@ export type RequiredEditionsRepeatedExpanded = Message<"buf.validate.conformance
  * Use `create(RequiredEditionsRepeatedExpandedSchema)` to create a new message.
  */
 export const RequiredEditionsRepeatedExpandedSchema: GenMessage<RequiredEditionsRepeatedExpanded> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 10);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 17);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredEditionsRepeatedExpandedIgnoreAlways
+ */
+export type RequiredEditionsRepeatedExpandedIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredEditionsRepeatedExpandedIgnoreAlways"> & {
+  /**
+   * @generated from field: repeated string val = 1 [features.repeated_field_encoding = EXPANDED];
+   */
+  val: string[];
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredEditionsRepeatedExpandedIgnoreAlways.
+ * Use `create(RequiredEditionsRepeatedExpandedIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredEditionsRepeatedExpandedIgnoreAlwaysSchema: GenMessage<RequiredEditionsRepeatedExpandedIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 18);
 
 /**
  * @generated from message buf.validate.conformance.cases.RequiredEditionsMap
@@ -309,5 +491,22 @@ export type RequiredEditionsMap = Message<"buf.validate.conformance.cases.Requir
  * Use `create(RequiredEditionsMapSchema)` to create a new message.
  */
 export const RequiredEditionsMapSchema: GenMessage<RequiredEditionsMap> = /*@__PURE__*/
-  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 11);
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 19);
+
+/**
+ * @generated from message buf.validate.conformance.cases.RequiredEditionsMapIgnoreAlways
+ */
+export type RequiredEditionsMapIgnoreAlways = Message<"buf.validate.conformance.cases.RequiredEditionsMapIgnoreAlways"> & {
+  /**
+   * @generated from field: map<string, string> val = 1;
+   */
+  val: { [key: string]: string };
+};
+
+/**
+ * Describes the message buf.validate.conformance.cases.RequiredEditionsMapIgnoreAlways.
+ * Use `create(RequiredEditionsMapIgnoreAlwaysSchema)` to create a new message.
+ */
+export const RequiredEditionsMapIgnoreAlwaysSchema: GenMessage<RequiredEditionsMapIgnoreAlways> = /*@__PURE__*/
+  messageDesc(file_buf_validate_conformance_cases_required_field_proto_editions, 20);
 


### PR DESCRIPTION
For now, we're skipping the failing tests tickled by https://github.com/bufbuild/protovalidate/pull/341 and https://github.com/bufbuild/protovalidate/pull/343.