### PR TITLE
Update parser to support previously reserved keywords

### DIFF
--- a/packages/cel/src/cel.peggy
+++ b/packages/cel/src/cel.peggy
@@ -146,10 +146,10 @@ MemberTail
   = (S @Access)*
 
 Access
-  = "." S field:Identifier S ![(]
+  = "." S field:Selector S ![(]
     { return ((prevExpr: Expr) => builder.newSelectExpr(offset(), prevExpr, field)) }
-  / "." S identifier:Identifier S "(" args:ExprList ")"
-    { return ((prevExpr: Expr) => builder.newMemberCallExpr(offset(), prevExpr, identifier, args)) }
+  / "." S func:Selector S "(" args:ExprList ")"
+    { return ((prevExpr: Expr) => builder.newMemberCallExpr(offset(), prevExpr, func, args)) }
   / "[" index:Expr "]"
     { return ((prevExpr: Expr) => builder.newCallExpr(offset(), "_[_]", [prevExpr, index])) }
 
@@ -157,9 +157,9 @@ Primary
   = Literal
   / "."? S identifier:Identifier S "(" args:ExprList ")"
     { return builder.newCallExpr(offset(), identifier, args) }
-  / dot:"."? S name:Identifier|1.., S "." S| S "{" entries:FieldInits (",")? S "}"
+  / dot:"."? S name:Selector|1.., S "." S| S "{" entries:FieldInits (",")? S "}"
     { return builder.newStructExpr(offset(), entries, (dot !== null ? dot : '') + name.join('.')) }
-  / "."? S name:Identifier
+  / "."? S name:Selector
     { return builder.newIdentExpr(offset(), name) }
   / "(" @Expr ")"
   / elements:("[" @ExprList (",")? S "]")
@@ -172,7 +172,7 @@ ExprList
 
 FieldInits
   = (
-      S key:Identifier $(S ":") value:Expr
+      S key:Selector $(S ":") value:Expr
       { return builder.newStructEntry(offset(), key, value) }
     )|0.., ","|
 
@@ -194,6 +194,16 @@ Identifier "identifier"
       }
 
       return id;
+    }
+
+Selector "selector"
+  = selector:$([_a-zA-Z][_a-zA-Z0-9]*)
+    {
+      if (["true", "false", "null", "in"].includes(selector)) {
+        error("reserved keyword");
+      }
+
+      return selector;
     }
 
 Literal

--- a/packages/cel/src/parser.ts
+++ b/packages/cel/src/parser.ts
@@ -451,79 +451,83 @@ const item388: runtime.Expectation = {
   type: "literal",
   value: ")",
 };
-const item402: runtime.Expectation = {
+const item408: runtime.Expectation = {
+  type: "other",
+  value: "selector",
+};
+const item413: runtime.Expectation = {
   type: "literal",
   value: "{",
 };
-const item412: runtime.Expectation = {
+const item423: runtime.Expectation = {
   type: "literal",
   value: ":",
 };
-const item421: runtime.Expectation = {
+const item432: runtime.Expectation = {
   type: "literal",
   value: "}",
 };
-const item440: runtime.Expectation = {
+const item451: runtime.Expectation = {
   type: "literal",
   value: "[",
 };
-const item445: runtime.Expectation = {
+const item456: runtime.Expectation = {
   type: "literal",
   value: "]",
 };
-const item512: runtime.Expectation = {
+const item524: runtime.Expectation = {
   type: "literal",
   value: "!",
 };
-const item528: runtime.Expectation = {
+const item540: runtime.Expectation = {
   type: "class",
   value: "/^[*\\/%]/g",
 };
-const item565: runtime.Expectation = {
+const item577: runtime.Expectation = {
   type: "literal",
   value: "<=",
 };
-const item567: runtime.Expectation = {
+const item579: runtime.Expectation = {
   type: "literal",
   value: "<",
 };
-const item569: runtime.Expectation = {
+const item581: runtime.Expectation = {
   type: "literal",
   value: ">=",
 };
-const item571: runtime.Expectation = {
+const item583: runtime.Expectation = {
   type: "literal",
   value: ">",
 };
-const item573: runtime.Expectation = {
+const item585: runtime.Expectation = {
   type: "literal",
   value: "==",
 };
-const item575: runtime.Expectation = {
+const item587: runtime.Expectation = {
   type: "literal",
   value: "!=",
 };
-const item579: runtime.Expectation = {
+const item591: runtime.Expectation = {
   type: "literal",
   value: "in",
 };
-const item581: runtime.Expectation = {
+const item593: runtime.Expectation = {
   type: "other",
   value: "relational operator",
 };
-const item589: runtime.Expectation = {
+const item601: runtime.Expectation = {
   type: "literal",
   value: "&&",
 };
-const item595: runtime.Expectation = {
+const item607: runtime.Expectation = {
   type: "literal",
   value: "||",
 };
-const item604: runtime.Expectation = {
+const item616: runtime.Expectation = {
   type: "literal",
   value: "?",
 };
-const item612: runtime.Expectation = {
+const item624: runtime.Expectation = {
   type: "end",
   value: "end of input",
 };
@@ -760,7 +764,20 @@ export function parse(
   ): Expr {
     return builder.newCallExpr(offset(), identifier, args);
   }
-  function item416(
+  function item407(
+    location: () => runtime.LocationRange,
+    range: () => runtime.Range,
+    text: () => string,
+    offset: () => number,
+    error: (s: string, l?: runtime.LocationRange) => void,
+    selector: string,
+  ): string {
+    if (["true", "false", "null", "in"].includes(selector)) {
+      error("reserved keyword");
+    }
+    return selector;
+  }
+  function item427(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -771,7 +788,7 @@ export function parse(
   ): Expr_CreateStruct_Entry {
     return builder.newStructEntry(offset(), key, value);
   }
-  function item423(
+  function item434(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -787,7 +804,7 @@ export function parse(
       (dot !== null ? dot : "") + name.join("."),
     );
   }
-  function item430(
+  function item441(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -797,7 +814,7 @@ export function parse(
   ): Expr {
     return builder.newIdentExpr(offset(), name);
   }
-  function item447(
+  function item458(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -807,7 +824,7 @@ export function parse(
   ): Expr {
     return builder.newListExpr(offset(), elements);
   }
-  function item461(
+  function item472(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -818,7 +835,7 @@ export function parse(
   ): Expr_CreateStruct_Entry {
     return builder.newMapEntry(offset(), key, value);
   }
-  function item470(
+  function item481(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -828,7 +845,7 @@ export function parse(
   ): Expr {
     return builder.newStructExpr(offset(), entries);
   }
-  function item486(
+  function item497(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -838,19 +855,19 @@ export function parse(
   ): (prevExpr: Expr) => Expr {
     return (prevExpr: Expr) => builder.newSelectExpr(offset(), prevExpr, field);
   }
-  function item494(
+  function item506(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
     offset: () => number,
     error: (s: string, l?: runtime.LocationRange) => void,
-    identifier: string,
+    func: string,
     args: Expr[],
   ): (prevExpr: Expr) => Expr {
     return (prevExpr: Expr) =>
-      builder.newMemberCallExpr(offset(), prevExpr, identifier, args);
+      builder.newMemberCallExpr(offset(), prevExpr, func, args);
   }
-  function item501(
+  function item513(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -861,7 +878,7 @@ export function parse(
     return (prevExpr: Expr) =>
       builder.newCallExpr(offset(), "_[_]", [prevExpr, index]);
   }
-  function item504(
+  function item516(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -877,7 +894,7 @@ export function parse(
       return tail.reduce((expr, op) => op(expr), primary);
     }
   }
-  function item517(
+  function item529(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -898,7 +915,7 @@ export function parse(
       return builder.newCallExpr(offset(), `${ops[0]}_`, [expr]);
     }
   }
-  function item529(
+  function item541(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -908,7 +925,7 @@ export function parse(
   ): string {
     return `_${o}_`;
   }
-  function item532(
+  function item544(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -920,7 +937,7 @@ export function parse(
     return (prevExpr: Expr) =>
       builder.newCallExpr(offset(), operator, [prevExpr, nextExpr]);
   }
-  function item534(
+  function item546(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -936,7 +953,7 @@ export function parse(
       return tail.reduce((expr, op) => op(expr), unary);
     }
   }
-  function item545(
+  function item557(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -946,7 +963,7 @@ export function parse(
   ): string {
     return `_${o}_`;
   }
-  function item547(
+  function item559(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -958,7 +975,7 @@ export function parse(
     return (prevExpr: Expr) =>
       builder.newCallExpr(offset(), operator, [prevExpr, nextExpr]);
   }
-  function item549(
+  function item561(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -974,7 +991,7 @@ export function parse(
       return tail.reduce((expr, op) => op(expr), multiplication);
     }
   }
-  function item576(
+  function item588(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -984,7 +1001,7 @@ export function parse(
   ): string {
     return `_${operator}_`;
   }
-  function item580(
+  function item592(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -993,7 +1010,7 @@ export function parse(
   ): string {
     return "@in";
   }
-  function item583(
+  function item595(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -1005,7 +1022,7 @@ export function parse(
     return (prevExpr: Expr) =>
       builder.newCallExpr(offset(), operator, [prevExpr, nextExpr]);
   }
-  function item585(
+  function item597(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -1021,7 +1038,7 @@ export function parse(
       return tail.reduce((expr, op) => op(expr), addition);
     }
   }
-  function item591(
+  function item603(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -1036,7 +1053,7 @@ export function parse(
       return builder.newCallExpr(offset(), "_&&_", relation);
     }
   }
-  function item597(
+  function item609(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -1051,7 +1068,7 @@ export function parse(
       return builder.newCallExpr(offset(), "_||_", and);
     }
   }
-  function item609(
+  function item621(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -1063,7 +1080,7 @@ export function parse(
     /* : [Expr, Expr] */
     return [t, f];
   }
-  function item611(
+  function item623(
     location: () => runtime.LocationRange,
     range: () => runtime.Range,
     text: () => string,
@@ -1090,7 +1107,7 @@ export function parse(
           remainder: result.remainder,
           failedExpectations: [
             {
-              expectation: item612,
+              expectation: item624,
               remainder: result.remainder,
             },
           ],
@@ -1115,7 +1132,7 @@ export function parse(
     if (result.success === true) {
       return {
         success: true,
-        value: item611(
+        value: item623(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -1183,7 +1200,7 @@ export function parse(
     } else {
       remainder = remainder.slice(result1[0].length);
     }
-    const result2 = item599(remainder);
+    const result2 = item611(remainder);
     failedExpectations.push(...result2.failedExpectations);
     if (result2.success === false) {
       return {
@@ -1215,7 +1232,7 @@ export function parse(
     if (result.success === true) {
       return {
         success: true,
-        value: item597(
+        value: item609(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -1251,7 +1268,7 @@ export function parse(
     do {
       let r = remainder;
       if (values.length > 0) {
-        result = item592(r);
+        result = item604(r);
         if (result.success === false) {
           break;
         }
@@ -1292,7 +1309,7 @@ export function parse(
     if (result.success === true) {
       return {
         success: true,
-        value: item591(
+        value: item603(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -1328,7 +1345,7 @@ export function parse(
     do {
       let r = remainder;
       if (values.length > 0) {
-        result = item586(r);
+        result = item598(r);
         if (result.success === false) {
           break;
         }
@@ -1369,7 +1386,7 @@ export function parse(
     if (result.success === true) {
       return {
         success: true,
-        value: item585(
+        value: item597(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -1416,7 +1433,7 @@ export function parse(
     } else {
       remainder = result0.remainder;
     }
-    const result1 = item551(remainder);
+    const result1 = item563(remainder);
     failedExpectations.push(...result1.failedExpectations);
     if (result1.success === false) {
       return {
@@ -1448,7 +1465,7 @@ export function parse(
     if (result.success === true) {
       return {
         success: true,
-        value: item549(
+        value: item561(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -1495,7 +1512,7 @@ export function parse(
     } else {
       remainder = result0.remainder;
     }
-    const result1 = item536(remainder);
+    const result1 = item548(remainder);
     failedExpectations.push(...result1.failedExpectations);
     if (result1.success === false) {
       return {
@@ -1527,7 +1544,7 @@ export function parse(
     if (result.success === true) {
       return {
         success: true,
-        value: item534(
+        value: item546(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -1574,7 +1591,7 @@ export function parse(
     } else {
       remainder = result0.remainder;
     }
-    const result1 = item519(remainder);
+    const result1 = item531(remainder);
     failedExpectations.push(...result1.failedExpectations);
     if (result1.success === false) {
       return {
@@ -1605,7 +1622,7 @@ export function parse(
   // }
   // }
   function item28(text: string): runtime.Success<Expr> | runtime.Failure {
-    const choices = [item30, item505];
+    const choices = [item30, item517];
     let failedExpectations: runtime.FailedExpectation[] = [];
     for (
       let func = choices.shift();
@@ -1643,7 +1660,7 @@ export function parse(
     if (result.success === true) {
       return {
         success: true,
-        value: item504(
+        value: item516(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -1710,7 +1727,7 @@ export function parse(
     } else {
       remainder = result1.remainder;
     }
-    const result2 = item473(remainder);
+    const result2 = item484(remainder);
     failedExpectations.push(...result2.failedExpectations);
     if (result2.success === false) {
       return {
@@ -2073,9 +2090,9 @@ export function parse(
   // Literal
   // / "."? S identifier:Identifier S "(" args:ExprList ")"
   // { return builder.newCallExpr(offset(), identifier, args) }
-  // / dot:"."? S name:Identifier|1.., S "." S| S "{" entries:FieldInits (",")? S "}"
+  // / dot:"."? S name:Selector|1.., S "." S| S "{" entries:FieldInits (",")? S "}"
   // { return builder.newStructExpr(offset(), entries, (dot !== null ? dot : '') + name.join('.')) }
-  // / "."? S name:Identifier
+  // / "."? S name:Selector
   // { return builder.newIdentExpr(offset(), name) }
   // / "(" @Expr ")"
   // / elements:("[" @ExprList (",")? S "]")
@@ -2087,10 +2104,10 @@ export function parse(
       item65,
       item362,
       item391,
-      item424,
-      item431,
-      item436,
-      item448,
+      item435,
+      item442,
+      item447,
+      item459,
     ];
     let failedExpectations: runtime.FailedExpectation[] = [];
     for (
@@ -5188,14 +5205,14 @@ export function parse(
       };
     }
   }
-  // dot:"."? S name:Identifier|1.., S "." S| S "{" entries:FieldInits (",")? S "}"
+  // dot:"."? S name:Selector|1.., S "." S| S "{" entries:FieldInits (",")? S "}"
   // { return builder.newStructExpr(offset(), entries, (dot !== null ? dot : '') + name.join('.')) }
   function item391(text: string): runtime.Success<Expr> | runtime.Failure {
     const result = item392(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item423(
+        value: item434(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -5224,7 +5241,7 @@ export function parse(
       return result;
     }
   }
-  // dot:"."? S name:Identifier|1.., S "." S| S "{" entries:FieldInits (",")? S "}"
+  // dot:"."? S name:Selector|1.., S "." S| S "{" entries:FieldInits (",")? S "}"
   function item392(
     text: string,
   ):
@@ -5300,7 +5317,7 @@ export function parse(
     }
     const result4 = remainder.match(/^\{/g);
     failedExpectations.push({
-      expectation: item402,
+      expectation: item413,
       remainder: remainder,
     });
     if (result4?.length !== 1) {
@@ -5312,7 +5329,7 @@ export function parse(
     } else {
       remainder = remainder.slice(result4[0].length);
     }
-    const result5 = item405(remainder);
+    const result5 = item416(remainder);
     failedExpectations.push(...result5.failedExpectations);
     if (result5.success === false) {
       return {
@@ -5361,7 +5378,7 @@ export function parse(
     }
     const result8 = remainder.match(/^\}/g);
     failedExpectations.push({
-      expectation: item421,
+      expectation: item432,
       remainder: remainder,
     });
     if (result8?.length !== 1) {
@@ -5418,7 +5435,7 @@ export function parse(
       };
     }
   }
-  // Identifier|1.., S "." S|
+  // Selector|1.., S "." S|
   function item397(text: string): runtime.Success<string[]> | runtime.Failure {
     const values: Array<string> = [];
     const failedExpectations: runtime.FailedExpectation[] = [];
@@ -5427,13 +5444,13 @@ export function parse(
     do {
       let r = remainder;
       if (values.length > 0) {
-        result = item398(r);
+        result = item409(r);
         if (result.success === false) {
           break;
         }
         r = result.remainder;
       }
-      result = item368(r);
+      result = item399(r);
       failedExpectations.push(...result.failedExpectations);
       if (result.success === false) {
         break;
@@ -5454,8 +5471,98 @@ export function parse(
       return { success: true, value: values, remainder, failedExpectations };
     }
   }
+  // Selector "selector"
+  // = selector:$([_a-zA-Z][_a-zA-Z0-9]*)
+  // {
+  // if (["true", "false", "null", "in"].includes(selector)) {
+  // error("reserved keyword");
+  // }
+  //
+  // return selector;
+  // }
+  //
+  function item399(text: string): runtime.Success<string> | runtime.Failure {
+    const result = item400(text);
+    if (result.success === true) {
+      return result;
+    } else {
+      return {
+        success: false,
+        remainder: result.remainder,
+        failedExpectations: [
+          {
+            expectation: item408,
+            remainder: result.remainder,
+          },
+        ],
+      };
+    }
+  }
+  // selector:$([_a-zA-Z][_a-zA-Z0-9]*)
+  // {
+  // if (["true", "false", "null", "in"].includes(selector)) {
+  // error("reserved keyword");
+  // }
+  //
+  // return selector;
+  // }
+  function item400(text: string): runtime.Success<string> | runtime.Failure {
+    const result = item402(text);
+    if (result.success === true) {
+      return {
+        success: true,
+        value: item407(
+          () =>
+            runtime.getLocation(parse$source, input, text, result.remainder),
+          () => runtime.getRange(parse$source, input, text, result.remainder),
+          () => runtime.getText(text, result.remainder),
+          () => input.length - text.length,
+          (
+            message: string,
+            location = runtime.getLocation(
+              parse$source,
+              input,
+              text,
+              result.remainder,
+            ),
+            name?: string,
+          ) => {
+            throw new ParseError(message, location, name);
+          },
+          result.value,
+        ),
+        remainder: result.remainder,
+        failedExpectations: [],
+      };
+    } else {
+      return result;
+    }
+  }
+  // $([_a-zA-Z][_a-zA-Z0-9]*)
+  function item402(text: string): runtime.Success<string> | runtime.Failure {
+    const matches = text.match(/^[_a-zA-Z]([_a-zA-Z0-9])*/g);
+    if (matches?.length === 1) {
+      return {
+        success: true,
+        value: matches[0],
+        remainder: text.slice(matches[0].length),
+        failedExpectations: [],
+      };
+    } else {
+      return {
+        success: false,
+        remainder: text,
+        failedExpectations: [
+          {
+            expectation: item374,
+            remainder: text,
+          },
+        ],
+      };
+    }
+  }
   // S "." S
-  function item398(
+  function item409(
     text: string,
   ):
     | runtime.Success<
@@ -5479,7 +5586,7 @@ export function parse(
     } else {
       remainder = result0.remainder;
     }
-    const result1 = item399(remainder);
+    const result1 = item410(remainder);
     failedExpectations.push(...result1.failedExpectations);
     if (result1.success === false) {
       return {
@@ -5509,7 +5616,7 @@ export function parse(
     };
   }
   // "."
-  function item399(text: string): runtime.Success<"."> | runtime.Failure {
+  function item410(text: string): runtime.Success<"."> | runtime.Failure {
     if (text.startsWith(".")) {
       return {
         success: true,
@@ -5531,10 +5638,10 @@ export function parse(
     }
   }
   // (
-  // S key:Identifier $(S ":") value:Expr
+  // S key:Selector $(S ":") value:Expr
   // { return builder.newStructEntry(offset(), key, value) }
   // )|0.., ","|
-  function item405(
+  function item416(
     text: string,
   ): runtime.Success<Expr_CreateStruct_Entry[]> | runtime.Failure {
     const values: Array<Expr_CreateStruct_Entry> = [];
@@ -5544,13 +5651,13 @@ export function parse(
     do {
       let r = remainder;
       if (values.length > 0) {
-        result = item417(r);
+        result = item428(r);
         if (result.success === false) {
           break;
         }
         r = result.remainder;
       }
-      result = item406(r);
+      result = item417(r);
       failedExpectations.push(...result.failedExpectations);
       if (result.success === false) {
         break;
@@ -5560,16 +5667,16 @@ export function parse(
     } while (true);
     return { success: true, value: values, remainder, failedExpectations };
   }
-  // S key:Identifier $(S ":") value:Expr
+  // S key:Selector $(S ":") value:Expr
   // { return builder.newStructEntry(offset(), key, value) }
-  function item406(
+  function item417(
     text: string,
   ): runtime.Success<Expr_CreateStruct_Entry> | runtime.Failure {
-    const result = item407(text);
+    const result = item418(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item416(
+        value: item427(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -5597,8 +5704,8 @@ export function parse(
       return result;
     }
   }
-  // S key:Identifier $(S ":") value:Expr
-  function item407(
+  // S key:Selector $(S ":") value:Expr
+  function item418(
     text: string,
   ): runtime.Success<[string, Expr]> | runtime.Failure {
     const failedExpectations: runtime.FailedExpectation[] = [];
@@ -5625,7 +5732,7 @@ export function parse(
     } else {
       remainder = remainder.slice(result0[0].length);
     }
-    const result1 = item368(remainder);
+    const result1 = item399(remainder);
     failedExpectations.push(...result1.failedExpectations);
     if (result1.success === false) {
       return {
@@ -5649,7 +5756,7 @@ export function parse(
         remainder: remainder,
       },
       {
-        expectation: item412,
+        expectation: item423,
         remainder: remainder,
       },
     );
@@ -5681,7 +5788,7 @@ export function parse(
     };
   }
   // ","
-  function item417(text: string): runtime.Success<","> | runtime.Failure {
+  function item428(text: string): runtime.Success<","> | runtime.Failure {
     if (text.startsWith(",")) {
       return {
         success: true,
@@ -5702,14 +5809,14 @@ export function parse(
       };
     }
   }
-  // "."? S name:Identifier
+  // "."? S name:Selector
   // { return builder.newIdentExpr(offset(), name) }
-  function item424(text: string): runtime.Success<Expr> | runtime.Failure {
-    const result = item425(text);
+  function item435(text: string): runtime.Success<Expr> | runtime.Failure {
+    const result = item436(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item430(
+        value: item441(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -5736,8 +5843,8 @@ export function parse(
       return result;
     }
   }
-  // "."? S name:Identifier
-  function item425(text: string): runtime.Success<[string]> | runtime.Failure {
+  // "."? S name:Selector
+  function item436(text: string): runtime.Success<[string]> | runtime.Failure {
     const failedExpectations: runtime.FailedExpectation[] = [];
     let remainder = text;
     const result0 = remainder.match(/^(\.)?/g);
@@ -5776,7 +5883,7 @@ export function parse(
     } else {
       remainder = remainder.slice(result1[0].length);
     }
-    const result2 = item368(remainder);
+    const result2 = item399(remainder);
     failedExpectations.push(...result2.failedExpectations);
     if (result2.success === false) {
       return {
@@ -5795,7 +5902,7 @@ export function parse(
     };
   }
   // "(" @Expr ")"
-  function item431(text: string): runtime.Success<Expr> | runtime.Failure {
+  function item442(text: string): runtime.Success<Expr> | runtime.Failure {
     const failedExpectations: runtime.FailedExpectation[] = [];
     let remainder = text;
     const result0 = remainder.match(/^\(/g);
@@ -5846,12 +5953,12 @@ export function parse(
   }
   // elements:("[" @ExprList (",")? S "]")
   // { return builder.newListExpr(offset(), elements) }
-  function item436(text: string): runtime.Success<Expr> | runtime.Failure {
-    const result = item438(text);
+  function item447(text: string): runtime.Success<Expr> | runtime.Failure {
+    const result = item449(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item447(
+        value: item458(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -5879,12 +5986,12 @@ export function parse(
     }
   }
   // "[" @ExprList (",")? S "]"
-  function item438(text: string): runtime.Success<Expr[]> | runtime.Failure {
+  function item449(text: string): runtime.Success<Expr[]> | runtime.Failure {
     const failedExpectations: runtime.FailedExpectation[] = [];
     let remainder = text;
     const result0 = remainder.match(/^\[/g);
     failedExpectations.push({
-      expectation: item440,
+      expectation: item451,
       remainder: remainder,
     });
     if (result0?.length !== 1) {
@@ -5945,7 +6052,7 @@ export function parse(
     }
     const result4 = remainder.match(/^\]/g);
     failedExpectations.push({
-      expectation: item445,
+      expectation: item456,
       remainder: remainder,
     });
     if (result4?.length !== 1) {
@@ -5966,12 +6073,12 @@ export function parse(
   }
   // entries:("{" @MapInits $((",")? S "}"))
   // { return builder.newStructExpr(offset(), entries) }
-  function item448(text: string): runtime.Success<Expr> | runtime.Failure {
-    const result = item450(text);
+  function item459(text: string): runtime.Success<Expr> | runtime.Failure {
+    const result = item461(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item470(
+        value: item481(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -5999,14 +6106,14 @@ export function parse(
     }
   }
   // "{" @MapInits $((",")? S "}")
-  function item450(
+  function item461(
     text: string,
   ): runtime.Success<Expr_CreateStruct_Entry[]> | runtime.Failure {
     const failedExpectations: runtime.FailedExpectation[] = [];
     let remainder = text;
     const result0 = remainder.match(/^\{/g);
     failedExpectations.push({
-      expectation: item402,
+      expectation: item413,
       remainder: remainder,
     });
     if (result0?.length !== 1) {
@@ -6018,7 +6125,7 @@ export function parse(
     } else {
       remainder = remainder.slice(result0[0].length);
     }
-    const result1 = item454(remainder);
+    const result1 = item465(remainder);
     failedExpectations.push(...result1.failedExpectations);
     if (result1.success === false) {
       return {
@@ -6046,7 +6153,7 @@ export function parse(
         remainder: remainder,
       },
       {
-        expectation: item421,
+        expectation: item432,
         remainder: remainder,
       },
     );
@@ -6070,7 +6177,7 @@ export function parse(
   // key:Expr ":" value:Expr
   // { return builder.newMapEntry(offset(), key, value) }
   // )|0.., ","|
-  function item454(
+  function item465(
     text: string,
   ): runtime.Success<Expr_CreateStruct_Entry[]> | runtime.Failure {
     const values: Array<Expr_CreateStruct_Entry> = [];
@@ -6080,13 +6187,13 @@ export function parse(
     do {
       let r = remainder;
       if (values.length > 0) {
-        result = item462(r);
+        result = item473(r);
         if (result.success === false) {
           break;
         }
         r = result.remainder;
       }
-      result = item455(r);
+      result = item466(r);
       failedExpectations.push(...result.failedExpectations);
       if (result.success === false) {
         break;
@@ -6098,14 +6205,14 @@ export function parse(
   }
   // key:Expr ":" value:Expr
   // { return builder.newMapEntry(offset(), key, value) }
-  function item455(
+  function item466(
     text: string,
   ): runtime.Success<Expr_CreateStruct_Entry> | runtime.Failure {
-    const result = item456(text);
+    const result = item467(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item461(
+        value: item472(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -6134,7 +6241,7 @@ export function parse(
     }
   }
   // key:Expr ":" value:Expr
-  function item456(
+  function item467(
     text: string,
   ): runtime.Success<[Expr, Expr]> | runtime.Failure {
     const failedExpectations: runtime.FailedExpectation[] = [];
@@ -6152,7 +6259,7 @@ export function parse(
     }
     const result1 = remainder.match(/^:/g);
     failedExpectations.push({
-      expectation: item412,
+      expectation: item423,
       remainder: remainder,
     });
     if (result1?.length !== 1) {
@@ -6183,7 +6290,7 @@ export function parse(
     };
   }
   // ","
-  function item462(text: string): runtime.Success<","> | runtime.Failure {
+  function item473(text: string): runtime.Success<","> | runtime.Failure {
     if (text.startsWith(",")) {
       return {
         success: true,
@@ -6205,7 +6312,7 @@ export function parse(
     }
   }
   // (S @Access)*
-  function item473(
+  function item484(
     text: string,
   ): runtime.Success<((prevExpr: Expr) => Expr)[]> | runtime.Failure {
     const values: Array<(prevExpr: Expr) => Expr> = [];
@@ -6214,7 +6321,7 @@ export function parse(
     let result;
     do {
       let r = remainder;
-      result = item474(r);
+      result = item485(r);
       failedExpectations.push(...result.failedExpectations);
       if (result.success === false) {
         break;
@@ -6225,7 +6332,7 @@ export function parse(
     return { success: true, value: values, remainder, failedExpectations };
   }
   // S @Access
-  function item474(
+  function item485(
     text: string,
   ): runtime.Success<(prevExpr: Expr) => Expr> | runtime.Failure {
     const failedExpectations: runtime.FailedExpectation[] = [];
@@ -6252,7 +6359,7 @@ export function parse(
     } else {
       remainder = remainder.slice(result0[0].length);
     }
-    const result1 = item477(remainder);
+    const result1 = item488(remainder);
     failedExpectations.push(...result1.failedExpectations);
     if (result1.success === false) {
       return {
@@ -6270,16 +6377,16 @@ export function parse(
       failedExpectations,
     };
   }
-  // "." S field:Identifier S ![(]
+  // "." S field:Selector S ![(]
   // { return ((prevExpr: Expr) => builder.newSelectExpr(offset(), prevExpr, field)) }
-  // / "." S identifier:Identifier S "(" args:ExprList ")"
-  // { return ((prevExpr: Expr) => builder.newMemberCallExpr(offset(), prevExpr, identifier, args)) }
+  // / "." S func:Selector S "(" args:ExprList ")"
+  // { return ((prevExpr: Expr) => builder.newMemberCallExpr(offset(), prevExpr, func, args)) }
   // / "[" index:Expr "]"
   // { return ((prevExpr: Expr) => builder.newCallExpr(offset(), "_[_]", [prevExpr, index])) }
-  function item477(
+  function item488(
     text: string,
   ): runtime.Success<(prevExpr: Expr) => Expr> | runtime.Failure {
-    const choices = [item478, item487, item495];
+    const choices = [item489, item498, item507];
     let failedExpectations: runtime.FailedExpectation[] = [];
     for (
       let func = choices.shift();
@@ -6303,16 +6410,16 @@ export function parse(
       failedExpectations,
     };
   }
-  // "." S field:Identifier S ![(]
+  // "." S field:Selector S ![(]
   // { return ((prevExpr: Expr) => builder.newSelectExpr(offset(), prevExpr, field)) }
-  function item478(
+  function item489(
     text: string,
   ): runtime.Success<(prevExpr: Expr) => Expr> | runtime.Failure {
-    const result = item479(text);
+    const result = item490(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item486(
+        value: item497(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -6339,8 +6446,8 @@ export function parse(
       return result;
     }
   }
-  // "." S field:Identifier S ![(]
-  function item479(text: string): runtime.Success<[string]> | runtime.Failure {
+  // "." S field:Selector S ![(]
+  function item490(text: string): runtime.Success<[string]> | runtime.Failure {
     const failedExpectations: runtime.FailedExpectation[] = [];
     let remainder = text;
     const result0 = remainder.match(/^\./g);
@@ -6379,7 +6486,7 @@ export function parse(
     } else {
       remainder = remainder.slice(result1[0].length);
     }
-    const result2 = item368(remainder);
+    const result2 = item399(remainder);
     failedExpectations.push(...result2.failedExpectations);
     if (result2.success === false) {
       return {
@@ -6430,16 +6537,16 @@ export function parse(
       failedExpectations,
     };
   }
-  // "." S identifier:Identifier S "(" args:ExprList ")"
-  // { return ((prevExpr: Expr) => builder.newMemberCallExpr(offset(), prevExpr, identifier, args)) }
-  function item487(
+  // "." S func:Selector S "(" args:ExprList ")"
+  // { return ((prevExpr: Expr) => builder.newMemberCallExpr(offset(), prevExpr, func, args)) }
+  function item498(
     text: string,
   ): runtime.Success<(prevExpr: Expr) => Expr> | runtime.Failure {
-    const result = item488(text);
+    const result = item499(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item494(
+        value: item506(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -6467,8 +6574,8 @@ export function parse(
       return result;
     }
   }
-  // "." S identifier:Identifier S "(" args:ExprList ")"
-  function item488(
+  // "." S func:Selector S "(" args:ExprList ")"
+  function item499(
     text: string,
   ): runtime.Success<[string, Expr[]]> | runtime.Failure {
     const failedExpectations: runtime.FailedExpectation[] = [];
@@ -6509,7 +6616,7 @@ export function parse(
     } else {
       remainder = remainder.slice(result1[0].length);
     }
-    const result2 = item368(remainder);
+    const result2 = item399(remainder);
     failedExpectations.push(...result2.failedExpectations);
     if (result2.success === false) {
       return {
@@ -6590,14 +6697,14 @@ export function parse(
   }
   // "[" index:Expr "]"
   // { return ((prevExpr: Expr) => builder.newCallExpr(offset(), "_[_]", [prevExpr, index])) }
-  function item495(
+  function item507(
     text: string,
   ): runtime.Success<(prevExpr: Expr) => Expr> | runtime.Failure {
-    const result = item496(text);
+    const result = item508(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item501(
+        value: item513(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -6625,12 +6732,12 @@ export function parse(
     }
   }
   // "[" index:Expr "]"
-  function item496(text: string): runtime.Success<[Expr]> | runtime.Failure {
+  function item508(text: string): runtime.Success<[Expr]> | runtime.Failure {
     const failedExpectations: runtime.FailedExpectation[] = [];
     let remainder = text;
     const result0 = remainder.match(/^\[/g);
     failedExpectations.push({
-      expectation: item440,
+      expectation: item451,
       remainder: remainder,
     });
     if (result0?.length !== 1) {
@@ -6655,7 +6762,7 @@ export function parse(
     }
     const result2 = remainder.match(/^\]/g);
     failedExpectations.push({
-      expectation: item445,
+      expectation: item456,
       remainder: remainder,
     });
     if (result2?.length !== 1) {
@@ -6685,12 +6792,12 @@ export function parse(
   // return builder.newCallExpr(offset(), `${ops[0]}_`, [expr]);
   // }
   // }
-  function item505(text: string): runtime.Success<Expr> | runtime.Failure {
-    const result = item506(text);
+  function item517(text: string): runtime.Success<Expr> | runtime.Failure {
+    const result = item518(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item517(
+        value: item529(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -6719,7 +6826,7 @@ export function parse(
     }
   }
   // S ops:$( "!"+ / "-"+ ) expr:Member
-  function item506(
+  function item518(
     text: string,
   ): runtime.Success<[string, Expr]> | runtime.Failure {
     const failedExpectations: runtime.FailedExpectation[] = [];
@@ -6746,7 +6853,7 @@ export function parse(
     } else {
       remainder = remainder.slice(result0[0].length);
     }
-    const result1 = item508(remainder);
+    const result1 = item520(remainder);
     failedExpectations.push(...result1.failedExpectations);
     if (result1.success === false) {
       return {
@@ -6776,7 +6883,7 @@ export function parse(
     };
   }
   // $( "!"+ / "-"+ )
-  function item508(text: string): runtime.Success<string> | runtime.Failure {
+  function item520(text: string): runtime.Success<string> | runtime.Failure {
     const matches = text.match(/^((!)+|(-)+)/g);
     if (matches?.length === 1) {
       return {
@@ -6791,7 +6898,7 @@ export function parse(
         remainder: text,
         failedExpectations: [
           {
-            expectation: item512,
+            expectation: item524,
             remainder: text,
           },
           {
@@ -6803,10 +6910,10 @@ export function parse(
     }
   }
   // MultiplicationTail?
-  function item519(
+  function item531(
     text: string,
   ): runtime.Success<((prevExpr: Expr) => Expr)[] | null> | runtime.Failure {
-    const result = item521(text);
+    const result = item533(text);
     if (result.success === true) {
       return result;
     } else {
@@ -6822,7 +6929,7 @@ export function parse(
   // S operator:( o:[*/%] { return `_${o}_` } ) nextExpr:Unary
   // { return ((prevExpr: Expr) => builder.newCallExpr(offset(), operator, [prevExpr, nextExpr])) }
   // )+
-  function item521(
+  function item533(
     text: string,
   ): runtime.Success<((prevExpr: Expr) => Expr)[]> | runtime.Failure {
     const values: Array<(prevExpr: Expr) => Expr> = [];
@@ -6831,7 +6938,7 @@ export function parse(
     let result;
     do {
       let r = remainder;
-      result = item522(r);
+      result = item534(r);
       failedExpectations.push(...result.failedExpectations);
       if (result.success === false) {
         break;
@@ -6854,14 +6961,14 @@ export function parse(
   }
   // S operator:( o:[*/%] { return `_${o}_` } ) nextExpr:Unary
   // { return ((prevExpr: Expr) => builder.newCallExpr(offset(), operator, [prevExpr, nextExpr])) }
-  function item522(
+  function item534(
     text: string,
   ): runtime.Success<(prevExpr: Expr) => Expr> | runtime.Failure {
-    const result = item523(text);
+    const result = item535(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item532(
+        value: item544(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -6890,7 +6997,7 @@ export function parse(
     }
   }
   // S operator:( o:[*/%] { return `_${o}_` } ) nextExpr:Unary
-  function item523(
+  function item535(
     text: string,
   ): runtime.Success<[string, Expr]> | runtime.Failure {
     const failedExpectations: runtime.FailedExpectation[] = [];
@@ -6917,7 +7024,7 @@ export function parse(
     } else {
       remainder = remainder.slice(result0[0].length);
     }
-    const result1 = item525(remainder);
+    const result1 = item537(remainder);
     failedExpectations.push(...result1.failedExpectations);
     if (result1.success === false) {
       return {
@@ -6947,12 +7054,12 @@ export function parse(
     };
   }
   // o:[*/%] { return `_${o}_` }
-  function item525(text: string): runtime.Success<string> | runtime.Failure {
-    const result = item527(text);
+  function item537(text: string): runtime.Success<string> | runtime.Failure {
+    const result = item539(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item529(
+        value: item541(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -6980,7 +7087,7 @@ export function parse(
     }
   }
   // [*/%]
-  function item527(text: string): runtime.Success<string> | runtime.Failure {
+  function item539(text: string): runtime.Success<string> | runtime.Failure {
     if (/^[*\/%]/g.test(text)) {
       return {
         success: true,
@@ -6994,7 +7101,7 @@ export function parse(
         remainder: text,
         failedExpectations: [
           {
-            expectation: item528,
+            expectation: item540,
             remainder: text,
           },
         ],
@@ -7002,10 +7109,10 @@ export function parse(
     }
   }
   // AdditionTail?
-  function item536(
+  function item548(
     text: string,
   ): runtime.Success<((prevExpr: Expr) => Expr)[] | null> | runtime.Failure {
-    const result = item538(text);
+    const result = item550(text);
     if (result.success === true) {
       return result;
     } else {
@@ -7021,7 +7128,7 @@ export function parse(
   // S operator:( o:[+-] { return `_${o}_` } ) nextExpr:Multiplication
   // { return ((prevExpr: Expr) => builder.newCallExpr(offset(), operator, [prevExpr, nextExpr])) }
   // )+
-  function item538(
+  function item550(
     text: string,
   ): runtime.Success<((prevExpr: Expr) => Expr)[]> | runtime.Failure {
     const values: Array<(prevExpr: Expr) => Expr> = [];
@@ -7030,7 +7137,7 @@ export function parse(
     let result;
     do {
       let r = remainder;
-      result = item539(r);
+      result = item551(r);
       failedExpectations.push(...result.failedExpectations);
       if (result.success === false) {
         break;
@@ -7053,14 +7160,14 @@ export function parse(
   }
   // S operator:( o:[+-] { return `_${o}_` } ) nextExpr:Multiplication
   // { return ((prevExpr: Expr) => builder.newCallExpr(offset(), operator, [prevExpr, nextExpr])) }
-  function item539(
+  function item551(
     text: string,
   ): runtime.Success<(prevExpr: Expr) => Expr> | runtime.Failure {
-    const result = item540(text);
+    const result = item552(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item547(
+        value: item559(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -7089,7 +7196,7 @@ export function parse(
     }
   }
   // S operator:( o:[+-] { return `_${o}_` } ) nextExpr:Multiplication
-  function item540(
+  function item552(
     text: string,
   ): runtime.Success<[string, Expr]> | runtime.Failure {
     const failedExpectations: runtime.FailedExpectation[] = [];
@@ -7116,7 +7223,7 @@ export function parse(
     } else {
       remainder = remainder.slice(result0[0].length);
     }
-    const result1 = item542(remainder);
+    const result1 = item554(remainder);
     failedExpectations.push(...result1.failedExpectations);
     if (result1.success === false) {
       return {
@@ -7146,12 +7253,12 @@ export function parse(
     };
   }
   // o:[+-] { return `_${o}_` }
-  function item542(text: string): runtime.Success<string> | runtime.Failure {
-    const result = item544(text);
+  function item554(text: string): runtime.Success<string> | runtime.Failure {
+    const result = item556(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item545(
+        value: item557(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -7179,7 +7286,7 @@ export function parse(
     }
   }
   // [+-]
-  function item544(text: string): runtime.Success<string> | runtime.Failure {
+  function item556(text: string): runtime.Success<string> | runtime.Failure {
     if (/^[+\-]/g.test(text)) {
       return {
         success: true,
@@ -7201,10 +7308,10 @@ export function parse(
     }
   }
   // RelationTail?
-  function item551(
+  function item563(
     text: string,
   ): runtime.Success<((prevExpr: Expr) => Expr)[] | null> | runtime.Failure {
-    const result = item553(text);
+    const result = item565(text);
     if (result.success === true) {
       return result;
     } else {
@@ -7220,7 +7327,7 @@ export function parse(
   // S operator:Relop nextExpr:Addition
   // { return ((prevExpr: Expr) => builder.newCallExpr(offset(), operator, [prevExpr, nextExpr])) }
   // )+
-  function item553(
+  function item565(
     text: string,
   ): runtime.Success<((prevExpr: Expr) => Expr)[]> | runtime.Failure {
     const values: Array<(prevExpr: Expr) => Expr> = [];
@@ -7229,7 +7336,7 @@ export function parse(
     let result;
     do {
       let r = remainder;
-      result = item554(r);
+      result = item566(r);
       failedExpectations.push(...result.failedExpectations);
       if (result.success === false) {
         break;
@@ -7252,14 +7359,14 @@ export function parse(
   }
   // S operator:Relop nextExpr:Addition
   // { return ((prevExpr: Expr) => builder.newCallExpr(offset(), operator, [prevExpr, nextExpr])) }
-  function item554(
+  function item566(
     text: string,
   ): runtime.Success<(prevExpr: Expr) => Expr> | runtime.Failure {
-    const result = item555(text);
+    const result = item567(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item583(
+        value: item595(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -7288,7 +7395,7 @@ export function parse(
     }
   }
   // S operator:Relop nextExpr:Addition
-  function item555(
+  function item567(
     text: string,
   ): runtime.Success<[string, Expr]> | runtime.Failure {
     const failedExpectations: runtime.FailedExpectation[] = [];
@@ -7315,7 +7422,7 @@ export function parse(
     } else {
       remainder = remainder.slice(result0[0].length);
     }
-    const result1 = item558(remainder);
+    const result1 = item570(remainder);
     failedExpectations.push(...result1.failedExpectations);
     if (result1.success === false) {
       return {
@@ -7351,8 +7458,8 @@ export function parse(
   // )
   // / "in" { return "@in" }
   //
-  function item558(text: string): runtime.Success<string> | runtime.Failure {
-    const result = item559(text);
+  function item570(text: string): runtime.Success<string> | runtime.Failure {
+    const result = item571(text);
     if (result.success === true) {
       return result;
     } else {
@@ -7361,7 +7468,7 @@ export function parse(
         remainder: result.remainder,
         failedExpectations: [
           {
-            expectation: item581,
+            expectation: item593,
             remainder: result.remainder,
           },
         ],
@@ -7373,8 +7480,8 @@ export function parse(
   // { return `_${operator}_` }
   // )
   // / "in" { return "@in" }
-  function item559(text: string): runtime.Success<string> | runtime.Failure {
-    const choices = [item560, item577];
+  function item571(text: string): runtime.Success<string> | runtime.Failure {
+    const choices = [item572, item589];
     let failedExpectations: runtime.FailedExpectation[] = [];
     for (
       let func = choices.shift();
@@ -7400,12 +7507,12 @@ export function parse(
   }
   // operator:$("<=" / "<" / ">=" / ">" / "==" / "!=")
   // { return `_${operator}_` }
-  function item560(text: string): runtime.Success<string> | runtime.Failure {
-    const result = item562(text);
+  function item572(text: string): runtime.Success<string> | runtime.Failure {
+    const result = item574(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item576(
+        value: item588(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -7433,7 +7540,7 @@ export function parse(
     }
   }
   // $("<=" / "<" / ">=" / ">" / "==" / "!=")
-  function item562(text: string): runtime.Success<string> | runtime.Failure {
+  function item574(text: string): runtime.Success<string> | runtime.Failure {
     const matches = text.match(/^(<=|<|>=|>|==|!=)/g);
     if (matches?.length === 1) {
       return {
@@ -7448,27 +7555,27 @@ export function parse(
         remainder: text,
         failedExpectations: [
           {
-            expectation: item565,
+            expectation: item577,
             remainder: text,
           },
           {
-            expectation: item567,
+            expectation: item579,
             remainder: text,
           },
           {
-            expectation: item569,
+            expectation: item581,
             remainder: text,
           },
           {
-            expectation: item571,
+            expectation: item583,
             remainder: text,
           },
           {
-            expectation: item573,
+            expectation: item585,
             remainder: text,
           },
           {
-            expectation: item575,
+            expectation: item587,
             remainder: text,
           },
         ],
@@ -7476,12 +7583,12 @@ export function parse(
     }
   }
   // "in" { return "@in" }
-  function item577(text: string): runtime.Success<string> | runtime.Failure {
-    const result = item578(text);
+  function item589(text: string): runtime.Success<string> | runtime.Failure {
+    const result = item590(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item580(
+        value: item592(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -7508,7 +7615,7 @@ export function parse(
     }
   }
   // "in"
-  function item578(text: string): runtime.Success<"in"> | runtime.Failure {
+  function item590(text: string): runtime.Success<"in"> | runtime.Failure {
     if (text.startsWith("in")) {
       return {
         success: true,
@@ -7522,7 +7629,7 @@ export function parse(
         remainder: text,
         failedExpectations: [
           {
-            expectation: item579,
+            expectation: item591,
             remainder: text,
           },
         ],
@@ -7530,7 +7637,7 @@ export function parse(
     }
   }
   // $(S "&&")
-  function item586(text: string): runtime.Success<string> | runtime.Failure {
+  function item598(text: string): runtime.Success<string> | runtime.Failure {
     const matches = text.match(
       /^(([\t\n\f\r ])+)?(\/\/([^\r\n])*([\r\n])+)?(([\t\n\f\r ])+)?&&/g,
     );
@@ -7555,7 +7662,7 @@ export function parse(
             remainder: text,
           },
           {
-            expectation: item589,
+            expectation: item601,
             remainder: text,
           },
         ],
@@ -7563,7 +7670,7 @@ export function parse(
     }
   }
   // $(S "||")
-  function item592(text: string): runtime.Success<string> | runtime.Failure {
+  function item604(text: string): runtime.Success<string> | runtime.Failure {
     const matches = text.match(
       /^(([\t\n\f\r ])+)?(\/\/([^\r\n])*([\r\n])+)?(([\t\n\f\r ])+)?\|\|/g,
     );
@@ -7588,7 +7695,7 @@ export function parse(
             remainder: text,
           },
           {
-            expectation: item595,
+            expectation: item607,
             remainder: text,
           },
         ],
@@ -7596,10 +7703,10 @@ export function parse(
     }
   }
   // TernaryTail?
-  function item599(
+  function item611(
     text: string,
   ): runtime.Success<[Expr, Expr] | null> | runtime.Failure {
-    const result = item601(text);
+    const result = item613(text);
     if (result.success === true) {
       return result;
     } else {
@@ -7616,14 +7723,14 @@ export function parse(
   // /* : [Expr, Expr] */
   // return [t, f];
   // }
-  function item601(
+  function item613(
     text: string,
   ): runtime.Success<[Expr, Expr]> | runtime.Failure {
-    const result = item602(text);
+    const result = item614(text);
     if (result.success === true) {
       return {
         success: true,
-        value: item609(
+        value: item621(
           () =>
             runtime.getLocation(parse$source, input, text, result.remainder),
           () => runtime.getRange(parse$source, input, text, result.remainder),
@@ -7652,14 +7759,14 @@ export function parse(
     }
   }
   // "?" t:ConditionalOr S ":" f:Expr S
-  function item602(
+  function item614(
     text: string,
   ): runtime.Success<[Expr, Expr]> | runtime.Failure {
     const failedExpectations: runtime.FailedExpectation[] = [];
     let remainder = text;
     const result0 = remainder.match(/^\?/g);
     failedExpectations.push({
-      expectation: item604,
+      expectation: item616,
       remainder: remainder,
     });
     if (result0?.length !== 1) {
@@ -7706,7 +7813,7 @@ export function parse(
     }
     const result3 = remainder.match(/^:/g);
     failedExpectations.push({
-      expectation: item412,
+      expectation: item423,
       remainder: remainder,
     });
     if (result3?.length !== 1) {


### PR DESCRIPTION
Fixes #51.

New tests should be incoming via https://github.com/google/cel-spec/pull/480. In the mean time, here's a branch with local updates showing the new tests passing: #208 