### PR TITLE
Fix isHostAndPort to reject leading zeros in port number

### DIFF
--- a/packages/protovalidate/src/lib.ts
+++ b/packages/protovalidate/src/lib.ts
@@ -592,6 +592,9 @@ function isPort(str: string): boolean {
     }
     return false;
   }
+  if (str.length > 1 && str[0] === "0") {
+    return false;
+  }
   return parseInt(str) <= 65535;
 }
 


### PR DESCRIPTION
ECMAScripts `parseInt` discards leading zeros. So `isHostAndPort` accepted "00" and "080" as valid port numbers.

The behavior established by protovalidate-go however rejects leading zeros as in "080". This updates the ECMAScript implementation to reject leading zeros as invalid.