### PR TITLE
Refactor function types

### DIFF
--- a/packages/cel/src/env.ts
+++ b/packages/cel/src/env.ts
@@ -17,8 +17,8 @@ import { createRegistryWithWKT } from "./registry.js";
 import {
   FuncRegistry,
   OrderedDispatcher,
+  type CelFunc,
   type Dispatcher,
-  type Func,
 } from "./func.js";
 import { STD_FUNCS } from "./std/std.js";
 import { Namespace } from "./namespace.js";
@@ -55,7 +55,7 @@ export interface CelEnvOptions {
    *
    * All functions must be uniue. This can be used to override any std function.
    */
-  funcs?: Func[];
+  funcs?: CelFunc[];
 }
 
 /**

--- a/packages/cel/src/ext/strings/strings.ts
+++ b/packages/cel/src/ext/strings/strings.ts
@@ -20,15 +20,15 @@ import {
   type Timestamp,
 } from "@bufbuild/protobuf/wkt";
 
-import { FuncOverload, Func } from "../../func.js";
+import { celOverload, celFunc } from "../../func.js";
 import { CelScalar, isCelType, listType, type CelValue } from "../../type.js";
 import { type CelList, celList, isCelList } from "../../list.js";
 import { type CelMap, isCelMap } from "../../map.js";
 import { isCelUint } from "../../uint.js";
 import { isReflectMessage } from "@bufbuild/protobuf/reflect";
 
-const charAt = new Func("charAt", [
-  new FuncOverload(
+const charAt = celFunc("charAt", [
+  celOverload(
     [CelScalar.STRING, CelScalar.INT],
     CelScalar.STRING,
     (str, index) => {
@@ -41,13 +41,13 @@ const charAt = new Func("charAt", [
   ),
 ]);
 
-const indexOf = new Func("indexOf", [
-  new FuncOverload(
+const indexOf = celFunc("indexOf", [
+  celOverload(
     [CelScalar.STRING, CelScalar.STRING],
     CelScalar.INT,
     (str, substr) => BigInt(str.indexOf(substr)),
   ),
-  new FuncOverload(
+  celOverload(
     [CelScalar.STRING, CelScalar.STRING, CelScalar.INT],
     CelScalar.INT,
     (str, substr, startN) => {
@@ -60,13 +60,13 @@ const indexOf = new Func("indexOf", [
   ),
 ]);
 
-const lastIndexOf = new Func("lastIndexOf", [
-  new FuncOverload(
+const lastIndexOf = celFunc("lastIndexOf", [
+  celOverload(
     [CelScalar.STRING, CelScalar.STRING],
     CelScalar.INT,
     (str, substr) => BigInt(str.lastIndexOf(substr)),
   ),
-  new FuncOverload(
+  celOverload(
     [CelScalar.STRING, CelScalar.STRING, CelScalar.INT],
     CelScalar.INT,
     (str, substr, startN) => {
@@ -79,8 +79,8 @@ const lastIndexOf = new Func("lastIndexOf", [
   ),
 ]);
 
-const lowerAscii = new Func("lowerAscii", [
-  new FuncOverload([CelScalar.STRING], CelScalar.STRING, (str) => {
+const lowerAscii = celFunc("lowerAscii", [
+  celOverload([CelScalar.STRING], CelScalar.STRING, (str) => {
     // Only lower case ascii characters.
     let result = "";
     for (let i = 0; i < str.length; i++) {
@@ -95,8 +95,8 @@ const lowerAscii = new Func("lowerAscii", [
   }),
 ]);
 
-const upperAscii = new Func("upperAscii", [
-  new FuncOverload([CelScalar.STRING], CelScalar.STRING, (str) => {
+const upperAscii = celFunc("upperAscii", [
+  celOverload([CelScalar.STRING], CelScalar.STRING, (str) => {
     let result = "";
     for (let i = 0; i < str.length; i++) {
       const c = str.charCodeAt(i);
@@ -127,13 +127,13 @@ function replaceOp(str: string, substr: string, repl: string, num: number) {
   return result;
 }
 
-const replace = new Func("replace", [
-  new FuncOverload(
+const replace = celFunc("replace", [
+  celOverload(
     [CelScalar.STRING, CelScalar.STRING, CelScalar.STRING],
     CelScalar.STRING,
     (str, substr, repl) => replaceOp(str, substr, repl, str.length),
   ),
-  new FuncOverload(
+  celOverload(
     [CelScalar.STRING, CelScalar.STRING, CelScalar.STRING, CelScalar.INT],
     CelScalar.STRING,
     (str, substr, repl, num) => replaceOp(str, substr, repl, Number(num)),
@@ -147,13 +147,13 @@ function splitOp(str: string, sep: string, num?: number) {
   return celList(str.split(sep, num));
 }
 
-const split = new Func("split", [
-  new FuncOverload(
+const split = celFunc("split", [
+  celOverload(
     [CelScalar.STRING, CelScalar.STRING],
     listType(CelScalar.STRING),
     splitOp,
   ),
-  new FuncOverload(
+  celOverload(
     [CelScalar.STRING, CelScalar.STRING, CelScalar.INT],
     listType(CelScalar.STRING),
     (str, sep, num) => splitOp(str, sep, Number(num)),
@@ -182,13 +182,9 @@ function substringOp(str: string, start: bigint, end?: bigint) {
   return str.substring(Number(start), Number(end));
 }
 
-const substring = new Func("substring", [
-  new FuncOverload(
-    [CelScalar.STRING, CelScalar.INT],
-    CelScalar.STRING,
-    substringOp,
-  ),
-  new FuncOverload(
+const substring = celFunc("substring", [
+  celOverload([CelScalar.STRING, CelScalar.INT], CelScalar.STRING, substringOp),
+  celOverload(
     [CelScalar.STRING, CelScalar.INT, CelScalar.INT],
     CelScalar.STRING,
     substringOp,
@@ -202,8 +198,8 @@ const WHITE_SPACE = new Set([
   0x2028, 0x2029, 0x202f, 0x205f, 0x3000,
 ]);
 
-const trim = new Func("trim", [
-  new FuncOverload([CelScalar.STRING], CelScalar.STRING, (str) => {
+const trim = celFunc("trim", [
+  celOverload([CelScalar.STRING], CelScalar.STRING, (str) => {
     // Trim using the unicode white space definition.
     let start = 0;
     let end = str.length - 1;
@@ -232,9 +228,9 @@ function joinOp(list: CelList, sep = "") {
   return result;
 }
 
-const join = new Func("join", [
-  new FuncOverload([listType(CelScalar.DYN)], CelScalar.STRING, joinOp),
-  new FuncOverload(
+const join = celFunc("join", [
+  celOverload([listType(CelScalar.DYN)], CelScalar.STRING, joinOp),
+  celOverload(
     [listType(CelScalar.DYN), CelScalar.STRING],
     CelScalar.STRING,
     joinOp,
@@ -254,8 +250,8 @@ const QUOTE_MAP: Map<number, string> = new Map([
   [0x5c, "\\\\"],
 ]);
 
-const quote = new Func("strings.quote", [
-  new FuncOverload([CelScalar.STRING], CelScalar.STRING, (str) => {
+const quote = celFunc("strings.quote", [
+  celOverload([CelScalar.STRING], CelScalar.STRING, (str) => {
     let result = '"';
     for (let i = 0; i < str.length; i++) {
       const c = str.charCodeAt(i);
@@ -558,8 +554,8 @@ function formatImpl(format: string, args: CelList) {
   return result;
 }
 
-const format = new Func("format", [
-  new FuncOverload(
+const format = celFunc("format", [
+  celOverload(
     [CelScalar.STRING, listType(CelScalar.DYN)],
     CelScalar.STRING,
     formatImpl,

--- a/packages/cel/src/index.ts
+++ b/packages/cel/src/index.ts
@@ -16,7 +16,12 @@ export {
   type CelResult,
   CelError,
 } from "./error.js";
-export { Func, FuncOverload } from "./func.js";
+export {
+  type CelFunc,
+  type CelOverload,
+  celFunc,
+  celOverload,
+} from "./func.js";
 export { type CelMap, celMap, isCelMap } from "./map.js";
 export { type CelList, celList, isCelList, celListConcat } from "./list.js";
 export { type CelUint, celUint, isCelUint } from "./uint.js";

--- a/packages/cel/src/std/cast.ts
+++ b/packages/cel/src/std/cast.ts
@@ -19,7 +19,7 @@ import {
   TimestampSchema,
 } from "@bufbuild/protobuf/wkt";
 
-import { FuncOverload, type FuncRegistry, Func } from "../func.js";
+import { type FuncRegistry, celOverload, celFunc } from "../func.js";
 import {
   isOverflowInt,
   isOverflowIntNum,
@@ -49,36 +49,36 @@ const DURATION = "duration";
 const TYPE = "type";
 const DYN = "dyn";
 
-const intFunc = new Func(INT, [
-  new FuncOverload([CelScalar.INT], CelScalar.INT, (x) => x),
-  new FuncOverload([CelScalar.UINT], CelScalar.INT, (x) => {
+const intFunc = celFunc(INT, [
+  celOverload([CelScalar.INT], CelScalar.INT, (x) => x),
+  celOverload([CelScalar.UINT], CelScalar.INT, (x) => {
     const val = x.value;
     if (isOverflowInt(val)) {
       throw overflow(INT, CelScalar.INT);
     }
     return x.value;
   }),
-  new FuncOverload([CelScalar.DOUBLE], CelScalar.INT, (x) => {
+  celOverload([CelScalar.DOUBLE], CelScalar.INT, (x) => {
     if (isOverflowIntNum(x)) {
       throw overflow(INT, CelScalar.INT);
     }
     return BigInt(Math.trunc(x));
   }),
-  new FuncOverload([CelScalar.STRING], CelScalar.INT, (x) => {
+  celOverload([CelScalar.STRING], CelScalar.INT, (x) => {
     const val = BigInt(x);
     if (isOverflowInt(val)) {
       throw overflow(INT, CelScalar.INT);
     }
     return val;
   }),
-  new FuncOverload([TIMESTAMP_TYPE], CelScalar.INT, (x) => {
+  celOverload([TIMESTAMP_TYPE], CelScalar.INT, (x) => {
     const val = x.message.seconds;
     if (isOverflowInt(val)) {
       throw overflow(INT, CelScalar.INT);
     }
     return BigInt(val);
   }),
-  new FuncOverload([DURATION_TYPE], CelScalar.INT, (x) => {
+  celOverload([DURATION_TYPE], CelScalar.INT, (x) => {
     const val = x.message.seconds;
     if (isOverflowInt(val)) {
       throw overflow(INT, CelScalar.INT);
@@ -87,21 +87,21 @@ const intFunc = new Func(INT, [
   }),
 ]);
 
-const uintFunc = new Func(UINT, [
-  new FuncOverload([CelScalar.UINT], CelScalar.UINT, (x) => x),
-  new FuncOverload([CelScalar.INT], CelScalar.UINT, (x) => {
+const uintFunc = celFunc(UINT, [
+  celOverload([CelScalar.UINT], CelScalar.UINT, (x) => x),
+  celOverload([CelScalar.INT], CelScalar.UINT, (x) => {
     if (isOverflowUint(x)) {
       throw overflow(UINT, CelScalar.UINT);
     }
     return celUint(x);
   }),
-  new FuncOverload([CelScalar.DOUBLE], CelScalar.UINT, (x) => {
+  celOverload([CelScalar.DOUBLE], CelScalar.UINT, (x) => {
     if (isOverflowUintNum(x)) {
       throw overflow(UINT, CelScalar.UINT);
     }
     return celUint(BigInt(Math.trunc(x)));
   }),
-  new FuncOverload([CelScalar.STRING], CelScalar.UINT, (x) => {
+  celOverload([CelScalar.STRING], CelScalar.UINT, (x) => {
     const val = BigInt(x);
     if (isOverflowUint(val)) {
       throw overflow(UINT, CelScalar.UINT);
@@ -110,16 +110,16 @@ const uintFunc = new Func(UINT, [
   }),
 ]);
 
-const doubleFunc = new Func(DOUBLE, [
-  new FuncOverload([CelScalar.DOUBLE], CelScalar.DOUBLE, (x) => x),
-  new FuncOverload([CelScalar.INT], CelScalar.DOUBLE, (x) => Number(x)),
-  new FuncOverload([CelScalar.UINT], CelScalar.DOUBLE, (x) => Number(x.value)),
-  new FuncOverload([CelScalar.STRING], CelScalar.DOUBLE, (x) => Number(x)),
+const doubleFunc = celFunc(DOUBLE, [
+  celOverload([CelScalar.DOUBLE], CelScalar.DOUBLE, (x) => x),
+  celOverload([CelScalar.INT], CelScalar.DOUBLE, (x) => Number(x)),
+  celOverload([CelScalar.UINT], CelScalar.DOUBLE, (x) => Number(x.value)),
+  celOverload([CelScalar.STRING], CelScalar.DOUBLE, (x) => Number(x)),
 ]);
 
-const boolFunc = new Func(BOOL, [
-  new FuncOverload([CelScalar.BOOL], CelScalar.BOOL, (x) => x),
-  new FuncOverload([CelScalar.STRING], CelScalar.BOOL, (x) => {
+const boolFunc = celFunc(BOOL, [
+  celOverload([CelScalar.BOOL], CelScalar.BOOL, (x) => x),
+  celOverload([CelScalar.STRING], CelScalar.BOOL, (x) => {
     switch (x) {
       case "true":
       case "True":
@@ -139,22 +139,20 @@ const boolFunc = new Func(BOOL, [
   }),
 ]);
 
-const bytesFunc = new Func(BYTES, [
-  new FuncOverload([CelScalar.BYTES], CelScalar.BYTES, (x) => x),
-  new FuncOverload([CelScalar.STRING], CelScalar.BYTES, (x) => Buffer.from(x)),
+const bytesFunc = celFunc(BYTES, [
+  celOverload([CelScalar.BYTES], CelScalar.BYTES, (x) => x),
+  celOverload([CelScalar.STRING], CelScalar.BYTES, (x) => Buffer.from(x)),
 ]);
 
-const stringFunc = new Func(STRING, [
-  new FuncOverload([CelScalar.STRING], CelScalar.STRING, (x) => x),
-  new FuncOverload([CelScalar.BOOL], CelScalar.STRING, (x) =>
+const stringFunc = celFunc(STRING, [
+  celOverload([CelScalar.STRING], CelScalar.STRING, (x) => x),
+  celOverload([CelScalar.BOOL], CelScalar.STRING, (x) =>
     x ? "true" : "false",
   ),
-  new FuncOverload([CelScalar.INT], CelScalar.STRING, (x) => x.toString()),
-  new FuncOverload([CelScalar.UINT], CelScalar.STRING, (x) =>
-    x.value.toString(),
-  ),
-  new FuncOverload([CelScalar.DOUBLE], CelScalar.STRING, (x) => x.toString()),
-  new FuncOverload([CelScalar.BYTES], CelScalar.STRING, (x) => {
+  celOverload([CelScalar.INT], CelScalar.STRING, (x) => x.toString()),
+  celOverload([CelScalar.UINT], CelScalar.STRING, (x) => x.value.toString()),
+  celOverload([CelScalar.DOUBLE], CelScalar.STRING, (x) => x.toString()),
+  celOverload([CelScalar.BYTES], CelScalar.STRING, (x) => {
     const coder = new TextDecoder(undefined, { fatal: true });
     try {
       return coder.decode(x);
@@ -162,38 +160,38 @@ const stringFunc = new Func(STRING, [
       throw new Error(`Failed to decode bytes as string: ${e}`);
     }
   }),
-  new FuncOverload([TIMESTAMP_TYPE], CelScalar.STRING, (x) =>
+  celOverload([TIMESTAMP_TYPE], CelScalar.STRING, (x) =>
     toJson(TimestampSchema, x.message),
   ),
-  new FuncOverload([DURATION_TYPE], CelScalar.STRING, (x) =>
+  celOverload([DURATION_TYPE], CelScalar.STRING, (x) =>
     toJson(DurationSchema, x.message),
   ),
 ]);
 
-const timestampFunc = new Func(TIMESTAMP, [
-  new FuncOverload([TIMESTAMP_TYPE], TIMESTAMP_TYPE, (x) => x),
-  new FuncOverload([CelScalar.STRING], TIMESTAMP_TYPE, (x) => {
+const timestampFunc = celFunc(TIMESTAMP, [
+  celOverload([TIMESTAMP_TYPE], TIMESTAMP_TYPE, (x) => x),
+  celOverload([CelScalar.STRING], TIMESTAMP_TYPE, (x) => {
     try {
       return fromJson(TimestampSchema, x);
     } catch (e) {
       throw new Error(`Failed to parse timestamp: ${e}`);
     }
   }),
-  new FuncOverload([CelScalar.INT], TIMESTAMP_TYPE, (x) =>
+  celOverload([CelScalar.INT], TIMESTAMP_TYPE, (x) =>
     timestampFromMs(Number(x)),
   ),
 ]);
 
-const durationFunc = new Func(DURATION, [
-  new FuncOverload([DURATION_TYPE], DURATION_TYPE, (x) => x),
-  new FuncOverload([CelScalar.STRING], DURATION_TYPE, parseDuration),
-  new FuncOverload([CelScalar.INT], DURATION_TYPE, (x) =>
+const durationFunc = celFunc(DURATION, [
+  celOverload([DURATION_TYPE], DURATION_TYPE, (x) => x),
+  celOverload([CelScalar.STRING], DURATION_TYPE, parseDuration),
+  celOverload([CelScalar.INT], DURATION_TYPE, (x) =>
     create(DurationSchema, { seconds: x }),
   ),
 ]);
 
-const typeFunc = new Func(TYPE, [
-  new FuncOverload([CelScalar.DYN], CelScalar.TYPE, (v) => {
+const typeFunc = celFunc(TYPE, [
+  celOverload([CelScalar.DYN], CelScalar.TYPE, (v) => {
     if (isMessage(v)) {
       return objectType(getMsgDesc(v.$typeName));
     }
@@ -201,8 +199,8 @@ const typeFunc = new Func(TYPE, [
   }),
 ]);
 
-const dynFunc = new Func(DYN, [
-  new FuncOverload([CelScalar.DYN], CelScalar.DYN, (x) => x),
+const dynFunc = celFunc(DYN, [
+  celOverload([CelScalar.DYN], CelScalar.DYN, (x) => x),
 ]);
 
 export function addCasts(funcs: FuncRegistry) {

--- a/packages/cel/src/std/logic.ts
+++ b/packages/cel/src/std/logic.ts
@@ -14,8 +14,8 @@
 
 import {
   type FuncRegistry,
-  Func,
-  FuncOverload,
+  celFunc,
+  celOverload,
   type CallDispatch,
 } from "../func.js";
 import * as opc from "../gen/dev/cel/expr/operator_const.js";
@@ -47,8 +47,8 @@ const notStrictlyFalse: CallDispatch = {
   },
 };
 
-const notFunc = new Func(opc.LOGICAL_NOT, [
-  new FuncOverload([CelScalar.BOOL], CelScalar.BOOL, (x) => !x),
+const notFunc = celFunc(opc.LOGICAL_NOT, [
+  celOverload([CelScalar.BOOL], CelScalar.BOOL, (x) => !x),
 ]);
 
 const and: CallDispatch = {
@@ -101,12 +101,12 @@ const or: CallDispatch = {
   },
 };
 
-const eqFunc = new Func(opc.EQUALS, [
-  new FuncOverload([CelScalar.DYN, CelScalar.DYN], CelScalar.BOOL, equals),
+const eqFunc = celFunc(opc.EQUALS, [
+  celOverload([CelScalar.DYN, CelScalar.DYN], CelScalar.BOOL, equals),
 ]);
 
-const neFunc = new Func(opc.NOT_EQUALS, [
-  new FuncOverload(
+const neFunc = celFunc(opc.NOT_EQUALS, [
+  celOverload(
     [CelScalar.DYN, CelScalar.DYN],
     CelScalar.BOOL,
     (lhs, rhs) => !equals(lhs, rhs),
@@ -117,109 +117,103 @@ function ltOp<T>(lhs: T, rhs: T) {
   return lhs < rhs;
 }
 // biome-ignore format: Easier to read it like a table
-const ltFunc = new Func(opc.LESS, [
-  new FuncOverload([CelScalar.BOOL, CelScalar.BOOL], CelScalar.BOOL, ltOp),
-  new FuncOverload([CelScalar.BYTES, CelScalar.BYTES], CelScalar.BOOL, (l, r) => compareBytes(l, r) < 0),
-  new FuncOverload([CelScalar.DOUBLE, CelScalar.DOUBLE], CelScalar.BOOL, ltOp),
-  new FuncOverload([CelScalar.STRING, CelScalar.STRING], CelScalar.BOOL, ltOp),
-  new FuncOverload([CelScalar.INT, CelScalar.INT], CelScalar.BOOL, ltOp),
-  new FuncOverload([CelScalar.INT, CelScalar.UINT], CelScalar.BOOL, (l, r) => l < r.value),
-  new FuncOverload([CelScalar.UINT, CelScalar.INT], CelScalar.BOOL, (l, r) => l.value < r),
-  new FuncOverload([CelScalar.UINT, CelScalar.UINT], CelScalar.BOOL, (l, r) => l.value < r.value),
+const ltFunc = celFunc(opc.LESS, [
+  celOverload([CelScalar.BOOL, CelScalar.BOOL], CelScalar.BOOL, ltOp),
+  celOverload([CelScalar.BYTES, CelScalar.BYTES], CelScalar.BOOL, (l, r) => compareBytes(l, r) < 0),
+  celOverload([CelScalar.DOUBLE, CelScalar.DOUBLE], CelScalar.BOOL, ltOp),
+  celOverload([CelScalar.STRING, CelScalar.STRING], CelScalar.BOOL, ltOp),
+  celOverload([CelScalar.INT, CelScalar.INT], CelScalar.BOOL, ltOp),
+  celOverload([CelScalar.INT, CelScalar.UINT], CelScalar.BOOL, (l, r) => l < r.value),
+  celOverload([CelScalar.UINT, CelScalar.INT], CelScalar.BOOL, (l, r) => l.value < r),
+  celOverload([CelScalar.UINT, CelScalar.UINT], CelScalar.BOOL, (l, r) => l.value < r.value),
   // TODO investigate: ECMAScript relational operators support mixed bigint/number operands, 
   // but removing the coercion to number here fails the conformance test "not_lt_dyn_int_big_lossy_double"
-  new FuncOverload([CelScalar.INT, CelScalar.DOUBLE], CelScalar.BOOL, (l, r) => Number(l) < r),
-  new FuncOverload([CelScalar.DOUBLE, CelScalar.INT], CelScalar.BOOL, (l, r) => l < Number(r)),
-  new FuncOverload([CelScalar.DOUBLE, CelScalar.UINT], CelScalar.BOOL, (l, r) => l < Number(r.value)),
-  new FuncOverload([CelScalar.UINT, CelScalar.DOUBLE], CelScalar.BOOL, (l, r) => Number(l.value) < r),
-  new FuncOverload([DURATION, DURATION], CelScalar.BOOL, (l, r) => compareDuration(l, r) < 0),
-  new FuncOverload([TIMESTAMP, TIMESTAMP], CelScalar.BOOL, (l, r) => compareTimestamp(l, r) < 0),
+  celOverload([CelScalar.INT, CelScalar.DOUBLE], CelScalar.BOOL, (l, r) => Number(l) < r),
+  celOverload([CelScalar.DOUBLE, CelScalar.INT], CelScalar.BOOL, (l, r) => l < Number(r)),
+  celOverload([CelScalar.DOUBLE, CelScalar.UINT], CelScalar.BOOL, (l, r) => l < Number(r.value)),
+  celOverload([CelScalar.UINT, CelScalar.DOUBLE], CelScalar.BOOL, (l, r) => Number(l.value) < r),
+  celOverload([DURATION, DURATION], CelScalar.BOOL, (l, r) => compareDuration(l, r) < 0),
+  celOverload([TIMESTAMP, TIMESTAMP], CelScalar.BOOL, (l, r) => compareTimestamp(l, r) < 0),
 ]);
 
 function lteOp<T>(lhs: T, rhs: T) {
   return lhs <= rhs;
 }
 // biome-ignore format: Easier to read it like a table
-const leFunc = new Func(opc.LESS_EQUALS, [
-  new FuncOverload([CelScalar.BOOL, CelScalar.BOOL], CelScalar.BOOL, lteOp),
-  new FuncOverload([CelScalar.BYTES, CelScalar.BYTES], CelScalar.BOOL, (l, r) => compareBytes(l, r) <= 0),
-  new FuncOverload([CelScalar.DOUBLE, CelScalar.DOUBLE], CelScalar.BOOL, lteOp),
-  new FuncOverload([CelScalar.STRING, CelScalar.STRING], CelScalar.BOOL, lteOp),
-  new FuncOverload([CelScalar.INT, CelScalar.INT], CelScalar.BOOL, lteOp),
-  new FuncOverload([CelScalar.INT, CelScalar.UINT], CelScalar.BOOL, (l, r) => l <= r.value),
-  new FuncOverload([CelScalar.UINT, CelScalar.INT], CelScalar.BOOL, (l, r) => l.value <= r),
-  new FuncOverload([CelScalar.UINT, CelScalar.UINT], CelScalar.BOOL, (l, r) => l.value <= r.value),
-  new FuncOverload([CelScalar.INT, CelScalar.DOUBLE], CelScalar.BOOL, (l, r) => Number(l) <= r),
-  new FuncOverload([CelScalar.DOUBLE, CelScalar.INT], CelScalar.BOOL, (l, r) => l <= Number(r)),
-  new FuncOverload([CelScalar.DOUBLE, CelScalar.UINT], CelScalar.BOOL, (l, r) => l <= Number(r.value)),
-  new FuncOverload([CelScalar.UINT, CelScalar.DOUBLE], CelScalar.BOOL, (l, r) => Number(l.value) <= r),
-  new FuncOverload([DURATION, DURATION], CelScalar.BOOL, (l, r) => compareDuration(l, r) <= 0),
-  new FuncOverload([TIMESTAMP, TIMESTAMP], CelScalar.BOOL, (l, r) => compareTimestamp(l, r) <= 0),
+const leFunc = celFunc(opc.LESS_EQUALS, [
+  celOverload([CelScalar.BOOL, CelScalar.BOOL], CelScalar.BOOL, lteOp),
+  celOverload([CelScalar.BYTES, CelScalar.BYTES], CelScalar.BOOL, (l, r) => compareBytes(l, r) <= 0),
+  celOverload([CelScalar.DOUBLE, CelScalar.DOUBLE], CelScalar.BOOL, lteOp),
+  celOverload([CelScalar.STRING, CelScalar.STRING], CelScalar.BOOL, lteOp),
+  celOverload([CelScalar.INT, CelScalar.INT], CelScalar.BOOL, lteOp),
+  celOverload([CelScalar.INT, CelScalar.UINT], CelScalar.BOOL, (l, r) => l <= r.value),
+  celOverload([CelScalar.UINT, CelScalar.INT], CelScalar.BOOL, (l, r) => l.value <= r),
+  celOverload([CelScalar.UINT, CelScalar.UINT], CelScalar.BOOL, (l, r) => l.value <= r.value),
+  celOverload([CelScalar.INT, CelScalar.DOUBLE], CelScalar.BOOL, (l, r) => Number(l) <= r),
+  celOverload([CelScalar.DOUBLE, CelScalar.INT], CelScalar.BOOL, (l, r) => l <= Number(r)),
+  celOverload([CelScalar.DOUBLE, CelScalar.UINT], CelScalar.BOOL, (l, r) => l <= Number(r.value)),
+  celOverload([CelScalar.UINT, CelScalar.DOUBLE], CelScalar.BOOL, (l, r) => Number(l.value) <= r),
+  celOverload([DURATION, DURATION], CelScalar.BOOL, (l, r) => compareDuration(l, r) <= 0),
+  celOverload([TIMESTAMP, TIMESTAMP], CelScalar.BOOL, (l, r) => compareTimestamp(l, r) <= 0),
 ]);
 
 function gtOp<T>(lhs: T, rhs: T) {
   return lhs > rhs;
 }
 // biome-ignore format: Easier to read it like a table
-const gtFunc = new Func(opc.GREATER, [
-  new FuncOverload([CelScalar.BOOL, CelScalar.BOOL], CelScalar.BOOL, gtOp),
-  new FuncOverload([CelScalar.BYTES, CelScalar.BYTES], CelScalar.BOOL, (l, r) => compareBytes(l, r) > 0),
-  new FuncOverload([CelScalar.DOUBLE, CelScalar.DOUBLE], CelScalar.BOOL, gtOp),
-  new FuncOverload([CelScalar.STRING, CelScalar.STRING], CelScalar.BOOL, gtOp),
-  new FuncOverload([CelScalar.INT, CelScalar.INT], CelScalar.BOOL, gtOp),
-  new FuncOverload([CelScalar.INT, CelScalar.UINT], CelScalar.BOOL, (l, r) => l > r.value),
-  new FuncOverload([CelScalar.UINT, CelScalar.INT], CelScalar.BOOL, (l, r) => l.value > r),
-  new FuncOverload([CelScalar.UINT, CelScalar.UINT], CelScalar.BOOL, (l, r) => l.value > r.value),
-  new FuncOverload([CelScalar.INT, CelScalar.DOUBLE], CelScalar.BOOL, (l, r) => Number(l) > r),
-  new FuncOverload([CelScalar.DOUBLE, CelScalar.INT], CelScalar.BOOL, (l, r) => l > Number(r)),
-  new FuncOverload([CelScalar.DOUBLE, CelScalar.UINT], CelScalar.BOOL, (l, r) => l > Number(r.value)),
-  new FuncOverload([CelScalar.UINT, CelScalar.DOUBLE], CelScalar.BOOL, (l, r) => Number(l.value) > r),
-  new FuncOverload([DURATION, DURATION], CelScalar.BOOL, (l, r) => compareDuration(l, r) > 0),
-  new FuncOverload([TIMESTAMP, TIMESTAMP], CelScalar.BOOL, (l, r) => compareTimestamp(l, r) > 0),
+const gtFunc = celFunc(opc.GREATER, [
+  celOverload([CelScalar.BOOL, CelScalar.BOOL], CelScalar.BOOL, gtOp),
+  celOverload([CelScalar.BYTES, CelScalar.BYTES], CelScalar.BOOL, (l, r) => compareBytes(l, r) > 0),
+  celOverload([CelScalar.DOUBLE, CelScalar.DOUBLE], CelScalar.BOOL, gtOp),
+  celOverload([CelScalar.STRING, CelScalar.STRING], CelScalar.BOOL, gtOp),
+  celOverload([CelScalar.INT, CelScalar.INT], CelScalar.BOOL, gtOp),
+  celOverload([CelScalar.INT, CelScalar.UINT], CelScalar.BOOL, (l, r) => l > r.value),
+  celOverload([CelScalar.UINT, CelScalar.INT], CelScalar.BOOL, (l, r) => l.value > r),
+  celOverload([CelScalar.UINT, CelScalar.UINT], CelScalar.BOOL, (l, r) => l.value > r.value),
+  celOverload([CelScalar.INT, CelScalar.DOUBLE], CelScalar.BOOL, (l, r) => Number(l) > r),
+  celOverload([CelScalar.DOUBLE, CelScalar.INT], CelScalar.BOOL, (l, r) => l > Number(r)),
+  celOverload([CelScalar.DOUBLE, CelScalar.UINT], CelScalar.BOOL, (l, r) => l > Number(r.value)),
+  celOverload([CelScalar.UINT, CelScalar.DOUBLE], CelScalar.BOOL, (l, r) => Number(l.value) > r),
+  celOverload([DURATION, DURATION], CelScalar.BOOL, (l, r) => compareDuration(l, r) > 0),
+  celOverload([TIMESTAMP, TIMESTAMP], CelScalar.BOOL, (l, r) => compareTimestamp(l, r) > 0),
 ]);
 
 function gteOp<T>(lhs: T, rhs: T) {
   return lhs >= rhs;
 }
 // biome-ignore format: Easier to read it like a table
-const geFunc = new Func(opc.GREATER_EQUALS, [
-  new FuncOverload([CelScalar.BOOL, CelScalar.BOOL], CelScalar.BOOL, gteOp),
-  new FuncOverload([CelScalar.BYTES, CelScalar.BYTES], CelScalar.BOOL, (l, r) => compareBytes(l, r) >= 0),
-  new FuncOverload([CelScalar.DOUBLE, CelScalar.DOUBLE], CelScalar.BOOL, gteOp),
-  new FuncOverload([CelScalar.STRING, CelScalar.STRING], CelScalar.BOOL, gteOp),
-  new FuncOverload([CelScalar.INT, CelScalar.INT], CelScalar.BOOL, gteOp),
-  new FuncOverload([CelScalar.INT, CelScalar.UINT], CelScalar.BOOL, (l, r) => l >= r.value),
-  new FuncOverload([CelScalar.UINT, CelScalar.INT], CelScalar.BOOL, (l, r) => l.value >= r),
-  new FuncOverload([CelScalar.UINT, CelScalar.UINT], CelScalar.BOOL, (l, r) => l.value >= r.value),
-  new FuncOverload([CelScalar.INT, CelScalar.DOUBLE], CelScalar.BOOL, (l, r) => Number(l) >= r),
-  new FuncOverload([CelScalar.DOUBLE, CelScalar.INT], CelScalar.BOOL, (l, r) => l >= Number(r)),
-  new FuncOverload([CelScalar.DOUBLE, CelScalar.UINT], CelScalar.BOOL, (l, r) => l >= Number(r.value)),
-  new FuncOverload([CelScalar.UINT, CelScalar.DOUBLE], CelScalar.BOOL, (l, r) => Number(l.value) >= r),
-  new FuncOverload([DURATION, DURATION], CelScalar.BOOL, (l, r) => compareDuration(l, r) >= 0),
-  new FuncOverload([TIMESTAMP, TIMESTAMP], CelScalar.BOOL, (l, r) => compareTimestamp(l, r) >= 0),
+const geFunc = celFunc(opc.GREATER_EQUALS, [
+  celOverload([CelScalar.BOOL, CelScalar.BOOL], CelScalar.BOOL, gteOp),
+  celOverload([CelScalar.BYTES, CelScalar.BYTES], CelScalar.BOOL, (l, r) => compareBytes(l, r) >= 0),
+  celOverload([CelScalar.DOUBLE, CelScalar.DOUBLE], CelScalar.BOOL, gteOp),
+  celOverload([CelScalar.STRING, CelScalar.STRING], CelScalar.BOOL, gteOp),
+  celOverload([CelScalar.INT, CelScalar.INT], CelScalar.BOOL, gteOp),
+  celOverload([CelScalar.INT, CelScalar.UINT], CelScalar.BOOL, (l, r) => l >= r.value),
+  celOverload([CelScalar.UINT, CelScalar.INT], CelScalar.BOOL, (l, r) => l.value >= r),
+  celOverload([CelScalar.UINT, CelScalar.UINT], CelScalar.BOOL, (l, r) => l.value >= r.value),
+  celOverload([CelScalar.INT, CelScalar.DOUBLE], CelScalar.BOOL, (l, r) => Number(l) >= r),
+  celOverload([CelScalar.DOUBLE, CelScalar.INT], CelScalar.BOOL, (l, r) => l >= Number(r)),
+  celOverload([CelScalar.DOUBLE, CelScalar.UINT], CelScalar.BOOL, (l, r) => l >= Number(r.value)),
+  celOverload([CelScalar.UINT, CelScalar.DOUBLE], CelScalar.BOOL, (l, r) => Number(l.value) >= r),
+  celOverload([DURATION, DURATION], CelScalar.BOOL, (l, r) => compareDuration(l, r) >= 0),
+  celOverload([TIMESTAMP, TIMESTAMP], CelScalar.BOOL, (l, r) => compareTimestamp(l, r) >= 0),
 ]);
 
-const containsFunc = new Func(olc.CONTAINS, [
-  new FuncOverload(
-    [CelScalar.STRING, CelScalar.STRING],
-    CelScalar.BOOL,
-    (x, y) => x.includes(y),
+const containsFunc = celFunc(olc.CONTAINS, [
+  celOverload([CelScalar.STRING, CelScalar.STRING], CelScalar.BOOL, (x, y) =>
+    x.includes(y),
   ),
 ]);
 
-const endsWithFunc = new Func(olc.ENDS_WITH, [
-  new FuncOverload(
-    [CelScalar.STRING, CelScalar.STRING],
-    CelScalar.BOOL,
-    (x, y) => x.endsWith(y),
+const endsWithFunc = celFunc(olc.ENDS_WITH, [
+  celOverload([CelScalar.STRING, CelScalar.STRING], CelScalar.BOOL, (x, y) =>
+    x.endsWith(y),
   ),
 ]);
 
-const startsWithFunc = new Func(olc.STARTS_WITH, [
-  new FuncOverload(
-    [CelScalar.STRING, CelScalar.STRING],
-    CelScalar.BOOL,
-    (x, y) => x.startsWith(y),
+const startsWithFunc = celFunc(olc.STARTS_WITH, [
+  celOverload([CelScalar.STRING, CelScalar.STRING], CelScalar.BOOL, (x, y) =>
+    x.startsWith(y),
   ),
 ]);
 
@@ -279,45 +273,35 @@ export function matchesString(x: string, y: string): boolean {
   return re.test(x);
 }
 
-const matchesFunc = new Func(olc.MATCHES, [
-  new FuncOverload(
+const matchesFunc = celFunc(olc.MATCHES, [
+  celOverload(
     [CelScalar.STRING, CelScalar.STRING],
     CelScalar.BOOL,
     matchesString,
   ),
 ]);
 
-const sizeFunc = new Func(olc.SIZE, [
-  new FuncOverload([CelScalar.STRING], CelScalar.INT, (x) => {
+const sizeFunc = celFunc(olc.SIZE, [
+  celOverload([CelScalar.STRING], CelScalar.INT, (x) => {
     let size = 0;
     for (const _ of x) {
       size++;
     }
     return BigInt(size);
   }),
-  new FuncOverload([CelScalar.BYTES], CelScalar.INT, (x) => BigInt(x.length)),
-  new FuncOverload([listType(CelScalar.DYN)], CelScalar.INT, (x) =>
+  celOverload([CelScalar.BYTES], CelScalar.INT, (x) => BigInt(x.length)),
+  celOverload([listType(CelScalar.DYN)], CelScalar.INT, (x) => BigInt(x.size)),
+  celOverload([mapType(CelScalar.INT, CelScalar.DYN)], CelScalar.INT, (x) =>
     BigInt(x.size),
   ),
-  new FuncOverload(
-    [mapType(CelScalar.INT, CelScalar.DYN)],
-    CelScalar.INT,
-    (x) => BigInt(x.size),
+  celOverload([mapType(CelScalar.UINT, CelScalar.DYN)], CelScalar.INT, (x) =>
+    BigInt(x.size),
   ),
-  new FuncOverload(
-    [mapType(CelScalar.UINT, CelScalar.DYN)],
-    CelScalar.INT,
-    (x) => BigInt(x.size),
+  celOverload([mapType(CelScalar.BOOL, CelScalar.DYN)], CelScalar.INT, (x) =>
+    BigInt(x.size),
   ),
-  new FuncOverload(
-    [mapType(CelScalar.BOOL, CelScalar.DYN)],
-    CelScalar.INT,
-    (x) => BigInt(x.size),
-  ),
-  new FuncOverload(
-    [mapType(CelScalar.STRING, CelScalar.DYN)],
-    CelScalar.INT,
-    (x) => BigInt(x.size),
+  celOverload([mapType(CelScalar.STRING, CelScalar.DYN)], CelScalar.INT, (x) =>
+    BigInt(x.size),
   ),
 ]);
 
@@ -325,8 +309,8 @@ function mapInOp(x: CelValue, y: CelMap) {
   return y.has(x as string);
 }
 
-const inFunc = new Func(opc.IN, [
-  new FuncOverload(
+const inFunc = celFunc(opc.IN, [
+  celOverload(
     [CelScalar.DYN, listType(CelScalar.DYN)],
     CelScalar.BOOL,
     (x, y) => {
@@ -338,22 +322,22 @@ const inFunc = new Func(opc.IN, [
       return false;
     },
   ),
-  new FuncOverload(
+  celOverload(
     [CelScalar.DYN, mapType(CelScalar.STRING, CelScalar.DYN)],
     CelScalar.BOOL,
     mapInOp,
   ),
-  new FuncOverload(
+  celOverload(
     [CelScalar.DYN, mapType(CelScalar.INT, CelScalar.DYN)],
     CelScalar.BOOL,
     mapInOp,
   ),
-  new FuncOverload(
+  celOverload(
     [CelScalar.DYN, mapType(CelScalar.UINT, CelScalar.DYN)],
     CelScalar.BOOL,
     mapInOp,
   ),
-  new FuncOverload(
+  celOverload(
     [CelScalar.DYN, mapType(CelScalar.BOOL, CelScalar.DYN)],
     CelScalar.BOOL,
     mapInOp,

--- a/packages/cel/src/std/time.ts
+++ b/packages/cel/src/std/time.ts
@@ -15,7 +15,7 @@
 import { timestampDate, TimestampSchema } from "@bufbuild/protobuf/wkt";
 
 import { CelScalar, TIMESTAMP, DURATION, type CelValue } from "../type.js";
-import { FuncOverload, type FuncRegistry, Func } from "../func.js";
+import { type FuncRegistry, celOverload, celFunc } from "../func.js";
 import * as olc from "../gen/dev/cel/expr/overload_const.js";
 import { toJson } from "@bufbuild/protobuf";
 
@@ -157,146 +157,138 @@ function makeTimeOp(t: TimeFunc) {
 
 type TimeFunc = (date: Date) => number;
 
-const getFullYearFunc = new Func(olc.TIME_GET_FULL_YEAR, [
-  new FuncOverload(
+const getFullYearFunc = celFunc(olc.TIME_GET_FULL_YEAR, [
+  celOverload(
     [TIMESTAMP],
     CelScalar.INT,
     makeTimeOp((d) => d.getFullYear()),
   ),
-  new FuncOverload(
+  celOverload(
     [TIMESTAMP, CelScalar.STRING],
     CelScalar.INT,
     makeTimeOp((d) => d.getFullYear()),
   ),
 ]);
 
-const getMonthFunc = new Func(olc.TIME_GET_MONTH, [
-  new FuncOverload(
+const getMonthFunc = celFunc(olc.TIME_GET_MONTH, [
+  celOverload(
     [TIMESTAMP],
     CelScalar.INT,
     makeTimeOp((d) => d.getMonth()),
   ),
-  new FuncOverload(
+  celOverload(
     [TIMESTAMP, CelScalar.STRING],
     CelScalar.INT,
     makeTimeOp((d) => d.getMonth()),
   ),
 ]);
 
-const getDateFunc = new Func(olc.TIME_GET_DATE, [
-  new FuncOverload(
+const getDateFunc = celFunc(olc.TIME_GET_DATE, [
+  celOverload(
     [TIMESTAMP],
     CelScalar.INT,
     makeTimeOp((d) => d.getDate()),
   ),
-  new FuncOverload(
+  celOverload(
     [TIMESTAMP, CelScalar.STRING],
     CelScalar.INT,
     makeTimeOp((d) => d.getDate()),
   ),
 ]);
 
-const getDayOfMonthFunc = new Func(olc.TIME_GET_DAY_OF_MONTH, [
-  new FuncOverload(
+const getDayOfMonthFunc = celFunc(olc.TIME_GET_DAY_OF_MONTH, [
+  celOverload(
     [TIMESTAMP],
     CelScalar.INT,
     makeTimeOp((d) => d.getDate() - 1),
   ),
-  new FuncOverload(
+  celOverload(
     [TIMESTAMP, CelScalar.STRING],
     CelScalar.INT,
     makeTimeOp((d) => d.getDate() - 1),
   ),
 ]);
 
-const getDayOfWeekFunc = new Func(olc.TIME_GET_DAY_OF_WEEK, [
-  new FuncOverload(
+const getDayOfWeekFunc = celFunc(olc.TIME_GET_DAY_OF_WEEK, [
+  celOverload(
     [TIMESTAMP],
     CelScalar.INT,
     makeTimeOp((d) => d.getDay()),
   ),
-  new FuncOverload(
+  celOverload(
     [TIMESTAMP, CelScalar.STRING],
     CelScalar.INT,
     makeTimeOp((d) => d.getDay()),
   ),
 ]);
 
-const getDayOfYearFunc = new Func(olc.TIME_GET_DAY_OF_YEAR, [
-  new FuncOverload(
+const getDayOfYearFunc = celFunc(olc.TIME_GET_DAY_OF_YEAR, [
+  celOverload(
     [TIMESTAMP],
     CelScalar.INT,
     makeTimeOp((d) => getDayOfYear(d)),
   ),
-  new FuncOverload(
+  celOverload(
     [TIMESTAMP, CelScalar.STRING],
     CelScalar.INT,
     makeTimeOp((d) => getDayOfYear(d)),
   ),
 ]);
 
-const getSecondsFunc = new Func(olc.TIME_GET_SECONDS, [
-  new FuncOverload(
+const getSecondsFunc = celFunc(olc.TIME_GET_SECONDS, [
+  celOverload(
     [TIMESTAMP],
     CelScalar.INT,
     makeTimeOp((d) => d.getSeconds()),
   ),
-  new FuncOverload(
+  celOverload(
     [TIMESTAMP, CelScalar.STRING],
     CelScalar.INT,
     makeTimeOp((d) => d.getSeconds()),
   ),
-  new FuncOverload([DURATION], CelScalar.INT, (dur) => dur.message.seconds),
+  celOverload([DURATION], CelScalar.INT, (dur) => dur.message.seconds),
 ]);
 
-const getMinutesFunc = new Func(olc.TIME_GET_MINUTES, [
-  new FuncOverload(
+const getMinutesFunc = celFunc(olc.TIME_GET_MINUTES, [
+  celOverload(
     [TIMESTAMP],
     CelScalar.INT,
     makeTimeOp((d) => d.getMinutes()),
   ),
-  new FuncOverload(
+  celOverload(
     [TIMESTAMP, CelScalar.STRING],
     CelScalar.INT,
     makeTimeOp((d) => d.getMinutes()),
   ),
-  new FuncOverload(
-    [DURATION],
-    CelScalar.INT,
-    (dur) => dur.message.seconds / 60n,
-  ),
+  celOverload([DURATION], CelScalar.INT, (dur) => dur.message.seconds / 60n),
 ]);
 
-const getHoursFunc = new Func(olc.TIME_GET_HOURS, [
-  new FuncOverload(
+const getHoursFunc = celFunc(olc.TIME_GET_HOURS, [
+  celOverload(
     [TIMESTAMP],
     CelScalar.INT,
     makeTimeOp((d) => d.getHours()),
   ),
-  new FuncOverload(
+  celOverload(
     [TIMESTAMP, CelScalar.STRING],
     CelScalar.INT,
     makeTimeOp((d) => d.getHours()),
   ),
-  new FuncOverload(
-    [DURATION],
-    CelScalar.INT,
-    (dur) => dur.message.seconds / 3600n,
-  ),
+  celOverload([DURATION], CelScalar.INT, (dur) => dur.message.seconds / 3600n),
 ]);
 
-const getMillisecondsFunc = new Func(olc.TIME_GET_MILLISECONDS, [
-  new FuncOverload(
+const getMillisecondsFunc = celFunc(olc.TIME_GET_MILLISECONDS, [
+  celOverload(
     [TIMESTAMP],
     CelScalar.INT,
     makeTimeOp((d) => d.getMilliseconds()),
   ),
-  new FuncOverload(
+  celOverload(
     [TIMESTAMP, CelScalar.STRING],
     CelScalar.INT,
     makeTimeOp((d) => d.getMilliseconds()),
   ),
-  new FuncOverload(
+  celOverload(
     [DURATION],
     CelScalar.INT,
     (dur) => BigInt(dur.message.nanos) / 1000000n,

--- a/packages/example/src/example.ts
+++ b/packages/example/src/example.ts
@@ -15,8 +15,8 @@
 import {
   celEnv,
   CelScalar,
-  Func,
-  FuncOverload,
+  celFunc,
+  celOverload,
   parse,
   plan,
   run,
@@ -50,8 +50,8 @@ console.log(result); // true
 
 // Provide a new function:
 
-const similar = new Func("similar", [
-  new FuncOverload(
+const similar = celFunc("similar", [
+  celOverload(
     // Parameter types.
     [CelScalar.STRING, CelScalar.STRING],
     // Return type.


### PR DESCRIPTION
Rename function types to have the `cel` prefix like the rest of the types.