### PR TITLE
Fix isHostAndPort to look for the last closing bracket of an IPv6 literal

### DIFF
--- a/packages/protovalidate/src/lib.ts
+++ b/packages/protovalidate/src/lib.ts
@@ -561,7 +561,7 @@ export function isHostAndPort(str: string, portRequired: boolean): boolean {
   }
   const splitIdx = str.lastIndexOf(":");
   if (str[0] == "[") {
-    const end = str.indexOf("]");
+    const end = str.lastIndexOf("]");
     switch (end + 1) {
       case str.length: // no port
         return !portRequired && isIp(str.substring(1, end), 6);


### PR DESCRIPTION
Fix a mistake that slipped in when porting from protovalidate-go.