### PR TITLE
Add `NullMessage`

### DIFF
--- a/packages/cel/src/equals.test.ts
+++ b/packages/cel/src/equals.test.ts
@@ -14,7 +14,7 @@
 
 import { before, describe, test } from "node:test";
 import * as assert from "node:assert/strict";
-import { ProtoNull, type CelVal } from "./value/value.js";
+import type { CelVal } from "./value/value.js";
 import { equals } from "./equals.js";
 import { getCelType } from "./value/type.js";
 import {
@@ -44,6 +44,7 @@ import { setEvalContext } from "./eval.js";
 import { celList, isCelList } from "./list.js";
 import { celMap, isCelMap } from "./map.js";
 import { celUint, isCelUint } from "./uint.js";
+import { isNullMessage, nullMessage } from "./null.js";
 
 /**
  * The tests are based cases in this accepted CEL proposal: https://github.com/google/cel-spec/wiki/proposal-210#proposal
@@ -97,7 +98,7 @@ describe("equals()", () => {
       ["str", create(StringValueSchema, { value: "str" })],
       // Nulls
       [null, null],
-      [null, new ProtoNull("Msg", null)],
+      [null, nullMessage(TestAllTypesSchema)],
       // Messages
       [
         create(TestAllTypesSchema, { singleInt32: 1 }),
@@ -198,8 +199,8 @@ function toTestString(value: unknown) {
     typeName = `reflect(${value.desc.typeName})`;
   } else if (isReflectMap(value)) {
     typeName = `map<${value.field().mapKey}, ${value.field()}>`;
-  } else if (value instanceof ProtoNull) {
-    typeName = `null_type<${value.messageTypeName}>`;
+  } else if (isNullMessage(value)) {
+    typeName = `null_type<${value.typeName}>`;
   } else {
     typeName = getCelType(value as CelVal).name;
   }
@@ -209,7 +210,7 @@ function toTestString(value: unknown) {
 function formatCelObject(value: object | null) {
   switch (true) {
     case value === null:
-    case value instanceof ProtoNull:
+    case isNullMessage(value):
       return "null";
     case isCelUint(value):
       return value.value.toString();

--- a/packages/cel/src/equals.ts
+++ b/packages/cel/src/equals.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { isMessage } from "@bufbuild/protobuf";
-import { CelObject, CelType, ProtoNull } from "./value/value.js";
+import { CelObject, CelType } from "./value/value.js";
 import {
   isReflectMap,
   isReflectMessage,
@@ -26,6 +26,7 @@ import { isWrapper } from "@bufbuild/protobuf/wkt";
 import { type CelList, isCelList } from "./list.js";
 import { type CelMap, isCelMap } from "./map.js";
 import { isCelUint } from "./uint.js";
+import { isNullMessage } from "./null.js";
 
 /**
  * Checks for equality of two CEL values. It follows the following rules:
@@ -78,13 +79,12 @@ export function equals(lhs: unknown, rhs: unknown): boolean {
       return isReflectMap(rhs) && equalsReflectMap(lhs, rhs);
   }
   // Proto Null
-  if (lhs instanceof ProtoNull) {
+  if (isNullMessage(lhs)) {
     return (
-      rhs === null ||
-      (rhs instanceof ProtoNull && lhs.messageTypeName === rhs.messageTypeName)
+      rhs === null || (isNullMessage(rhs) && lhs.typeName === rhs.typeName)
     );
   }
-  if (rhs instanceof ProtoNull && lhs === null) {
+  if (isNullMessage(rhs) && lhs === null) {
     return true;
   }
   if (lhs instanceof CelObject) {

--- a/packages/cel/src/index.ts
+++ b/packages/cel/src/index.ts
@@ -37,7 +37,6 @@ export {
   isCelVal,
   CelError,
   CelErrors,
-  ProtoNull,
   CelObject,
 } from "./value/value.js";
 export { getCelType } from "./value/type.js";
@@ -49,6 +48,7 @@ export { Func, FuncRegistry } from "./func.js";
 export { type CelMap, celMap, isCelMap } from "./map.js";
 export { type CelList, celList, isCelList, celListConcat } from "./list.js";
 export { type CelUint, celUint, isCelUint } from "./uint.js";
+export { type NullMessage, nullMessage } from "./null.js";
 
 export function createEnv(namespace: string, registry: Registry): CelEnv {
   const env = new CelEnv(namespace, registry);

--- a/packages/cel/src/null.ts
+++ b/packages/cel/src/null.ts
@@ -17,8 +17,6 @@ import { reflect, type ReflectMessage } from "@bufbuild/protobuf/reflect";
 
 const privateSymbol = Symbol.for("@bufbuild/cel/null");
 
-// TODO(srikrsna): Do we need a WeakMap? DescMessages are global, and should not be GCed.
-// A regular map might suffice, unless weakmap removes keys irrespective of GC.
 const cache = new WeakMap<DescMessage, NullMessageImpl>();
 
 /**

--- a/packages/cel/src/null.ts
+++ b/packages/cel/src/null.ts
@@ -1,0 +1,71 @@
+// Copyright 2024-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DescMessage } from "@bufbuild/protobuf";
+import { reflect, type ReflectMessage } from "@bufbuild/protobuf/reflect";
+
+const privateSymbol = Symbol.for("@bufbuild/cel/null");
+
+// TODO(srikrsna): Do we need a WeakMap? DescMessages are global, and should not be GCed.
+// A regular map might suffice, unless weakmap removes keys irrespective of GC.
+const cache = new WeakMap<DescMessage, NullMessageImpl>();
+
+/**
+ * Represents a null protobuf message.
+ */
+export interface NullMessage {
+  [privateSymbol]: unknown;
+
+  /**
+   * Fully qualified name of the message.
+   */
+  readonly typeName: string;
+
+  /**
+   * The zero value of the message.
+   */
+  readonly zero: ReflectMessage;
+}
+
+/**
+ * Creates NullMessage from a DescMessage.
+ */
+export function nullMessage(desc: DescMessage): NullMessage {
+  let impl = cache.get(desc);
+  if (impl === undefined) {
+    impl = new NullMessageImpl(reflect(desc));
+    cache.set(desc, impl);
+  }
+  return impl;
+}
+
+/**
+ * Returns true if the given value is a NullMessage.
+ */
+export function isNullMessage(v: unknown): v is NullMessage {
+  return typeof v === "object" && v !== null && privateSymbol in v;
+}
+
+class NullMessageImpl implements NullMessage {
+  [privateSymbol] = {};
+  constructor(private readonly _zero: ReflectMessage) {}
+
+  get typeName() {
+    return this._zero.desc.typeName;
+  }
+
+  get zero() {
+    return this._zero;
+  }
+}

--- a/packages/cel/src/testing.ts
+++ b/packages/cel/src/testing.ts
@@ -19,7 +19,6 @@ import {
   CelType,
   makeStringExtFuncRegistry,
   ObjectActivation,
-  ProtoNull,
   type CelResult,
   isCelMap,
 } from "./index.js";
@@ -46,6 +45,7 @@ import { ProtoValAdapter } from "./adapter/proto.js";
 import { celList, isCelList } from "./list.js";
 import { celMap } from "./map.js";
 import { celUint, isCelUint, type CelUint } from "./uint.js";
+import { isNullMessage } from "./null.js";
 
 const STRINGS_EXT_FUNCS = makeStringExtFuncRegistry();
 
@@ -223,7 +223,7 @@ function celValueToValue(
     case "symbol":
       throw new Error(`unrecognised cel type: ${typeof value}`);
   }
-  if (value === null || value instanceof ProtoNull) {
+  if (value === null || isNullMessage(value)) {
     return { kind: { case: "nullValue", value: NullValue.NULL_VALUE } };
   }
   if (value instanceof Uint8Array) {

--- a/packages/cel/src/value/type.ts
+++ b/packages/cel/src/value/type.ts
@@ -27,7 +27,6 @@ import {
 } from "@bufbuild/protobuf/wkt";
 
 import {
-  ProtoNull,
   CelObject,
   type CelVal,
   CelType,
@@ -37,6 +36,7 @@ import {
 import { isCelList } from "../list.js";
 import { isCelMap } from "../map.js";
 import { celUint, isCelUint } from "../uint.js";
+import { isNullMessage } from "../null.js";
 
 export const DYN = new CelType("dyn");
 export const NULL = new ConcreteType("null_type", null);
@@ -101,8 +101,8 @@ export function getCelType(val: CelVal): CelType {
     case "object":
       if (val === null) {
         return NULL;
-      } else if (val instanceof ProtoNull) {
-        return getCelType(val.defaultValue);
+      } else if (isNullMessage(val)) {
+        return new CelType(val.zero.desc.typeName);
       } else if (val instanceof Uint8Array) {
         return BYTES;
       } else if (isMessage(val)) {

--- a/packages/cel/src/value/value.ts
+++ b/packages/cel/src/value/value.ts
@@ -38,6 +38,7 @@ import type { Timestamp } from "@bufbuild/protobuf/wkt";
 import { type CelList, isCelList } from "../list.js";
 import { type CelMap, isCelMap } from "../map.js";
 import { isCelUint, type CelUint } from "../uint.js";
+import { isNullMessage, type NullMessage } from "../null.js";
 
 /** Cel Number types, which all existing on the same logical number line. */
 export type CelNum = bigint | CelUint | number;
@@ -181,7 +182,7 @@ export function isCelMsg(val: unknown): val is CelMsg {
 /** All types Cel understands natively */
 export type CelVal =
   | null
-  | ProtoNull
+  | NullMessage
   | CelPrim
   | CelMsg
   | CelMap
@@ -192,7 +193,7 @@ export type CelVal =
 export function isCelVal(val: unknown): val is CelVal {
   return (
     val === null ||
-    val instanceof ProtoNull ||
+    isNullMessage(val) ||
     isCelPrim(val) ||
     isCelMsg(val) ||
     isCelList(val) ||
@@ -209,15 +210,6 @@ export interface Unwrapper<V = unknown> {
 export interface CelValAdapter<V = unknown> extends Unwrapper<V> {
   toCel(native: CelResult<V>): CelResult;
   fromCel(cel: CelVal): CelResult<V>;
-}
-
-// proto3 has typed nulls.
-export class ProtoNull {
-  constructor(
-    public readonly messageTypeName: string,
-    public readonly defaultValue: CelVal,
-    public readonly value: CelVal = null,
-  ) {}
 }
 
 export class CelObject {
@@ -341,7 +333,7 @@ export function coerceToBigInt(
 ): CelResult<bigint> {
   if (val instanceof CelError) {
     return val;
-  } else if (val === undefined || val === null || val instanceof ProtoNull) {
+  } else if (val === undefined || val === null) {
     return 0n;
   } else if (isCelWrap(val) || isCelUint(val)) {
     val = val.value;
@@ -360,7 +352,7 @@ export function coerceToNumber(
 ): CelResult<number> {
   if (val instanceof CelError) {
     return val;
-  } else if (val === undefined || val === null || val instanceof ProtoNull) {
+  } else if (val === undefined || val === null) {
     return 0;
   } else if (isCelWrap(val) || isCelUint(val)) {
     val = val.value;
@@ -379,7 +371,7 @@ export function coerceToString(
 ): CelResult<string> {
   if (val instanceof CelError) {
     return val;
-  } else if (val === undefined || val === null || val instanceof ProtoNull) {
+  } else if (val === undefined || val === null) {
     return "";
   } else if (isCelWrap(val) || isCelUint(val)) {
     val = val.value;
@@ -396,7 +388,7 @@ export function coerceToBytes(
 ): CelResult<Uint8Array> {
   if (val instanceof CelError) {
     return val;
-  } else if (val === undefined || val === null || val instanceof ProtoNull) {
+  } else if (val === undefined || val === null) {
     return new Uint8Array();
   } else if (isCelWrap(val) || isCelUint(val)) {
     val = val.value;


### PR DESCRIPTION
Replaces the `ProtoNull` type. Follows the same pattern as `CelUint`, `CelList`, and `CelMap`.