### PR TITLE
Port IPv6 validation corner cases

### DIFF
--- a/packages/protovalidate-testing/expected-failures.yaml
+++ b/packages/protovalidate-testing/expected-failures.yaml
@@ -1,24 +1,3 @@
-library/is_ip:
-  - version/omitted/invalid/ipv6/g
-  #       input: [type.googleapis.com/buf.validate.conformance.cases.IsIp]:{val:":0::0"}
-  #        want: validation error (1 violation)
-  #          1. constraint_id: "library.is_ip"
-  #         got: valid
-  - version/omitted/invalid/ipv6/h
-  #       input: [type.googleapis.com/buf.validate.conformance.cases.IsIp]:{val:"0::0:"}
-  #        want: validation error (1 violation)
-  #          1. constraint_id: "library.is_ip"
-  #         got: valid
-  - version/omitted/invalid/ipv6/i
-  #       input: [type.googleapis.com/buf.validate.conformance.cases.IsIp]:{val:"0::0:"}
-  #        want: validation error (1 violation)
-  #          1. constraint_id: "library.is_ip"
-  #         got: valid
-  - version/omitted/invalid/ipv6/j
-  #       input: [type.googleapis.com/buf.validate.conformance.cases.IsIp]:{val:"::0000ffff"}
-  #        want: validation error (1 violation)
-  #          1. constraint_id: "library.is_ip"
-  #         got: valid
 custom_constraints:
   - compilation/incorrect_type
   #       input: [type.googleapis.com/buf.validate.conformance.cases.custom_constraints.IncorrectType]:{a:123}


### PR DESCRIPTION
This ports the ipv6 fix from https://github.com/bufbuild/protovalidate-go/pull/215.

For context see the description on the above PR. The summary is that this fixes the validation for some corner cases of IPv6 address validation. Namely:

Adds a check that an IPv6 address can't begin or end on a single colon.
Adds a check to fail-fast on invalid hextets.