### PR TITLE
Update cel-spec to `0.19.0`

### DIFF
--- a/packages/cel-spec/README.md
+++ b/packages/cel-spec/README.md
@@ -1,6 +1,6 @@
 # @bufbuild/cel-spec
 
-This package provides CEL definitions and test data from https://github.com/google/cel-spec <!-- upstreamCelSpecRef -->v0.18.0<!-- upstreamCelSpecRef -->.
+This package provides CEL definitions and test data from https://github.com/google/cel-spec <!-- upstreamCelSpecRef -->v0.19.0<!-- upstreamCelSpecRef -->.
 
 CEL uses Protocol Buffer definitions for parsed expressions. For example, the
 message `cel.expr.ParsedExpr` provides an abstract representation of a parsed

--- a/packages/cel-spec/package.json
+++ b/packages/cel-spec/package.json
@@ -38,7 +38,7 @@
     "attw": "attw --pack",
     "license-header": "license-header"
   },
-  "upstreamCelSpecRef": "v0.18.0",
+  "upstreamCelSpecRef": "v0.19.0",
   "type": "module",
   "sideEffects": false,
   "exports": {

--- a/packages/cel-spec/proto/cel/expr/conformance/test/simple.proto
+++ b/packages/cel-spec/proto/cel/expr/conformance/test/simple.proto
@@ -26,7 +26,7 @@ option cc_enable_arenas = true;
 option go_package = "cel.dev/expr/conformance/test";
 option java_multiple_files = true;
 option java_outer_classname = "SimpleProto";
-option java_package = "dev.cel.expr.conformance";
+option java_package = "dev.cel.expr.conformance.test";
 
 // The format of a simple test file, expected to be stored in text format.
 // A file is the unit of granularity for selecting conformance tests,
@@ -76,6 +76,9 @@ message SimpleTest {
   // Disables the check phase.
   bool disable_check = 5;
 
+  // Disables the evaluate phase.
+  bool check_only = 15;
+
   // The type environment to use for the check phase.
   repeated cel.expr.Decl type_env = 6;
 
@@ -97,6 +100,9 @@ message SimpleTest {
     // *   a floating point NaN should match any NaN.
     cel.expr.Value value = 8;
 
+    // A result and deduced expression type.
+    TypedResult typed_result = 16;
+
     // Matches error evaluation results.
     cel.expr.ErrorSet eval_error = 9;
 
@@ -111,7 +117,17 @@ message SimpleTest {
     // (Using explicit message since oneof can't handle repeated.)
     UnknownSetMatcher any_unknowns = 12;
   }
-  // Next is 15.
+  // Next is 17.
+}
+
+// Matches a result along with deduced expression type.
+message TypedResult {
+  // A normal value, which must match the evaluation result exactly
+  // via value equality semantics. This is ignored if the test is `check_only`.
+  cel.expr.Value result = 1;
+
+  // The deduced type of the expression as reported by the checker.
+  cel.expr.Type deduced_type = 2;
 }
 
 // Matches error results from Eval.

--- a/packages/cel-spec/src/gen/cel/expr/conformance/test/simple_pb.ts
+++ b/packages/cel-spec/src/gen/cel/expr/conformance/test/simple_pb.ts
@@ -20,7 +20,7 @@
 
 import type { GenFile, GenMessage } from "@bufbuild/protobuf/codegenv1";
 import { fileDesc, messageDesc } from "@bufbuild/protobuf/codegenv1";
-import type { Decl } from "../../checked_pb.js";
+import type { Decl, Type } from "../../checked_pb.js";
 import { file_cel_expr_checked } from "../../checked_pb.js";
 import type { ErrorSet, ExprValue, UnknownSet } from "../../eval_pb.js";
 import { file_cel_expr_eval } from "../../eval_pb.js";
@@ -32,7 +32,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file cel/expr/conformance/test/simple.proto.
  */
 export const file_cel_expr_conformance_test_simple: GenFile = /*@__PURE__*/
-  fileDesc("CiZjZWwvZXhwci9jb25mb3JtYW5jZS90ZXN0L3NpbXBsZS5wcm90bxIZY2VsLmV4cHIuY29uZm9ybWFuY2UudGVzdCJyCg5TaW1wbGVUZXN0RmlsZRIMCgRuYW1lGAEgASgJEhMKC2Rlc2NyaXB0aW9uGAIgASgJEj0KB3NlY3Rpb24YAyADKAsyLC5jZWwuZXhwci5jb25mb3JtYW5jZS50ZXN0LlNpbXBsZVRlc3RTZWN0aW9uImsKEVNpbXBsZVRlc3RTZWN0aW9uEgwKBG5hbWUYASABKAkSEwoLZGVzY3JpcHRpb24YAiABKAkSMwoEdGVzdBgDIAMoCzIlLmNlbC5leHByLmNvbmZvcm1hbmNlLnRlc3QuU2ltcGxlVGVzdCLSBAoKU2ltcGxlVGVzdBIMCgRuYW1lGAEgASgJEhMKC2Rlc2NyaXB0aW9uGAIgASgJEgwKBGV4cHIYAyABKAkSFgoOZGlzYWJsZV9tYWNyb3MYBCABKAgSFQoNZGlzYWJsZV9jaGVjaxgFIAEoCBIgCgh0eXBlX2VudhgGIAMoCzIOLmNlbC5leHByLkRlY2wSEQoJY29udGFpbmVyGA0gASgJEg4KBmxvY2FsZRgOIAEoCRJFCghiaW5kaW5ncxgHIAMoCzIzLmNlbC5leHByLmNvbmZvcm1hbmNlLnRlc3QuU2ltcGxlVGVzdC5CaW5kaW5nc0VudHJ5EiAKBXZhbHVlGAggASgLMg8uY2VsLmV4cHIuVmFsdWVIABIoCgpldmFsX2Vycm9yGAkgASgLMhIuY2VsLmV4cHIuRXJyb3JTZXRIABJFCg9hbnlfZXZhbF9lcnJvcnMYCiABKAsyKi5jZWwuZXhwci5jb25mb3JtYW5jZS50ZXN0LkVycm9yU2V0TWF0Y2hlckgAEicKB3Vua25vd24YCyABKAsyFC5jZWwuZXhwci5Vbmtub3duU2V0SAASRAoMYW55X3Vua25vd25zGAwgASgLMiwuY2VsLmV4cHIuY29uZm9ybWFuY2UudGVzdC5Vbmtub3duU2V0TWF0Y2hlckgAGkQKDUJpbmRpbmdzRW50cnkSCwoDa2V5GAEgASgJEiIKBXZhbHVlGAIgASgLMhMuY2VsLmV4cHIuRXhwclZhbHVlOgI4AUIQCg5yZXN1bHRfbWF0Y2hlciI1Cg9FcnJvclNldE1hdGNoZXISIgoGZXJyb3JzGAEgAygLMhIuY2VsLmV4cHIuRXJyb3JTZXQiOwoRVW5rbm93blNldE1hdGNoZXISJgoIdW5rbm93bnMYASADKAsyFC5jZWwuZXhwci5Vbmtub3duU2V0QksKGGRldi5jZWwuZXhwci5jb25mb3JtYW5jZUILU2ltcGxlUHJvdG9QAVodY2VsLmRldi9leHByL2NvbmZvcm1hbmNlL3Rlc3T4AQFiBnByb3RvMw", [file_cel_expr_checked, file_cel_expr_eval, file_cel_expr_value]);
+  fileDesc("CiZjZWwvZXhwci9jb25mb3JtYW5jZS90ZXN0L3NpbXBsZS5wcm90bxIZY2VsLmV4cHIuY29uZm9ybWFuY2UudGVzdCJyCg5TaW1wbGVUZXN0RmlsZRIMCgRuYW1lGAEgASgJEhMKC2Rlc2NyaXB0aW9uGAIgASgJEj0KB3NlY3Rpb24YAyADKAsyLC5jZWwuZXhwci5jb25mb3JtYW5jZS50ZXN0LlNpbXBsZVRlc3RTZWN0aW9uImsKEVNpbXBsZVRlc3RTZWN0aW9uEgwKBG5hbWUYASABKAkSEwoLZGVzY3JpcHRpb24YAiABKAkSMwoEdGVzdBgDIAMoCzIlLmNlbC5leHByLmNvbmZvcm1hbmNlLnRlc3QuU2ltcGxlVGVzdCKmBQoKU2ltcGxlVGVzdBIMCgRuYW1lGAEgASgJEhMKC2Rlc2NyaXB0aW9uGAIgASgJEgwKBGV4cHIYAyABKAkSFgoOZGlzYWJsZV9tYWNyb3MYBCABKAgSFQoNZGlzYWJsZV9jaGVjaxgFIAEoCBISCgpjaGVja19vbmx5GA8gASgIEiAKCHR5cGVfZW52GAYgAygLMg4uY2VsLmV4cHIuRGVjbBIRCgljb250YWluZXIYDSABKAkSDgoGbG9jYWxlGA4gASgJEkUKCGJpbmRpbmdzGAcgAygLMjMuY2VsLmV4cHIuY29uZm9ybWFuY2UudGVzdC5TaW1wbGVUZXN0LkJpbmRpbmdzRW50cnkSIAoFdmFsdWUYCCABKAsyDy5jZWwuZXhwci5WYWx1ZUgAEj4KDHR5cGVkX3Jlc3VsdBgQIAEoCzImLmNlbC5leHByLmNvbmZvcm1hbmNlLnRlc3QuVHlwZWRSZXN1bHRIABIoCgpldmFsX2Vycm9yGAkgASgLMhIuY2VsLmV4cHIuRXJyb3JTZXRIABJFCg9hbnlfZXZhbF9lcnJvcnMYCiABKAsyKi5jZWwuZXhwci5jb25mb3JtYW5jZS50ZXN0LkVycm9yU2V0TWF0Y2hlckgAEicKB3Vua25vd24YCyABKAsyFC5jZWwuZXhwci5Vbmtub3duU2V0SAASRAoMYW55X3Vua25vd25zGAwgASgLMiwuY2VsLmV4cHIuY29uZm9ybWFuY2UudGVzdC5Vbmtub3duU2V0TWF0Y2hlckgAGkQKDUJpbmRpbmdzRW50cnkSCwoDa2V5GAEgASgJEiIKBXZhbHVlGAIgASgLMhMuY2VsLmV4cHIuRXhwclZhbHVlOgI4AUIQCg5yZXN1bHRfbWF0Y2hlciJUCgtUeXBlZFJlc3VsdBIfCgZyZXN1bHQYASABKAsyDy5jZWwuZXhwci5WYWx1ZRIkCgxkZWR1Y2VkX3R5cGUYAiABKAsyDi5jZWwuZXhwci5UeXBlIjUKD0Vycm9yU2V0TWF0Y2hlchIiCgZlcnJvcnMYASADKAsyEi5jZWwuZXhwci5FcnJvclNldCI7ChFVbmtub3duU2V0TWF0Y2hlchImCgh1bmtub3ducxgBIAMoCzIULmNlbC5leHByLlVua25vd25TZXRCUAodZGV2LmNlbC5leHByLmNvbmZvcm1hbmNlLnRlc3RCC1NpbXBsZVByb3RvUAFaHWNlbC5kZXYvZXhwci9jb25mb3JtYW5jZS90ZXN0+AEBYgZwcm90bzM", [file_cel_expr_checked, file_cel_expr_eval, file_cel_expr_value]);
 
 /**
  * The format of a simple test file, expected to be stored in text format.
@@ -153,6 +153,13 @@ export type SimpleTest = Message<"cel.expr.conformance.test.SimpleTest"> & {
   disableCheck: boolean;
 
   /**
+   * Disables the evaluate phase.
+   *
+   * @generated from field: bool check_only = 15;
+   */
+  checkOnly: boolean;
+
+  /**
    * The type environment to use for the check phase.
    *
    * @generated from field: repeated cel.expr.Decl type_env = 6;
@@ -199,6 +206,14 @@ export type SimpleTest = Message<"cel.expr.conformance.test.SimpleTest"> & {
     case: "value";
   } | {
     /**
+     * A result and deduced expression type.
+     *
+     * @generated from field: cel.expr.conformance.test.TypedResult typed_result = 16;
+     */
+    value: TypedResult;
+    case: "typedResult";
+  } | {
+    /**
      * Matches error evaluation results.
      *
      * @generated from field: cel.expr.ErrorSet eval_error = 9;
@@ -242,6 +257,35 @@ export const SimpleTestSchema: GenMessage<SimpleTest> = /*@__PURE__*/
   messageDesc(file_cel_expr_conformance_test_simple, 2);
 
 /**
+ * Matches a result along with deduced expression type.
+ *
+ * @generated from message cel.expr.conformance.test.TypedResult
+ */
+export type TypedResult = Message<"cel.expr.conformance.test.TypedResult"> & {
+  /**
+   * A normal value, which must match the evaluation result exactly
+   * via value equality semantics. This is ignored if the test is `check_only`.
+   *
+   * @generated from field: cel.expr.Value result = 1;
+   */
+  result?: Value;
+
+  /**
+   * The deduced type of the expression as reported by the checker.
+   *
+   * @generated from field: cel.expr.Type deduced_type = 2;
+   */
+  deducedType?: Type;
+};
+
+/**
+ * Describes the message cel.expr.conformance.test.TypedResult.
+ * Use `create(TypedResultSchema)` to create a new message.
+ */
+export const TypedResultSchema: GenMessage<TypedResult> = /*@__PURE__*/
+  messageDesc(file_cel_expr_conformance_test_simple, 3);
+
+/**
  * Matches error results from Eval.
  *
  * @generated from message cel.expr.conformance.test.ErrorSetMatcher
@@ -260,7 +304,7 @@ export type ErrorSetMatcher = Message<"cel.expr.conformance.test.ErrorSetMatcher
  * Use `create(ErrorSetMatcherSchema)` to create a new message.
  */
 export const ErrorSetMatcherSchema: GenMessage<ErrorSetMatcher> = /*@__PURE__*/
-  messageDesc(file_cel_expr_conformance_test_simple, 3);
+  messageDesc(file_cel_expr_conformance_test_simple, 4);
 
 /**
  * Matches unknown results from Eval.
@@ -281,5 +325,5 @@ export type UnknownSetMatcher = Message<"cel.expr.conformance.test.UnknownSetMat
  * Use `create(UnknownSetMatcherSchema)` to create a new message.
  */
 export const UnknownSetMatcherSchema: GenMessage<UnknownSetMatcher> = /*@__PURE__*/
-  messageDesc(file_cel_expr_conformance_test_simple, 4);
+  messageDesc(file_cel_expr_conformance_test_simple, 5);
 

--- a/packages/cel-spec/src/testdata-json.ts
+++ b/packages/cel-spec/src/testdata-json.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Generated from github.com/google/cel-spec v0.18.0 by scripts/fetch-testdata.js
+// Generated from github.com/google/cel-spec v0.19.0 by scripts/fetch-testdata.js
 import type { JsonObject } from "@bufbuild/protobuf";
 
 export const testdataJson: JsonObject[] = [
@@ -19534,6 +19534,308 @@ export const testdataJson: JsonObject[] = [
                   "message": "range"
                 }
               ]
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "type_deductions",
+    "description": "Tests for type checker deduced types",
+    "section": [
+      {
+        "name": "constant_literals",
+        "test": [
+          {
+            "name": "bool",
+            "expr": "true",
+            "typedResult": {
+              "result": {
+                "boolValue": true
+              },
+              "deducedType": {
+                "primitive": "BOOL"
+              }
+            }
+          },
+          {
+            "name": "int",
+            "expr": "42",
+            "typedResult": {
+              "result": {
+                "int64Value": "42"
+              },
+              "deducedType": {
+                "primitive": "INT64"
+              }
+            }
+          },
+          {
+            "name": "uint",
+            "expr": "42u",
+            "typedResult": {
+              "result": {
+                "uint64Value": "42"
+              },
+              "deducedType": {
+                "primitive": "UINT64"
+              }
+            }
+          },
+          {
+            "name": "double",
+            "expr": "0.1",
+            "typedResult": {
+              "result": {
+                "doubleValue": 0.1
+              },
+              "deducedType": {
+                "primitive": "DOUBLE"
+              }
+            }
+          },
+          {
+            "name": "string",
+            "expr": "\"test\"",
+            "typedResult": {
+              "result": {
+                "stringValue": "test"
+              },
+              "deducedType": {
+                "primitive": "STRING"
+              }
+            }
+          },
+          {
+            "name": "bytes",
+            "expr": "b\"test\"",
+            "typedResult": {
+              "result": {
+                "bytesValue": "dGVzdA=="
+              },
+              "deducedType": {
+                "primitive": "BYTES"
+              }
+            }
+          },
+          {
+            "name": "null",
+            "expr": "null",
+            "typedResult": {
+              "result": {
+                "nullValue": null
+              },
+              "deducedType": {
+                "null": null
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "complex_intializers",
+        "test": [
+          {
+            "name": "list",
+            "expr": "[1]",
+            "typedResult": {
+              "result": {
+                "listValue": {
+                  "values": [
+                    {
+                      "int64Value": "1"
+                    }
+                  ]
+                }
+              },
+              "deducedType": {
+                "listType": {
+                  "elemType": {
+                    "primitive": "INT64"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name": "map",
+            "expr": "{'abc': 123}",
+            "typedResult": {
+              "result": {
+                "mapValue": {
+                  "entries": [
+                    {
+                      "key": {
+                        "stringValue": "abc"
+                      },
+                      "value": {
+                        "int64Value": "123"
+                      }
+                    }
+                  ]
+                }
+              },
+              "deducedType": {
+                "mapType": {
+                  "keyType": {
+                    "primitive": "STRING"
+                  },
+                  "valueType": {
+                    "primitive": "INT64"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name": "struct",
+            "expr": "TestAllTypes{single_int64: 1}",
+            "container": "cel.expr.conformance.proto3",
+            "typedResult": {
+              "result": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "singleInt64": "1"
+                }
+              },
+              "deducedType": {
+                "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "field_access",
+        "test": [
+          {
+            "name": "int_field",
+            "expr": "TestAllTypes{single_int64: 1}.single_int64",
+            "container": "cel.expr.conformance.proto3",
+            "typedResult": {
+              "result": {
+                "int64Value": "1"
+              },
+              "deducedType": {
+                "primitive": "INT64"
+              }
+            }
+          },
+          {
+            "name": "repeated_int_field",
+            "expr": "TestAllTypes{}.repeated_int64",
+            "container": "cel.expr.conformance.proto3",
+            "typedResult": {
+              "result": {
+                "listValue": {}
+              },
+              "deducedType": {
+                "listType": {
+                  "elemType": {
+                    "primitive": "INT64"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name": "map_bool_int",
+            "expr": "TestAllTypes{}.map_bool_int64",
+            "container": "cel.expr.conformance.proto3",
+            "typedResult": {
+              "result": {
+                "mapValue": {}
+              },
+              "deducedType": {
+                "mapType": {
+                  "keyType": {
+                    "primitive": "BOOL"
+                  },
+                  "valueType": {
+                    "primitive": "INT64"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "indexing",
+        "test": [
+          {
+            "name": "list",
+            "expr": "['foo'][0]",
+            "typedResult": {
+              "result": {
+                "stringValue": "foo"
+              },
+              "deducedType": {
+                "primitive": "STRING"
+              }
+            }
+          },
+          {
+            "name": "map",
+            "expr": "{'abc': 123}['abc']",
+            "typedResult": {
+              "result": {
+                "int64Value": "123"
+              },
+              "deducedType": {
+                "primitive": "INT64"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "functions",
+        "test": [
+          {
+            "name": "nested_calls",
+            "expr": "('foo' + 'bar').startsWith('foo')",
+            "typedResult": {
+              "result": {
+                "boolValue": true
+              },
+              "deducedType": {
+                "primitive": "BOOL"
+              }
+            }
+          },
+          {
+            "name": "function_result_type",
+            "expr": "fn('abc', 123)",
+            "checkOnly": true,
+            "typeEnv": [
+              {
+                "name": "fn",
+                "function": {
+                  "overloads": [
+                    {
+                      "overloadId": "fn_string_int",
+                      "params": [
+                        {
+                          "primitive": "STRING"
+                        },
+                        {
+                          "primitive": "INT64"
+                        }
+                      ],
+                      "resultType": {
+                        "primitive": "STRING"
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "typedResult": {
+              "deducedType": {
+                "primitive": "STRING"
+              }
             }
           }
         ]


### PR DESCRIPTION
Update cel-spec to `0.19.0`. The major changes are the addition of a new assertion type for types. It also includes a value check we check for that for now and skip the type check.