### PR TITLE
Target ES2020

### DIFF
--- a/packages/cel-spec/tsconfig.json
+++ b/packages/cel-spec/tsconfig.json
@@ -1,16 +1,4 @@
 {
   "include": ["src/**/*"],
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    // to-debug-string.ts uses the `v` flag, which requires ES2024
-    "target": "es2024",
-    "lib": [
-      // For string.replaceAll in to-debug-string.ts
-      "es2021.string",
-      // For Intl.Segmenter in to-debug.string.ts
-      "es2022.intl",
-      // For string.isWellFormed in to-debug-string.ts
-      "es2024.string"
-    ]
-  }
+  "extends": "../../tsconfig.base.json"
 }

--- a/packages/cel/tsconfig.json
+++ b/packages/cel/tsconfig.json
@@ -3,8 +3,9 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src/**/*.test.ts"],
   "compilerOptions": {
-    // peggy generated code uses ES2021 features
-    "target": "es2021",
-    "lib": ["ES2021"]
+    "lib": [
+      // For string.replaceAll in parser.ts
+      "es2021.string"
+    ]
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,14 +1,7 @@
 {
   "compilerOptions": {
-    // We target ES2020 because we (currently) use BigInt literals and require the Text Encoding API.
     "target": "es2020",
-    "lib": [
-      "ES2017",
-      // ES2020.BigInt for 64-bit integers
-      "ES2020.BigInt",
-      // ES2022.Error for Error.cause
-      "ES2022.Error"
-    ],
+    "lib": ["ES2020"],
     "declaration": true,
     "types": ["@types/node"],
     // We don't have dependencies that require interop


### PR DESCRIPTION
Cleaning up compiler targets and libs. 

Targeting ES2020, we need the following exception in @bufbuild/cel: es2021.string for string.replaceAll in parser.ts.

to-debug-string.ts in @bufbuild/cel-spec also uses string.replaceAll, as well as the regex flag `v` (ES2024) and Intl.Segmenter (ES2022). 

Instead of adding more exceptions (and making it easy for other non-ES2020 features to slip into the code base), I'm silencing compiler errors with `@ts-expect-error` annotations. The exported function `toDebugString` is specific to compiler tests, and has been marked with a `@private` annotation. I believe this is a reasonable compromise.

