### PR TITLE
Add `EvalContext`

### DIFF
--- a/packages/cel/src/celenv.ts
+++ b/packages/cel/src/celenv.ts
@@ -44,6 +44,7 @@ import {
   isReflectMap,
   isReflectMessage,
 } from "@bufbuild/protobuf/reflect";
+import { setEvalContext } from "./eval.js";
 
 /**
  * A CEL parser interface
@@ -140,7 +141,14 @@ export class CelEnv {
   }
 
   public eval(expr: Interpretable): CelResult {
-    return expr.eval(this.ctx);
+    const unset = setEvalContext({
+      registry: this.planner.getAdapter().registry,
+    });
+    try {
+      return expr.eval(this.ctx);
+    } finally {
+      unset();
+    }
   }
 
   /** Parses, plans, and evals the given expr. */

--- a/packages/cel/src/eval.ts
+++ b/packages/cel/src/eval.ts
@@ -1,0 +1,48 @@
+// Copyright 2024-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Registry } from "@bufbuild/protobuf";
+
+/**
+ * Context available in the evaluation phase.
+ */
+export interface EvalContext {
+  /**
+   * The protobuf registry.
+   */
+  readonly registry: Registry;
+  // TODO(srikrsna): Investigate adding activation here.
+}
+
+const contextStack: EvalContext[] = [];
+
+/**
+ * Sets the EvalContext for the current execution scope.
+ */
+export function setEvalContext(context: EvalContext) {
+  contextStack.push(context);
+  return () => contextStack.pop();
+}
+
+/**
+ * Gets the current EvalContext.
+ *
+ * Throws an error if it doesn't.
+ */
+export function getEvalContext(): EvalContext {
+  if (contextStack.length === 0) {
+    throw new Error("cannot use `getEvalContext` outside of an evaluation");
+  }
+  return contextStack[contextStack.length - 1];
+}


### PR DESCRIPTION
Groundwork for further refactors. We want to consolidate the adapter logic, the registry is probably the only thing stopping that. Adding a context means we can create functions that can get this information from a global function instead of creating them per environment. Due to the single threaded nature of es and synchronous nature of CEL, we can safely use a global stack.