### PR TITLE
Add conformance tests for the parser

### DIFF
--- a/packages/cel-spec/biome.json
+++ b/packages/cel-spec/biome.json
@@ -2,6 +2,6 @@
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "extends": ["../../biome.base.json"],
   "files": {
-    "ignore": ["dist", "src/wkt/gen", "src/testdata-json.ts"]
+    "ignore": ["dist", "src/wkt/gen", "src/testdata/conformance.ts"]
   }
 }

--- a/packages/cel-spec/package.json
+++ b/packages/cel-spec/package.json
@@ -19,11 +19,13 @@
     "fetch-proto": "node scripts/fetch-proto.js",
     "postfetch-proto": "license-header proto",
     "fetch-testdata": "node scripts/fetch-testdata.js",
-    "postfetch-testdata": "license-header src/testdata-json.ts",
+    "postfetch-testdata": "biome format --write src/testdata/conformance.ts src/testdata/json/*.json && license-header src/testdata/conformance.ts",
     "fetch-parser": "go run -C scripts gen_parser_tests.go -output ../src/testdata/parser.ts parser/parser_test.go",
     "postfetch-parser": "biome format --write src/testdata/parser.ts && license-header src/testdata/parser.ts",
     "fetch-parser-comprehensions": "go run -C scripts gen_parser_tests.go -output ../src/testdata/parser-comprehensions.ts ext/comprehensions_test.go",
     "postfetch-parser-comprehensions": "biome format --write src/testdata/parser-comprehensions.ts && license-header src/testdata/parser-comprehensions.ts",
+    "fetch-parser-conformance": "go run -C scripts gen_parser_tests.go -output ../src/testdata/parser-conformance.ts ../src/testdata/json",
+    "postfetch-parser-conformance": "biome format --write src/testdata/parser-conformance.ts && license-header src/testdata/parser-conformance.ts",
     "update-exports": "node scripts/update-exports.js",
     "postupdate-exports": "biome format --write package.json",
     "update-readme": "node scripts/update-readme.js",
@@ -42,9 +44,17 @@
   "type": "module",
   "sideEffects": false,
   "exports": {
+    "./testdata/conformance.js": {
+      "import": "./dist/esm/testdata/conformance.js",
+      "require": "./dist/cjs/testdata/conformance.js"
+    },
     "./testdata/parser-comprehensions.js": {
       "import": "./dist/esm/testdata/parser-comprehensions.js",
       "require": "./dist/cjs/testdata/parser-comprehensions.js"
+    },
+    "./testdata/parser-conformance.js": {
+      "import": "./dist/esm/testdata/parser-conformance.js",
+      "require": "./dist/cjs/testdata/parser-conformance.js"
     },
     "./testdata/parser.js": {
       "import": "./dist/esm/testdata/parser.js",
@@ -117,8 +127,12 @@
   },
   "typesVersions": {
     "*": {
+      "testdata/conformance.js": ["./dist/cjs/testdata/conformance.d.ts"],
       "testdata/parser-comprehensions.js": [
         "./dist/cjs/testdata/parser-comprehensions.d.ts"
+      ],
+      "testdata/parser-conformance.js": [
+        "./dist/cjs/testdata/parser-conformance.d.ts"
       ],
       "testdata/parser.js": ["./dist/cjs/testdata/parser.d.ts"],
       "testdata/registry.js": ["./dist/cjs/testdata/registry.d.ts"],

--- a/packages/cel-spec/scripts/fetch-testdata.js
+++ b/packages/cel-spec/scripts/fetch-testdata.js
@@ -14,7 +14,7 @@
 
 import { extractFiles, fetchRepository, readPackageJson } from "./common.js";
 import { spawnSync } from "node:child_process";
-import { writeFileSync } from "node:fs";
+import { promises as fs } from "node:fs";
 
 /*
  * Fetch conformance test data from the upstream github.com/google/cel-spec
@@ -32,17 +32,28 @@ const testdataTextProto = extractFiles(
   /^cel-spec-[^/]+\/tests\/simple\/testdata\/([^/]+\.textproto)$/,
 );
 // Convert textproto to JSON with `buf convert`, using the local module "proto".
-const testdataJson = convertTestDataToJson(
+const testdataJsonFiles = convertTestDataToJson(
   testdataTextProto,
   "proto",
   "cel.expr.conformance.test.SimpleTestFile",
 );
-// Write as JSON array to a TypeScript file
-writeFileSync(
-  "src/testdata-json.ts",
+
+// Write to JSON
+const writes = testdataJsonFiles.map((file) =>
+  fs.writeFile(
+    `src/testdata/json/${file.name}.json`,
+    JSON.stringify(file, null, 2),
+  ),
+);
+
+for await (const _ of writes);
+
+// Write to TypeScript
+await fs.writeFile(
+  "src/testdata/conformance.ts",
   `// Generated from github.com/google/cel-spec ${upstreamCelSpecRef} by scripts/fetch-testdata.js
 
-export const testdataJson = ${JSON.stringify(testdataJson, null, 2)} as const;`,
+export const testdata = ${JSON.stringify(testdataJsonFiles, null, 2)} as const;`,
 );
 
 /**

--- a/packages/cel-spec/src/testdata/conformance.ts
+++ b/packages/cel-spec/src/testdata/conformance.ts
@@ -14,7 +14,7 @@
 
 // Generated from github.com/google/cel-spec v0.24.0 by scripts/fetch-testdata.js
 
-export const testdataJson = [
+export const testdata = [
   {
     "name": "basic",
     "description": "Basic conformance tests that all implementations should pass.",

--- a/packages/cel-spec/src/testdata/json/basic.json
+++ b/packages/cel-spec/src/testdata/json/basic.json
@@ -1,0 +1,436 @@
+{
+  "name": "basic",
+  "description": "Basic conformance tests that all implementations should pass.",
+  "section": [
+    {
+      "name": "self_eval_zeroish",
+      "description": "Simple self-evaluating forms to zero-ish values.",
+      "test": [
+        {
+          "name": "self_eval_int_zero",
+          "expr": "0",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "self_eval_uint_zero",
+          "expr": "0u",
+          "value": {
+            "uint64Value": "0"
+          }
+        },
+        {
+          "name": "self_eval_uint_alias_zero",
+          "expr": "0U",
+          "value": {
+            "uint64Value": "0"
+          }
+        },
+        {
+          "name": "self_eval_float_zero",
+          "expr": "0.0",
+          "value": {
+            "doubleValue": 0
+          }
+        },
+        {
+          "name": "self_eval_float_zerowithexp",
+          "expr": "0e+0",
+          "value": {
+            "doubleValue": 0
+          }
+        },
+        {
+          "name": "self_eval_string_empty",
+          "expr": "''",
+          "value": {
+            "stringValue": ""
+          }
+        },
+        {
+          "name": "self_eval_string_empty_quotes",
+          "expr": "\"\"",
+          "value": {
+            "stringValue": ""
+          }
+        },
+        {
+          "name": "self_eval_string_raw_prefix",
+          "expr": "r\"\"",
+          "value": {
+            "stringValue": ""
+          }
+        },
+        {
+          "name": "self_eval_bytes_empty",
+          "expr": "b\"\"",
+          "value": {
+            "bytesValue": ""
+          }
+        },
+        {
+          "name": "self_eval_bool_false",
+          "expr": "false",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "self_eval_null",
+          "expr": "null",
+          "value": {
+            "nullValue": null
+          }
+        },
+        {
+          "name": "self_eval_empty_list",
+          "expr": "[]",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "self_eval_empty_map",
+          "expr": "{}",
+          "value": {
+            "mapValue": {}
+          }
+        },
+        {
+          "name": "self_eval_string_raw_prefix_triple_double",
+          "expr": "r\"\"\"\"\"\"",
+          "value": {
+            "stringValue": ""
+          }
+        },
+        {
+          "name": "self_eval_string_raw_prefix_triple_single",
+          "expr": "r''''''",
+          "value": {
+            "stringValue": ""
+          }
+        }
+      ]
+    },
+    {
+      "name": "self_eval_nonzeroish",
+      "description": "Simple self-evaluating forms to non-zero-ish values.",
+      "test": [
+        {
+          "name": "self_eval_int_nonzero",
+          "expr": "42",
+          "value": {
+            "int64Value": "42"
+          }
+        },
+        {
+          "name": "self_eval_uint_nonzero",
+          "expr": "123456789u",
+          "value": {
+            "uint64Value": "123456789"
+          }
+        },
+        {
+          "name": "self_eval_uint_alias_nonzero",
+          "expr": "123456789U",
+          "value": {
+            "uint64Value": "123456789"
+          }
+        },
+        {
+          "name": "self_eval_int_negative_min",
+          "expr": "-9223372036854775808",
+          "value": {
+            "int64Value": "-9223372036854775808"
+          }
+        },
+        {
+          "name": "self_eval_float_negative_exp",
+          "expr": "-2.3e+1",
+          "value": {
+            "doubleValue": -23
+          }
+        },
+        {
+          "name": "self_eval_string_excl",
+          "expr": "\"!\"",
+          "value": {
+            "stringValue": "!"
+          }
+        },
+        {
+          "name": "self_eval_string_escape",
+          "expr": "'\\''",
+          "value": {
+            "stringValue": "'"
+          }
+        },
+        {
+          "name": "self_eval_bytes_escape",
+          "expr": "b'ÿ'",
+          "value": {
+            "bytesValue": "w78="
+          }
+        },
+        {
+          "name": "self_eval_bytes_invalid_utf8",
+          "expr": "b'\\000\\xff'",
+          "value": {
+            "bytesValue": "AP8="
+          }
+        },
+        {
+          "name": "self_eval_list_singleitem",
+          "expr": "[-1]",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "int64Value": "-1"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "self_eval_map_singleitem",
+          "expr": "{\"k\":\"v\"}",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "k"
+                  },
+                  "value": {
+                    "stringValue": "v"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "self_eval_bool_true",
+          "expr": "true",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "self_eval_int_hex",
+          "expr": "0x55555555",
+          "value": {
+            "int64Value": "1431655765"
+          }
+        },
+        {
+          "name": "self_eval_int_hex_negative",
+          "expr": "-0x55555555",
+          "value": {
+            "int64Value": "-1431655765"
+          }
+        },
+        {
+          "name": "self_eval_uint_hex",
+          "expr": "0x55555555u",
+          "value": {
+            "uint64Value": "1431655765"
+          }
+        },
+        {
+          "name": "self_eval_uint_alias_hex",
+          "expr": "0x55555555U",
+          "value": {
+            "uint64Value": "1431655765"
+          }
+        },
+        {
+          "name": "self_eval_unicode_escape_four",
+          "expr": "\"\\u270c\"",
+          "value": {
+            "stringValue": "✌"
+          }
+        },
+        {
+          "name": "self_eval_unicode_escape_eight",
+          "expr": "\"\\U0001f431\"",
+          "value": {
+            "stringValue": "🐱"
+          }
+        },
+        {
+          "name": "self_eval_ascii_escape_seq",
+          "expr": "\"\\a\\b\\f\\n\\r\\t\\v\\\"\\'\\\\\"",
+          "value": {
+            "stringValue": "\u0007\b\f\n\r\t\u000b\"'\\"
+          }
+        }
+      ]
+    },
+    {
+      "name": "variables",
+      "description": "Variable lookups.",
+      "test": [
+        {
+          "name": "self_eval_bound_lookup",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "primitive": "INT64"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "int64Value": "123"
+              }
+            }
+          },
+          "value": {
+            "int64Value": "123"
+          }
+        },
+        {
+          "name": "self_eval_unbound_lookup",
+          "description": "An unbound variable should be marked as an error during execution. See google/cel-go#154",
+          "expr": "x",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "undeclared reference to 'x' (in container '')"
+              }
+            ]
+          }
+        },
+        {
+          "name": "unbound_is_runtime_error",
+          "description": "Make sure we can short-circuit around an unbound variable.",
+          "expr": "x || true",
+          "disableCheck": true,
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "functions",
+      "description": "Basic mechanisms for function calls.",
+      "test": [
+        {
+          "name": "binop",
+          "expr": "1 + 1",
+          "value": {
+            "int64Value": "2"
+          }
+        },
+        {
+          "name": "unbound",
+          "expr": "f_unknown(17)",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "unbound function"
+              }
+            ]
+          }
+        },
+        {
+          "name": "unbound_is_runtime_error",
+          "expr": "f_unknown(17) || true",
+          "disableCheck": true,
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "reserved_const",
+      "description": "Named constants should never be shadowed by identifiers.",
+      "test": [
+        {
+          "name": "false",
+          "expr": "false",
+          "typeEnv": [
+            {
+              "name": "false",
+              "ident": {
+                "type": {
+                  "primitive": "BOOL"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "false": {
+              "value": {
+                "boolValue": true
+              }
+            }
+          },
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "true",
+          "expr": "true",
+          "typeEnv": [
+            {
+              "name": "true",
+              "ident": {
+                "type": {
+                  "primitive": "BOOL"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "true": {
+              "value": {
+                "boolValue": false
+              }
+            }
+          },
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "null",
+          "expr": "null",
+          "typeEnv": [
+            {
+              "name": "null",
+              "ident": {
+                "type": {
+                  "primitive": "BOOL"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "null": {
+              "value": {
+                "boolValue": true
+              }
+            }
+          },
+          "value": {
+            "nullValue": null
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/bindings_ext.json
+++ b/packages/cel-spec/src/testdata/json/bindings_ext.json
@@ -1,0 +1,46 @@
+{
+  "name": "bindings_ext",
+  "description": "Tests for the bindings extension library.",
+  "section": [
+    {
+      "name": "bind",
+      "test": [
+        {
+          "name": "boolean_literal",
+          "expr": "cel.bind(t, true, t)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "string_concat",
+          "expr": "cel.bind(msg, \"hello\", msg + msg + msg)",
+          "value": {
+            "stringValue": "hellohellohello"
+          }
+        },
+        {
+          "name": "bind_nested",
+          "expr": "cel.bind(t1, true, cel.bind(t2, true, t1 && t2))",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "macro_exists",
+          "expr": "cel.bind(valid_elems, [1, 2, 3], [3, 4, 5].exists(e, e in valid_elems))",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "macro_not_exists",
+          "expr": "cel.bind(valid_elems, [1, 2, 3], ![4, 5].exists(e, e in valid_elems))",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/block_ext.json
+++ b/packages/cel-spec/src/testdata/json/block_ext.json
@@ -1,0 +1,1096 @@
+{
+  "name": "block_ext",
+  "description": "Tests for cel.block.",
+  "section": [
+    {
+      "name": "basic",
+      "test": [
+        {
+          "name": "int_add",
+          "expr": "cel.block([1, cel.index(0) + 1, cel.index(1) + 1, cel.index(2) + 1], cel.index(3))",
+          "value": {
+            "int64Value": "4"
+          }
+        },
+        {
+          "name": "size_1",
+          "expr": "cel.block([[1, 2], size(cel.index(0)), cel.index(1) + cel.index(1), cel.index(2) + 1], cel.index(3))",
+          "value": {
+            "int64Value": "5"
+          }
+        },
+        {
+          "name": "size_2",
+          "expr": "cel.block([[1, 2], size(cel.index(0)), 2 + cel.index(1), cel.index(2) + cel.index(1), cel.index(3) + 1], cel.index(4))",
+          "value": {
+            "int64Value": "7"
+          }
+        },
+        {
+          "name": "size_3",
+          "expr": "cel.block([[0], size(cel.index(0)), [1, 2], size(cel.index(2)), cel.index(1) + cel.index(1), cel.index(4) + cel.index(3), cel.index(5) + cel.index(3)], cel.index(6))",
+          "value": {
+            "int64Value": "6"
+          }
+        },
+        {
+          "name": "size_4",
+          "expr": "cel.block([[0], size(cel.index(0)), [1, 2], size(cel.index(2)), [1, 2, 3], size(cel.index(4)), 5 + cel.index(1), cel.index(6) + cel.index(1), cel.index(7) + cel.index(3), cel.index(8) + cel.index(3), cel.index(9) + cel.index(5), cel.index(10) + cel.index(5)], cel.index(11))",
+          "value": {
+            "int64Value": "17"
+          }
+        },
+        {
+          "name": "timestamp",
+          "expr": "cel.block([timestamp(1000000000), int(cel.index(0)), timestamp(cel.index(1)), cel.index(2).getFullYear(), timestamp(50), int(cel.index(4)), timestamp(cel.index(5)), timestamp(200), int(cel.index(7)), timestamp(cel.index(8)), cel.index(9).getFullYear(), timestamp(75), int(cel.index(11)), timestamp(cel.index(12)), cel.index(13).getFullYear(), cel.index(3) + cel.index(14), cel.index(6).getFullYear(), cel.index(15) + cel.index(16), cel.index(17) + cel.index(3), cel.index(6).getSeconds(), cel.index(18) + cel.index(19), cel.index(20) + cel.index(10), cel.index(21) + cel.index(10), cel.index(13).getMinutes(), cel.index(22) + cel.index(23), cel.index(24) + cel.index(3)], cel.index(25))",
+          "value": {
+            "int64Value": "13934"
+          }
+        },
+        {
+          "name": "map_index",
+          "expr": "cel.block([{\"a\": 2}, cel.index(0)[\"a\"], cel.index(1) * cel.index(1), cel.index(1) + cel.index(2)], cel.index(3))",
+          "value": {
+            "int64Value": "6"
+          }
+        },
+        {
+          "name": "nested_map_construction",
+          "expr": "cel.block([{\"b\": 1}, {\"e\": cel.index(0)}], {\"a\": cel.index(0), \"c\": cel.index(0), \"d\": cel.index(1), \"e\": cel.index(1)})",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "a"
+                  },
+                  "value": {
+                    "mapValue": {
+                      "entries": [
+                        {
+                          "key": {
+                            "stringValue": "b"
+                          },
+                          "value": {
+                            "int64Value": "1"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "stringValue": "c"
+                  },
+                  "value": {
+                    "mapValue": {
+                      "entries": [
+                        {
+                          "key": {
+                            "stringValue": "b"
+                          },
+                          "value": {
+                            "int64Value": "1"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "stringValue": "d"
+                  },
+                  "value": {
+                    "mapValue": {
+                      "entries": [
+                        {
+                          "key": {
+                            "stringValue": "e"
+                          },
+                          "value": {
+                            "mapValue": {
+                              "entries": [
+                                {
+                                  "key": {
+                                    "stringValue": "b"
+                                  },
+                                  "value": {
+                                    "int64Value": "1"
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "stringValue": "e"
+                  },
+                  "value": {
+                    "mapValue": {
+                      "entries": [
+                        {
+                          "key": {
+                            "stringValue": "e"
+                          },
+                          "value": {
+                            "mapValue": {
+                              "entries": [
+                                {
+                                  "key": {
+                                    "stringValue": "b"
+                                  },
+                                  "value": {
+                                    "int64Value": "1"
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "nested_list_construction",
+          "expr": "cel.block([[1, 2, 3, 4], [1, 2], [cel.index(1), cel.index(0)]], [1, cel.index(0), 2, cel.index(0), 5, cel.index(0), 7, cel.index(2), cel.index(1)])",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "int64Value": "1"
+                },
+                {
+                  "listValue": {
+                    "values": [
+                      {
+                        "int64Value": "1"
+                      },
+                      {
+                        "int64Value": "2"
+                      },
+                      {
+                        "int64Value": "3"
+                      },
+                      {
+                        "int64Value": "4"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "int64Value": "2"
+                },
+                {
+                  "listValue": {
+                    "values": [
+                      {
+                        "int64Value": "1"
+                      },
+                      {
+                        "int64Value": "2"
+                      },
+                      {
+                        "int64Value": "3"
+                      },
+                      {
+                        "int64Value": "4"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "int64Value": "5"
+                },
+                {
+                  "listValue": {
+                    "values": [
+                      {
+                        "int64Value": "1"
+                      },
+                      {
+                        "int64Value": "2"
+                      },
+                      {
+                        "int64Value": "3"
+                      },
+                      {
+                        "int64Value": "4"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "int64Value": "7"
+                },
+                {
+                  "listValue": {
+                    "values": [
+                      {
+                        "listValue": {
+                          "values": [
+                            {
+                              "int64Value": "1"
+                            },
+                            {
+                              "int64Value": "2"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "listValue": {
+                          "values": [
+                            {
+                              "int64Value": "1"
+                            },
+                            {
+                              "int64Value": "2"
+                            },
+                            {
+                              "int64Value": "3"
+                            },
+                            {
+                              "int64Value": "4"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "listValue": {
+                    "values": [
+                      {
+                        "int64Value": "1"
+                      },
+                      {
+                        "int64Value": "2"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "select",
+          "expr": "cel.block([msg.single_int64, cel.index(0) + cel.index(0)], cel.index(1))",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "singleInt32": 5,
+                  "singleInt64": "3",
+                  "oneofType": {
+                    "payload": {
+                      "singleInt32": 8,
+                      "singleInt64": "10",
+                      "mapInt32Int64": {
+                        "0": "1",
+                        "1": "5",
+                        "2": "2"
+                      },
+                      "mapStringString": {
+                        "key": "A"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "6"
+          }
+        },
+        {
+          "name": "select_nested_1",
+          "expr": "cel.block([msg.oneof_type, cel.index(0).payload, cel.index(1).single_int64, cel.index(1).single_int32, cel.index(2) + cel.index(3), cel.index(4) + cel.index(2), msg.single_int64, cel.index(5) + cel.index(6), cel.index(1).oneof_type, cel.index(8).payload, cel.index(9).single_int64, cel.index(7) + cel.index(10)], cel.index(11))",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "singleInt32": 5,
+                  "singleInt64": "3",
+                  "oneofType": {
+                    "payload": {
+                      "singleInt32": 8,
+                      "singleInt64": "10",
+                      "mapInt32Int64": {
+                        "0": "1",
+                        "1": "5",
+                        "2": "2"
+                      },
+                      "mapStringString": {
+                        "key": "A"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "31"
+          }
+        },
+        {
+          "name": "select_nested_2",
+          "expr": "cel.block([msg.oneof_type, cel.index(0).payload, cel.index(1).oneof_type, cel.index(2).payload, cel.index(3).oneof_type, cel.index(4).payload, cel.index(5).oneof_type, cel.index(6).payload, cel.index(7).single_bool, true || cel.index(8), cel.index(4).child, cel.index(10).child, cel.index(11).payload, cel.index(12).single_bool], cel.index(9) || cel.index(13))",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "singleInt32": 5,
+                  "singleInt64": "3",
+                  "oneofType": {
+                    "payload": {
+                      "singleInt32": 8,
+                      "singleInt64": "10",
+                      "mapInt32Int64": {
+                        "0": "1",
+                        "1": "5",
+                        "2": "2"
+                      },
+                      "mapStringString": {
+                        "key": "A"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "select_nested_message_map_index_1",
+          "expr": "cel.block([msg.oneof_type, cel.index(0).payload, cel.index(1).map_int32_int64, cel.index(2)[1], cel.index(3) + cel.index(3), cel.index(4) + cel.index(3)], cel.index(5))",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "singleInt32": 5,
+                  "singleInt64": "3",
+                  "oneofType": {
+                    "payload": {
+                      "singleInt32": 8,
+                      "singleInt64": "10",
+                      "mapInt32Int64": {
+                        "0": "1",
+                        "1": "5",
+                        "2": "2"
+                      },
+                      "mapStringString": {
+                        "key": "A"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "15"
+          }
+        },
+        {
+          "name": "select_nested_message_map_index_2",
+          "expr": "cel.block([msg.oneof_type, cel.index(0).payload, cel.index(1).map_int32_int64, cel.index(2)[0], cel.index(2)[1], cel.index(3) + cel.index(4), cel.index(2)[2], cel.index(5) + cel.index(6)], cel.index(7))",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "singleInt32": 5,
+                  "singleInt64": "3",
+                  "oneofType": {
+                    "payload": {
+                      "singleInt32": 8,
+                      "singleInt64": "10",
+                      "mapInt32Int64": {
+                        "0": "1",
+                        "1": "5",
+                        "2": "2"
+                      },
+                      "mapStringString": {
+                        "key": "A"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "8"
+          }
+        },
+        {
+          "name": "ternary",
+          "expr": "cel.block([msg.single_int64, cel.index(0) > 0, cel.index(1) ? cel.index(0) : 0], cel.index(2))",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "singleInt32": 5,
+                  "singleInt64": "3",
+                  "oneofType": {
+                    "payload": {
+                      "singleInt32": 8,
+                      "singleInt64": "10",
+                      "mapInt32Int64": {
+                        "0": "1",
+                        "1": "5",
+                        "2": "2"
+                      },
+                      "mapStringString": {
+                        "key": "A"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "3"
+          }
+        },
+        {
+          "name": "nested_ternary",
+          "expr": "cel.block([msg.single_int64, msg.single_int32, cel.index(0) > 0, cel.index(1) > 0, cel.index(0) + cel.index(1), cel.index(3) ? cel.index(4) : 0, cel.index(2) ? cel.index(5) : 0], cel.index(6))",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "singleInt32": 5,
+                  "singleInt64": "3",
+                  "oneofType": {
+                    "payload": {
+                      "singleInt32": 8,
+                      "singleInt64": "10",
+                      "mapInt32Int64": {
+                        "0": "1",
+                        "1": "5",
+                        "2": "2"
+                      },
+                      "mapStringString": {
+                        "key": "A"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "8"
+          }
+        },
+        {
+          "name": "multiple_macros_1",
+          "expr": "cel.block([[1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) > 0), size([cel.index(0)]), [2].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) > 1), size([cel.index(2)])], cel.index(1) + cel.index(1) + cel.index(3) + cel.index(3))",
+          "value": {
+            "int64Value": "4"
+          }
+        },
+        {
+          "name": "multiple_macros_2",
+          "expr": "cel.block([[1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) > 0), [cel.index(0)], ['a'].exists(cel.iterVar(0, 1), cel.iterVar(0, 1) == 'a'), [cel.index(2)]], cel.index(1) + cel.index(1) + cel.index(3) + cel.index(3))",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "boolValue": true
+                },
+                {
+                  "boolValue": true
+                },
+                {
+                  "boolValue": true
+                },
+                {
+                  "boolValue": true
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "multiple_macros_3",
+          "expr": "cel.block([[1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) > 0)], cel.index(0) && cel.index(0) && [1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) > 1) && [2].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) > 1))",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "nested_macros_1",
+          "expr": "cel.block([[1, 2, 3]], cel.index(0).map(cel.iterVar(0, 0), cel.index(0).map(cel.iterVar(1, 0), cel.iterVar(1, 0) + 1)))",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "listValue": {
+                    "values": [
+                      {
+                        "int64Value": "2"
+                      },
+                      {
+                        "int64Value": "3"
+                      },
+                      {
+                        "int64Value": "4"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "listValue": {
+                    "values": [
+                      {
+                        "int64Value": "2"
+                      },
+                      {
+                        "int64Value": "3"
+                      },
+                      {
+                        "int64Value": "4"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "listValue": {
+                    "values": [
+                      {
+                        "int64Value": "2"
+                      },
+                      {
+                        "int64Value": "3"
+                      },
+                      {
+                        "int64Value": "4"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "nested_macros_2",
+          "expr": "[1, 2].map(cel.iterVar(0, 0), [1, 2, 3].filter(cel.iterVar(1, 0), cel.iterVar(1, 0) == cel.iterVar(0, 0)))",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "listValue": {
+                    "values": [
+                      {
+                        "int64Value": "1"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "listValue": {
+                    "values": [
+                      {
+                        "int64Value": "2"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "adjacent_macros",
+          "expr": "cel.block([[1, 2, 3], cel.index(0).map(cel.iterVar(0, 0), cel.index(0).map(cel.iterVar(1, 0), cel.iterVar(1, 0) + 1))], cel.index(1) == cel.index(1))",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "macro_shadowed_variable_1",
+          "expr": "cel.block([x - 1, cel.index(0) > 3], [cel.index(1) ? cel.index(0) : 5].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) - 1 > 3) || cel.index(1))",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "primitive": "INT64"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "int64Value": "5"
+              }
+            }
+          },
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "macro_shadowed_variable_2",
+          "expr": "['foo', 'bar'].map(cel.iterVar(1, 0), [cel.iterVar(1, 0) + cel.iterVar(1, 0), cel.iterVar(1, 0) + cel.iterVar(1, 0)]).map(cel.iterVar(0, 0), [cel.iterVar(0, 0) + cel.iterVar(0, 0), cel.iterVar(0, 0) + cel.iterVar(0, 0)])",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "primitive": "INT64"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "int64Value": "5"
+              }
+            }
+          },
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "listValue": {
+                    "values": [
+                      {
+                        "listValue": {
+                          "values": [
+                            {
+                              "stringValue": "foofoo"
+                            },
+                            {
+                              "stringValue": "foofoo"
+                            },
+                            {
+                              "stringValue": "foofoo"
+                            },
+                            {
+                              "stringValue": "foofoo"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "listValue": {
+                          "values": [
+                            {
+                              "stringValue": "foofoo"
+                            },
+                            {
+                              "stringValue": "foofoo"
+                            },
+                            {
+                              "stringValue": "foofoo"
+                            },
+                            {
+                              "stringValue": "foofoo"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "listValue": {
+                    "values": [
+                      {
+                        "listValue": {
+                          "values": [
+                            {
+                              "stringValue": "barbar"
+                            },
+                            {
+                              "stringValue": "barbar"
+                            },
+                            {
+                              "stringValue": "barbar"
+                            },
+                            {
+                              "stringValue": "barbar"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "listValue": {
+                          "values": [
+                            {
+                              "stringValue": "barbar"
+                            },
+                            {
+                              "stringValue": "barbar"
+                            },
+                            {
+                              "stringValue": "barbar"
+                            },
+                            {
+                              "stringValue": "barbar"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "inclusion_list",
+          "expr": "cel.block([[1, 2, 3], 1 in cel.index(0), 2 in cel.index(0), cel.index(1) && cel.index(2), [3, cel.index(0)], 3 in cel.index(4), cel.index(5) && cel.index(1)], cel.index(3) && cel.index(6))",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "inclusion_map",
+          "expr": "cel.block([{true: false}, {\"a\": 1, 2: cel.index(0), 3: cel.index(0)}], 2 in cel.index(1))",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "presence_test",
+          "expr": "cel.block([{\"a\": true}, has(cel.index(0).a), cel.index(0)[\"a\"]], cel.index(1) && cel.index(2))",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "presence_test_2",
+          "expr": "cel.block([{\"a\": true}, has(cel.index(0).a)], cel.index(1) && cel.index(1))",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "presence_test_with_ternary",
+          "expr": "cel.block([msg.oneof_type, has(cel.index(0).payload), cel.index(0).payload, cel.index(2).single_int64, cel.index(1) ? cel.index(3) : 0], cel.index(4))",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "singleInt32": 5,
+                  "singleInt64": "3",
+                  "oneofType": {
+                    "payload": {
+                      "singleInt32": 8,
+                      "singleInt64": "10",
+                      "mapInt32Int64": {
+                        "0": "1",
+                        "1": "5",
+                        "2": "2"
+                      },
+                      "mapStringString": {
+                        "key": "A"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "10"
+          }
+        },
+        {
+          "name": "presence_test_with_ternary_2",
+          "expr": "cel.block([msg.oneof_type, cel.index(0).payload, cel.index(1).single_int64, has(cel.index(0).payload), cel.index(2) * 0, cel.index(3) ? cel.index(2) : cel.index(4)], cel.index(5))",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "singleInt32": 5,
+                  "singleInt64": "3",
+                  "oneofType": {
+                    "payload": {
+                      "singleInt32": 8,
+                      "singleInt64": "10",
+                      "mapInt32Int64": {
+                        "0": "1",
+                        "1": "5",
+                        "2": "2"
+                      },
+                      "mapStringString": {
+                        "key": "A"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "10"
+          }
+        },
+        {
+          "name": "presence_test_with_ternary_3",
+          "expr": "cel.block([msg.oneof_type, cel.index(0).payload, cel.index(1).single_int64, has(cel.index(1).single_int64), cel.index(2) * 0, cel.index(3) ? cel.index(2) : cel.index(4)], cel.index(5))",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "singleInt32": 5,
+                  "singleInt64": "3",
+                  "oneofType": {
+                    "payload": {
+                      "singleInt32": 8,
+                      "singleInt64": "10",
+                      "mapInt32Int64": {
+                        "0": "1",
+                        "1": "5",
+                        "2": "2"
+                      },
+                      "mapStringString": {
+                        "key": "A"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "10"
+          }
+        },
+        {
+          "name": "presence_test_with_ternary_nested",
+          "expr": "cel.block([msg.oneof_type, cel.index(0).payload, cel.index(1).map_string_string, has(msg.oneof_type), has(cel.index(0).payload), cel.index(3) && cel.index(4), has(cel.index(1).single_int64), cel.index(5) && cel.index(6), has(cel.index(1).map_string_string), has(cel.index(2).key), cel.index(8) && cel.index(9), cel.index(2).key, cel.index(11) == \"A\", cel.index(10) ? cel.index(12) : false], cel.index(7) ? cel.index(13) : false)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "singleInt32": 5,
+                  "singleInt64": "3",
+                  "oneofType": {
+                    "payload": {
+                      "singleInt32": 8,
+                      "singleInt64": "10",
+                      "mapInt32Int64": {
+                        "0": "1",
+                        "1": "5",
+                        "2": "2"
+                      },
+                      "mapStringString": {
+                        "key": "A"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "optional_list",
+          "expr": "cel.block([optional.none(), [?cel.index(0), ?optional.of(opt_x)], [5], [10, ?cel.index(0), cel.index(1), cel.index(1)], [10, cel.index(2), cel.index(2)]], cel.index(3) == cel.index(4))",
+          "typeEnv": [
+            {
+              "name": "opt_x",
+              "ident": {
+                "type": {
+                  "primitive": "INT64"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "opt_x": {
+              "value": {
+                "int64Value": "5"
+              }
+            }
+          },
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "optional_map",
+          "expr": "cel.block([optional.of(\"hello\"), {?\"hello\": cel.index(0)}, cel.index(1)[\"hello\"], cel.index(2) + cel.index(2)], cel.index(3) == \"hellohello\")",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "optional_map_chained",
+          "expr": "cel.block([{\"key\": \"test\"}, optional.of(\"test\"), {?\"key\": cel.index(1)}, cel.index(2)[?\"bogus\"], cel.index(0)[?\"bogus\"], cel.index(3).or(cel.index(4)), cel.index(0)[\"key\"], cel.index(5).orValue(cel.index(6))], cel.index(7))",
+          "value": {
+            "stringValue": "test"
+          }
+        },
+        {
+          "name": "optional_message",
+          "expr": "cel.block([optional.ofNonZeroValue(1), optional.of(4), TestAllTypes{?single_int64: cel.index(0), ?single_int32: cel.index(1)}, cel.index(2).single_int32, cel.index(2).single_int64, cel.index(3) + cel.index(4)], cel.index(5))",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "int64Value": "5"
+          }
+        },
+        {
+          "name": "call",
+          "expr": "cel.block([\"h\" + \"e\", cel.index(0) + \"l\", cel.index(1) + \"l\", cel.index(2) + \"o\", cel.index(3) + \" world\"], cel.index(4).matches(cel.index(3)))",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/comparisons.json
+++ b/packages/cel-spec/src/testdata/json/comparisons.json
@@ -1,0 +1,3271 @@
+{
+  "name": "comparisons",
+  "description": "Tests for boolean-valued functions and operators.",
+  "section": [
+    {
+      "name": "eq_literal",
+      "description": "Literals comparison on _==_",
+      "test": [
+        {
+          "name": "eq_int",
+          "expr": "1 == 1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_int",
+          "expr": "-1 == 1",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_int_uint",
+          "expr": "dyn(1) == 1u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_int_uint",
+          "expr": "dyn(2) == 1u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_int_double",
+          "expr": "dyn(1) == 1.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_int_double",
+          "expr": "dyn(2) == 1.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_uint",
+          "expr": "2u == 2u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_uint",
+          "expr": "1u == 2u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_uint_int",
+          "expr": "dyn(1u) == 1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_uint_int",
+          "expr": "dyn(2u) == 1",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_uint_double",
+          "expr": "dyn(1u) == 1.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_uint_double",
+          "expr": "dyn(2u) == 1.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_double",
+          "expr": "1.0 == 1.0e+0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_double",
+          "expr": "-1.0 == 1.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_double_nan",
+          "expr": "0.0/0.0 == 0.0/0.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_int_double_nan",
+          "expr": "dyn(1) == 0.0/0.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_uint_double_nan",
+          "expr": "dyn(1u) == 0.0/0.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_double_int",
+          "expr": "dyn(1.0) == 1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_double_int",
+          "expr": "dyn(2.0) == 1",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_double_uint",
+          "expr": "dyn(1.0) == 1u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_double_uint",
+          "expr": "dyn(2.0) == 1u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_string",
+          "expr": "'' == \"\"",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_string",
+          "expr": "'a' == 'b'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_raw_string",
+          "expr": "'abc' == r'abc'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_string_case",
+          "expr": "'abc' == 'ABC'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_string_unicode",
+          "expr": "'ίσος' == 'ίσος'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_string_unicode_ascii",
+          "expr": "'a' == 'à'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "no_string_normalization",
+          "description": "Should not normalize Unicode.",
+          "expr": "'Am\\u00E9lie' == 'Ame\\u0301lie'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_null",
+          "expr": "null == null",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_bool",
+          "expr": "true == true",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_bool",
+          "expr": "false == true",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_bytes",
+          "description": "Test bytes literal equality with encoding",
+          "expr": "b'ÿ' == b'\\303\\277'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_bytes",
+          "expr": "b'abc' == b'abcd'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_list_empty",
+          "expr": "[] == []",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_list_null",
+          "expr": "[null] == [null]",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_list_null",
+          "expr": "['1', '2', null] == ['1', '2', '3']",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_list_numbers",
+          "expr": "[1, 2, 3] == [1, 2, 3]",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_list_mixed_type_numbers",
+          "expr": "[1.0, 2.0, 3] == [1u, 2, 3u]",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_list_mixed_type_numbers",
+          "expr": "[1.0, 2.1] == [1u, 2]",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_list_order",
+          "expr": "[1, 2, 3] == [1, 3, 2]",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_list_string_case",
+          "expr": "['case'] == ['cAse']",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_list_length",
+          "expr": "['one'] == [2, 3]",
+          "disableCheck": true,
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_list_false_vs_types",
+          "expr": "[1, 'dos', 3] == [1, 2, 4]",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_map_empty",
+          "expr": "{} == {}",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_map_null",
+          "expr": "{'k': null} == {'k': null}",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_map_null",
+          "expr": "{'k': 1, 'j': 2} == {'k': 1, 'j': null}",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_map_onekey",
+          "expr": "{'k':'v'} == {\"k\":\"v\"}",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_map_double_value",
+          "expr": "{'k':1.0} == {'k':1e+0}",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_map_mixed_type_numbers",
+          "expr": "{1: 1.0, 2u: 3u} == {1u: 1, 2: 3.0}",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_map_value",
+          "expr": "{'k':'v'} == {'k':'v1'}",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_map_extra_key",
+          "expr": "{'k':'v','k1':'v1'} == {'k':'v'}",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_map_key_order",
+          "expr": "{'k1':'v1','k2':'v2'} == {'k2':'v2','k1':'v1'}",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_map_key_casing",
+          "expr": "{'key':'value'} == {'Key':'value'}",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_map_false_vs_types",
+          "expr": "{'k1': 1, 'k2': 'dos', 'k3': 3} == {'k1': 1, 'k2': 2, 'k3': 4}",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_mixed_types",
+          "expr": "1.0 == 1",
+          "disableCheck": true,
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_list_elem_mixed_types",
+          "expr": "[1] == [1.0]",
+          "disableCheck": true,
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_map_value_mixed_types",
+          "expr": "{'k':'v', 1:1} == {'k':'v', 1:'v1'}",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_dyn_json_null",
+          "expr": "dyn(google.protobuf.Value{}) == null",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_dyn_bool_null",
+          "expr": "dyn(false) == null",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_dyn_bytes_null",
+          "expr": "dyn(b'') == null",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_dyn_double_null",
+          "expr": "dyn(2.1) == null",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_dyn_duration_null",
+          "expr": "dyn(duration('0s')) == null",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_dyn_int_null",
+          "expr": "dyn(1) == null",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_dyn_list_null",
+          "expr": "dyn([]) == null",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_dyn_map_null",
+          "expr": "dyn({}) == null",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_dyn_proto2_msg_null",
+          "expr": "dyn(TestAllTypes{}) == null",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_dyn_proto3_msg_null",
+          "expr": "dyn(TestAllTypes{}) == null",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_dyn_string_null",
+          "expr": "dyn('') == null",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_dyn_timestamp_null",
+          "expr": "dyn(timestamp(0)) == null",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_list_elem_null",
+          "expr": "[1, 2, null] == [1, null, 3]",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_map_value_null",
+          "expr": "{1:'hello', 2:'world'} == {1:'goodbye', 2:null}",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_dyn_int_uint",
+          "expr": "dyn(1) == 1u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_dyn_int_double",
+          "expr": "dyn(1) == 1.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_dyn_uint_int",
+          "expr": "dyn(1u) == 1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_dyn_uint_double",
+          "expr": "dyn(1u) == 1.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_dyn_double_int",
+          "expr": "dyn(1.0) == 1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_dyn_double_uint",
+          "expr": "dyn(1.0) == 1u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_eq_dyn_int_uint",
+          "expr": "dyn(1) == 2u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_dyn_int_double",
+          "expr": "dyn(1) == 2.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_dyn_uint_int",
+          "expr": "dyn(1u) == 2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_dyn_uint_double",
+          "expr": "dyn(1u) == 120",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_dyn_double_int",
+          "expr": "dyn(1.0) == 2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_eq_dyn_double_uint",
+          "expr": "dyn(1.0) == 2u",
+          "value": {
+            "boolValue": false
+          }
+        }
+      ]
+    },
+    {
+      "name": "eq_wrapper",
+      "description": "Wrapper type comparison on _==_. Wrapper types treated as boxed primitives when they appear on message fields. An unset wrapper field should be treated as null. The tests show the distinction between unset, empty, and set equality behavior.",
+      "test": [
+        {
+          "name": "eq_bool",
+          "expr": "google.protobuf.BoolValue{value: true} == true",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_bool_empty",
+          "expr": "google.protobuf.BoolValue{} == false",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_bool_not_null",
+          "expr": "google.protobuf.BoolValue{} != null",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_bool_proto2_null",
+          "expr": "TestAllTypes{}.single_bool_wrapper == null",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_bool_proto3_null",
+          "expr": "TestAllTypes{}.single_bool_wrapper == null",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_bytes",
+          "expr": "google.protobuf.BytesValue{value: b'set'} == b'set'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_bytes_empty",
+          "expr": "google.protobuf.BytesValue{} == b''",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_bytes_not_null",
+          "expr": "google.protobuf.BytesValue{} != null",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_bytes_proto2_null",
+          "expr": "TestAllTypes{}.single_bytes_wrapper == null",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_bytes_proto3_null",
+          "expr": "TestAllTypes{}.single_bytes_wrapper == null",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_double",
+          "expr": "google.protobuf.DoubleValue{value: -1.175494e-40} == -1.175494e-40",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_double_empty",
+          "expr": "google.protobuf.DoubleValue{} == 0.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_double_not_null",
+          "expr": "google.protobuf.DoubleValue{} != null",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_double_proto2_null",
+          "expr": "TestAllTypes{}.single_double_wrapper == null",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_double_proto3_null",
+          "expr": "TestAllTypes{}.single_double_wrapper == null",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_float",
+          "expr": "google.protobuf.FloatValue{value: -1.5} == -1.5",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_float_empty",
+          "expr": "google.protobuf.FloatValue{} == 0.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_float_not_null",
+          "expr": "google.protobuf.FloatValue{} != null",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_float_proto2_null",
+          "expr": "TestAllTypes{}.single_float_wrapper == null",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_float_proto3_null",
+          "expr": "TestAllTypes{}.single_float_wrapper == null",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_int32",
+          "expr": "google.protobuf.Int32Value{value: 123} == 123",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_int32_empty",
+          "expr": "google.protobuf.Int32Value{} == 0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_int32_not_null",
+          "expr": "google.protobuf.Int32Value{} != null",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_int32_proto2_null",
+          "expr": "TestAllTypes{}.single_int32_wrapper == null",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_int32_proto3_null",
+          "expr": "TestAllTypes{}.single_int32_wrapper == null",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_int64",
+          "expr": "google.protobuf.Int64Value{value: 2147483650} == 2147483650",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_int64_empty",
+          "expr": "google.protobuf.Int64Value{} == 0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_int64_not_null",
+          "expr": "google.protobuf.Int64Value{} != null",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_int64_proto2_null",
+          "expr": "TestAllTypes{}.single_int64_wrapper == null",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_int64_proto3_null",
+          "expr": "TestAllTypes{}.single_int64_wrapper == null",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_string",
+          "expr": "google.protobuf.StringValue{value: 'set'} == 'set'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_string_empty",
+          "expr": "google.protobuf.StringValue{} == ''",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_string_not_null",
+          "expr": "google.protobuf.StringValue{} != null",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_string_proto2_null",
+          "expr": "TestAllTypes{}.single_string_wrapper == null",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_string_proto3_null",
+          "expr": "TestAllTypes{}.single_string_wrapper == null",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_uint32",
+          "expr": "google.protobuf.UInt32Value{value: 42u} == 42u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_uint32_empty",
+          "expr": "google.protobuf.UInt32Value{} == 0u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_uint32_not_null",
+          "expr": "google.protobuf.UInt32Value{} != null",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_uint32_proto2_null",
+          "expr": "TestAllTypes{}.single_uint32_wrapper == null",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_uint32_proto3_null",
+          "expr": "TestAllTypes{}.single_uint32_wrapper == null",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_uint64",
+          "expr": "google.protobuf.UInt64Value{value: 4294967296u} == 4294967296u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_uint64_empty",
+          "expr": "google.protobuf.UInt64Value{} == 0u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_uint64_not_null",
+          "expr": "google.protobuf.UInt64Value{} != null",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_uint64_proto2_null",
+          "expr": "TestAllTypes{}.single_uint64_wrapper == null",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_uint64_proto3_null",
+          "expr": "TestAllTypes{}.single_uint64_wrapper == null",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_proto2",
+          "expr": "TestAllTypes{single_int64: 1234, single_string: '1234'} == TestAllTypes{single_int64: 1234, single_string: '1234'}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_proto3",
+          "expr": "TestAllTypes{single_int64: 1234, single_string: '1234'} == TestAllTypes{single_int64: 1234, single_string: '1234'}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_proto2_missing_fields_neq",
+          "expr": "TestAllTypes{single_int64: 1234} == TestAllTypes{single_string: '1234'}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_proto3_missing_fields_neq",
+          "expr": "TestAllTypes{single_int64: 1234} == TestAllTypes{single_string: '1234'}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_proto_nan_equal",
+          "description": "For proto equality, fields with NaN value are treated as not equal.",
+          "expr": "TestAllTypes{single_double: double('NaN')} == TestAllTypes{single_double: double('NaN')}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_proto_different_types",
+          "description": "At runtime, differently typed messages are treated as not equal.",
+          "expr": "dyn(TestAllTypes{}) == dyn(NestedTestAllTypes{})",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_proto2_any_unpack_equal",
+          "description": "Any values should be unpacked and compared.",
+          "expr": "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} == TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_proto2_any_unpack_not_equal",
+          "description": "Any values should be unpacked and compared.",
+          "expr": "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'a\\000\\000\\000\\000\\000H\\223\\300r\\0041234'}} == TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_proto2_any_unpack_bytewise_fallback_not_equal",
+          "description": "If an any field is missing its type_url, the comparison should fallback to a bytewise comparison of the serialized proto.",
+          "expr": "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} == TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_proto2_any_unpack_bytewise_fallback_equal",
+          "description": "If an any field is missing its type_url, the comparison should fallback to a bytewise comparison of the serialized proto.",
+          "expr": "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} == TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_proto3_any_unpack_equal",
+          "description": "Any values should be unpacked and compared.",
+          "expr": "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} == TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_proto3_any_unpack_not_equal",
+          "description": "Any values should be unpacked and compared.",
+          "expr": "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'a\\000\\000\\000\\000\\000H\\223\\300r\\0041234'}} == TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_proto3_any_unpack_bytewise_fallback_not_equal",
+          "description": "If an any field is missing its type_url, the comparison should fallback to a bytewise comparison of the serialized proto.",
+          "expr": "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} == TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "eq_proto3_any_unpack_bytewise_fallback_equal",
+          "description": "If an any field is missing its type_url, the comparison should fallback to a bytewise comparison of the serialized proto.",
+          "expr": "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} == TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "ne_literal",
+      "description": "Literals comparison on _!=_",
+      "test": [
+        {
+          "name": "ne_int",
+          "expr": "24 != 42",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_int",
+          "expr": "1 != 1",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_int_double",
+          "expr": "dyn(24) != 24.1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_int_double",
+          "expr": "dyn(1) != 1.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_int_uint",
+          "expr": "dyn(24) != 42u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_int_uint",
+          "expr": "dyn(1) != 1u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_uint",
+          "expr": "1u != 2u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_uint",
+          "expr": "99u != 99u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_uint_double",
+          "expr": "dyn(1u) != 2.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_uint_double",
+          "expr": "dyn(99u) != 99.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_double",
+          "expr": "9.0e+3 != 9001.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_double_nan",
+          "expr": "0.0/0.0 != 0.0/0.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_int_double_nan",
+          "expr": "dyn(1) != 0.0/0.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_uint_double_nan",
+          "expr": "dyn(1u) != 0.0/0.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_double",
+          "expr": "1.0 != 1e+0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_double_int",
+          "expr": "dyn(9000) != 9001.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_double_int",
+          "expr": "dyn(1) != 1e+0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_double_uint",
+          "expr": "dyn(9000u) != 9001.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_double_uint",
+          "expr": "dyn(1u) != 1e+0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_double_nan",
+          "expr": "0.0/0.0 != 0.0/0.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "ne_string",
+          "expr": "'abc' != ''",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_string",
+          "expr": "'abc' != 'abc'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_string_unicode",
+          "expr": "'résumé' != 'resume'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_string_unicode",
+          "expr": "'ίδιο' != 'ίδιο'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_bytes",
+          "expr": "b'\\x00\\xFF' != b'ÿ'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_bytes",
+          "expr": "b'\\303\\277' != b'ÿ'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_bool",
+          "expr": "false != true",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_bool",
+          "expr": "true != true",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_ne_null",
+          "description": "null can only be equal to null, or else it won't match",
+          "expr": "null != null",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_list_empty",
+          "expr": "[] != [1]",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_list_empty",
+          "expr": "[] != []",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_list_bool",
+          "expr": "[true, false, true] != [true, true, false]",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_list_bool",
+          "expr": "[false, true] != [false, true]",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_ne_list_of_list",
+          "expr": "[[]] != [[]]",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_map_by_value",
+          "expr": "{'k':'v'} != {'k':'v1'}",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "ne_map_by_key",
+          "expr": "{'k':true} != {'k1':true}",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_ne_map_int_to_float",
+          "expr": "{1:1.0} != {1:1.0}",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_ne_map_key_order",
+          "expr": "{'a':'b','c':'d'} != {'c':'d','a':'b'}",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_mixed_types",
+          "expr": "2u != 2",
+          "disableCheck": true,
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_proto2",
+          "expr": "TestAllTypes{single_int64: 1234, single_string: '1234'} != TestAllTypes{single_int64: 1234, single_string: '1234'}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_proto3",
+          "expr": "TestAllTypes{single_int64: 1234, single_string: '1234'} != TestAllTypes{single_int64: 1234, single_string: '1234'}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_proto2_missing_fields_neq",
+          "expr": "TestAllTypes{single_int64: 1234} != TestAllTypes{single_string: '1234'}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "ne_proto3_missing_fields_neq",
+          "expr": "TestAllTypes{single_int64: 1234} != TestAllTypes{single_string: '1234'}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "ne_proto_nan_not_equal",
+          "description": "For proto equality, NaN field values are not considered equal.",
+          "expr": "TestAllTypes{single_double: double('NaN')} != TestAllTypes{single_double: double('NaN')}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "ne_proto_different_types",
+          "description": "At runtime, comparing differently typed messages is false.",
+          "expr": "dyn(TestAllTypes{}) != dyn(NestedTestAllTypes{})",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "ne_proto2_any_unpack",
+          "description": "Any values should be unpacked and compared.",
+          "expr": "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} != TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_proto2_any_unpack_bytewise_fallback",
+          "description": "If an any field is missing its type_url, the comparison should fallback to a bytewise comparison of the serialized proto.",
+          "expr": "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} != TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "ne_proto3_any_unpack",
+          "description": "Any values should be unpacked and compared.",
+          "expr": "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} != TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "ne_proto3_any_unpack_bytewise_fallback",
+          "description": "If an any field is missing its type_url, the comparison should fallback to a bytewise comparison of the serialized proto.",
+          "expr": "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} != TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "lt_literal",
+      "description": "Literals comparison on _<_. (a < b) == (b > a) == !(a >= b) == !(b <= a)",
+      "test": [
+        {
+          "name": "lt_int",
+          "expr": "-1 < 0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lt_int",
+          "expr": "0 < 0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lt_uint",
+          "expr": "0u < 1u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lt_uint",
+          "expr": "2u < 2u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lt_double",
+          "expr": "1.0 < 1.0000001",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lt_double",
+          "description": "Following IEEE 754, negative zero compares equal to zero",
+          "expr": "-0.0 < 0.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lt_string",
+          "expr": "'a' < 'b'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lt_string_empty_to_nonempty",
+          "expr": "'' < 'a'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lt_string_case",
+          "expr": "'Abc' < 'aBC'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lt_string_length",
+          "expr": "'abc' < 'abcd'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lt_string_diacritical_mark_sensitive",
+          "description": "Verifies that the we're not using a string comparison function that strips diacritical marks (á)",
+          "expr": "'a' < '\\u00E1'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lt_string_empty",
+          "expr": "'' < ''",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lt_string_same",
+          "expr": "'abc' < 'abc'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lt_string_case_length",
+          "expr": "'a' < 'AB'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "unicode_order_lexical",
+          "description": "Compare the actual code points of the string, instead of decomposing ế into 'e' plus accent modifiers.",
+          "expr": "'f' < '\\u1EBF'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lt_bytes",
+          "expr": "b'a' < b'b'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lt_bytes_same",
+          "expr": "b'abc' < b'abc'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lt_bytes_width",
+          "expr": "b'á' < b'b'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lt_bool_false_first",
+          "expr": "false < true",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lt_bool_same",
+          "expr": "true < true",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lt_bool_true_first",
+          "expr": "true < false",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lt_list_unsupported",
+          "expr": "[0] < [1]",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "lt_map_unsupported",
+          "expr": "{0:'a'} < {1:'b'}",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "lt_null_unsupported",
+          "description": "Ensure _<_ doesn't have a binding for null",
+          "expr": "null < null",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "lt_mixed_types_error",
+          "expr": "'foo' < 1024",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "lt_dyn_int_uint",
+          "expr": "dyn(1) < 2u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lt_dyn_int_double",
+          "expr": "dyn(1) < 2.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lt_dyn_uint_int",
+          "expr": "dyn(1u) < 2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lt_dyn_uint_double",
+          "expr": "dyn(1u) < 2.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lt_dyn_double_int",
+          "expr": "dyn(1.0) < 2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lt_dyn_double_uint",
+          "expr": "dyn(1.0) < 2u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lt_dyn_int_uint",
+          "expr": "dyn(1) < 1u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lt_dyn_int_double",
+          "expr": "dyn(1) < 1.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lt_dyn_uint_int",
+          "expr": "dyn(1u) < 1",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lt_dyn_uint_double",
+          "expr": "dyn(1u) < 1.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lt_dyn_double_int",
+          "expr": "dyn(1.0) < 1",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lt_dyn_double_uint",
+          "expr": "dyn(1.0) < 1u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lt_dyn_int_big_uint",
+          "expr": "dyn(1) < 9223372036854775808u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lt_dyn_small_int_uint",
+          "expr": "dyn(-1) < 0u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lt_dyn_int_big_lossy_double",
+          "expr": "dyn(9223372036854775807) < 9223372036854775808.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lt_dyn_int_big_lossy_double",
+          "expr": "dyn(9223372036854775807) < 9223372036854777857.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lt_dyn_int_small_double",
+          "expr": "dyn(9223372036854775807) < -9223372036854777857.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lt_dyn_int_small_lossy_double",
+          "expr": "dyn(-9223372036854775808) < -9223372036854775809.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lt_dyn_uint_small_int",
+          "expr": "dyn(1u) < -9223372036854775808",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lt_dyn_big_uint_int",
+          "expr": "dyn(9223372036854775808u) < 1",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lt_dyn_uint_small_double",
+          "expr": "dyn(18446744073709551615u) < -1.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lt_dyn_uint_big_double",
+          "expr": "dyn(18446744073709551615u) < 18446744073709590000.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lt_dyn_big_double_uint",
+          "expr": "dyn(18446744073709553665.0) < 18446744073709551615u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lt_dyn_big_double_int",
+          "expr": "dyn(9223372036854775808.0) < 9223372036854775807",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lt_dyn_small_double_int",
+          "expr": "dyn(-9223372036854775809.0) < -9223372036854775808",
+          "value": {
+            "boolValue": false
+          }
+        }
+      ]
+    },
+    {
+      "name": "gt_literal",
+      "description": "Literals comparison on _>_",
+      "test": [
+        {
+          "name": "gt_int",
+          "expr": "42 > -42",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gt_int",
+          "expr": "0 > 0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gt_uint",
+          "expr": "48u > 46u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gt_uint",
+          "expr": "0u > 999u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gt_double",
+          "expr": "1e+1 > 1e+0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gt_double",
+          "expr": ".99 > 9.9e-1",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gt_string_case",
+          "expr": "'abc' > 'aBc'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gt_string_to_empty",
+          "expr": "'A' > ''",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gt_string_empty_to_empty",
+          "expr": "'' > ''",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gt_string_unicode",
+          "expr": "'α' > 'omega'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gt_bytes_one",
+          "expr": "b'\u0001' > b'\u0000'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gt_bytes_one_to_empty",
+          "expr": "b'\u0000' > b''",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gt_bytes_sorting",
+          "expr": "b'\u0000\u0001' > b'\u0001'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gt_bool_true_false",
+          "expr": "true > false",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gt_bool_false_true",
+          "expr": "false > true",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gt_bool_same",
+          "expr": "true > true",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gt_null_unsupported",
+          "expr": "null > null",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "gt_list_unsupported",
+          "expr": "[1] > [0]",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "gt_map_unsupported",
+          "expr": "{1:'b'} > {0:'a'}",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "gt_mixed_types_error",
+          "expr": "'foo' > 1024",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "gt_dyn_int_uint",
+          "expr": "dyn(2) > 1u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gt_dyn_int_double",
+          "expr": "dyn(2) > 1.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gt_dyn_uint_int",
+          "expr": "dyn(2u) > 1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gt_dyn_uint_double",
+          "expr": "dyn(2u) > 1.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gt_dyn_double_int",
+          "expr": "dyn(2.0) > 1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gt_dyn_double_uint",
+          "expr": "dyn(2.0) > 1u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gt_dyn_int_uint",
+          "expr": "dyn(1) > 1u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gt_dyn_int_double",
+          "expr": "dyn(1) > 1.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gt_dyn_uint_int",
+          "expr": "dyn(1u) > 1",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gt_dyn_uint_double",
+          "expr": "dyn(1u) > 1.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gt_dyn_double_int",
+          "expr": "dyn(1.0) > 1",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gt_dyn_double_uint",
+          "expr": "dyn(1.0) > 1u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gt_dyn_int_big_uint",
+          "expr": "dyn(1) > 9223372036854775808u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gt_dyn_small_int_uint",
+          "expr": "dyn(-1) > 0u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gt_dyn_int_big_double",
+          "expr": "dyn(9223372036854775807) > 9223372036854775808.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gt_dyn_int_small_lossy_double",
+          "description": "The conversion of the int to double is lossy and the numbers end up being equal",
+          "expr": "dyn(-9223372036854775808) > -9223372036854775809.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gt_dyn_int_small_lossy_double_greater",
+          "expr": "dyn(-9223372036854775808) > -9223372036854777857.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gt_dyn_uint_small_int",
+          "expr": "dyn(1u) > -1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gt_dyn_big_uint_int",
+          "expr": "dyn(9223372036854775808u) > 1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gt_dyn_uint_small_double",
+          "expr": "dyn(9223372036854775807u) > -1.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gt_dyn_uint_big_double",
+          "expr": "dyn(18446744073709551615u) > 18446744073709590000.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gt_dyn_big_double_uint",
+          "expr": "dyn(18446744073709553665.0) > 18446744073709551615u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gt_dyn_big_double_int",
+          "expr": "dyn(9223372036854775808.0) > 9223372036854775807",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gt_dyn_small_double_int",
+          "expr": "dyn(-9223372036854775809.0) > -9223372036854775808",
+          "value": {
+            "boolValue": false
+          }
+        }
+      ]
+    },
+    {
+      "name": "lte_literal",
+      "description": "Literals comparison on _<=_",
+      "test": [
+        {
+          "name": "lte_int_lt",
+          "expr": "0 <= 1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lte_int_eq",
+          "expr": "1 <= 1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lte_int_gt",
+          "expr": "1 <= -1",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lte_uint_lt",
+          "expr": "0u <= 1u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lte_uint_eq",
+          "expr": "1u <= 1u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lte_uint_gt",
+          "expr": "1u <= 0u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lte_double_lt",
+          "expr": "0.0 <= 0.1e-31",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lte_double_eq",
+          "expr": "0.0 <= 0e-1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lte_double_gt",
+          "expr": "1.0 <= 0.99",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lte_string_empty",
+          "expr": "'' <= ''",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lte_string_from_empty",
+          "expr": "'' <= 'a'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lte_string_to_empty",
+          "expr": "'a' <= ''",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lte_string_lexicographical",
+          "expr": "'aBc' <= 'abc'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lte_string_unicode_eq",
+          "expr": "'α' <= 'α'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lte_string_unicode_lt",
+          "expr": "'a' <= 'α'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lte_string_unicode",
+          "expr": "'α' <= 'a'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lte_bytes_empty",
+          "expr": "b'' <= b'\u0000'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lte_bytes_length",
+          "expr": "b'\u0001\u0000' <= b'\u0001'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lte_bool_false_true",
+          "expr": "false <= true",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lte_bool_false_false",
+          "expr": "false <= false",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lte_bool_true_false",
+          "expr": "true <= false",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lte_null_unsupported",
+          "expr": "null <= null",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "lte_list_unsupported",
+          "expr": "[0] <= [0]",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "lte_map_unsupported",
+          "expr": "{0:'a'} <= {1:'b'}",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "lte_mixed_types_error",
+          "expr": "'foo' <= 1024",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "lte_dyn_int_uint",
+          "expr": "dyn(1) <= 2u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lte_dyn_int_double",
+          "expr": "dyn(1) <= 2.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lte_dyn_uint_int",
+          "expr": "dyn(1u) <= 2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lte_dyn_uint_double",
+          "expr": "dyn(1u) <= 2.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lte_dyn_double_int",
+          "expr": "dyn(1.0) <= 2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lte_dyn_double_uint",
+          "expr": "dyn(1.0) <= 2u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lte_dyn_int_uint",
+          "expr": "dyn(2) <= 1u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lte_dyn_int_double",
+          "expr": "dyn(2) <= 1.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lte_dyn_uint_int",
+          "expr": "dyn(2u) <= 1",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lte_dyn_uint_double",
+          "expr": "dyn(2u) <= 1.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lte_dyn_double_int",
+          "expr": "dyn(2.0) <= 1",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lte_dyn_double_uint",
+          "expr": "dyn(2.0) <= 1u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lte_dyn_int_big_uint",
+          "expr": "dyn(1) <= 9223372036854775808u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lte_dyn_small_int_uint",
+          "expr": "dyn(-1) <= 0u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lte_dyn_int_big_double",
+          "expr": "dyn(9223372036854775807) <= 9223372036854775808.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lte_dyn_int_small_lossy_double",
+          "description": "The conversion of the int to double is lossy and the numbers end up being equal",
+          "expr": "dyn(-9223372036854775808) <= -9223372036854775809.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lte_dyn_int_small_lossy_double_less",
+          "expr": "dyn(-9223372036854775808) <= -9223372036854777857.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lte_dyn_uint_small_int",
+          "expr": "dyn(1u) <= -9223372036854775808",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lte_dyn_big_uint_int",
+          "expr": "dyn(9223372036854775808u) <= 1",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_lte_dyn_uint_small_double",
+          "expr": "dyn(18446744073709551615u) <= -1.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lte_dyn_uint_big_double",
+          "expr": "dyn(18446744073709551615u) <= 18446744073709590000.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_lte_dyn_big_double_uint",
+          "expr": "dyn(18446744073709553665.0) <= 18446744073709551615u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "lte_dyn_big_double_int",
+          "expr": "dyn(9223372036854775808.0) <= 9223372036854775807",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "lte_dyn_small_double_int",
+          "expr": "dyn(-9223372036854775809.0) <= -9223372036854775808",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "gte_literal",
+      "description": "Literals comparison on _>=_",
+      "test": [
+        {
+          "name": "gte_int_gt",
+          "expr": "0 >= -1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_int_eq",
+          "expr": "999 >= 999",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gte_int_lt",
+          "expr": "999 >= 1000",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gte_uint_gt",
+          "expr": "1u >= 0u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_uint_eq",
+          "expr": "0u >= 0u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gte_uint_lt",
+          "expr": "1u >= 10u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gte_double_gt",
+          "expr": "1e+1 >= 1e+0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_double_eq",
+          "expr": "9.80665 >= 9.80665e+0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gte_double_lt",
+          "expr": "0.9999 >= 1.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gte_string_empty",
+          "expr": "'' >= ''",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_string_to_empty",
+          "expr": "'a' >= ''",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_string_empty_to_nonempty",
+          "expr": "'' >= 'a'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gte_string_length",
+          "expr": "'abcd' >= 'abc'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gte_string_lexicographical",
+          "expr": "'abc' >= 'abd'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gte_string_unicode_eq",
+          "expr": "'τ' >= 'τ'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_string_unicode_gt",
+          "expr": "'τ' >= 't'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_get_string_unicode",
+          "expr": "'t' >= 'τ'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gte_bytes_to_empty",
+          "expr": "b'\u0000' >= b''",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gte_bytes_empty_to_nonempty",
+          "expr": "b'' >= b'\u0000'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gte_bytes_samelength",
+          "expr": "b'\u0000\u0001' >= b'\u0001\u0000'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gte_bool_gt",
+          "expr": "true >= false",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_bool_eq",
+          "expr": "true >= true",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gte_bool_lt",
+          "expr": "false >= true",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gte_null_unsupported",
+          "expr": "null >= null",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "gte_list_unsupported",
+          "expr": "['y'] >= ['x']",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "gte_map_unsupported",
+          "expr": "{1:'b'} >= {0:'a'}",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "gte_mixed_types_error",
+          "expr": "'foo' >= 1.0",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "gte_dyn_int_uint",
+          "expr": "dyn(2) >= 1u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_dyn_int_double",
+          "expr": "dyn(2) >= 1.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_dyn_uint_int",
+          "expr": "dyn(2u) >= 1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_dyn_uint_double",
+          "expr": "dyn(2u) >= 1.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_dyn_double_int",
+          "expr": "dyn(2.0) >= 1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_dyn_double_uint",
+          "expr": "dyn(2.0) >= 1u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gte_dyn_int_uint",
+          "expr": "dyn(0) >= 1u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gte_dyn_int_double",
+          "expr": "dyn(0) >= 1.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gte_dyn_uint_int",
+          "expr": "dyn(0u) >= 1",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gte_dyn_uint_double",
+          "expr": "dyn(0u) >= 1.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gte_dyn_double_int",
+          "expr": "dyn(0.0) >= 1",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gte_dyn_double_uint",
+          "expr": "dyn(0.0) >= 1u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gte_dyn_int_big_uint",
+          "expr": "dyn(1) >= 9223372036854775808u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_gte_dyn_small_int_uint",
+          "expr": "dyn(-1) >= 0u",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gte_dyn_int_big_lossy_double",
+          "expr": "dyn(9223372036854775807) >= 9223372036854775808.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gte_dyn_int_big_double",
+          "expr": "dyn(9223372036854775807) >= 9223372036854777857.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gte_dyn_int_small_lossy_double_equal",
+          "description": "The conversion of the int to double is lossy and the numbers end up being equal",
+          "expr": "dyn(-9223372036854775808) >= -9223372036854775809.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_dyn_int_small_lossy_double_greater",
+          "expr": "dyn(-9223372036854775808) >= -9223372036854777857.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_dyn_uint_small_int",
+          "expr": "dyn(1u) >= -1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_dyn_big_uint_int",
+          "expr": "dyn(9223372036854775808u) >= 1",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_dyn_uint_small_double",
+          "expr": "dyn(9223372036854775807u) >= -1.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_gte_dyn_uint_big_double",
+          "expr": "dyn(18446744073709551615u) >= 18446744073709553665.0",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "gte_dyn_big_double_uint",
+          "expr": "dyn(18446744073709553665.0) >= 18446744073709551615u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_dyn_big_double_int",
+          "expr": "dyn(9223372036854775808.0) >= 9223372036854775807",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "gte_dyn_small_double_int",
+          "expr": "dyn(-9223372036854775809.0) >= -9223372036854775808",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "in_list_literal",
+      "description": "Set membership tests using list literals and the 'in' operator",
+      "test": [
+        {
+          "name": "elem_not_in_empty_list",
+          "expr": "'empty' in []",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "elem_in_list",
+          "expr": "'elem' in ['elem', 'elemA', 'elemB']",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "elem_not_in_list",
+          "expr": "'not' in ['elem1', 'elem2', 'elem3']",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "elem_in_mixed_type_list",
+          "description": "Set membership tests should succeed if the 'elem' exists in a mixed element type list.",
+          "expr": "'elem' in [1, 'elem', 2]",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "elem_in_mixed_type_list_cross_type",
+          "description": "Set membership tests should return false due to the introduction of heterogeneous-equality. Set membership via 'in' is equivalent to the macro exists() behavior.",
+          "expr": "'elem' in [1u, 'str', 2, b'bytes']",
+          "value": {
+            "boolValue": false
+          }
+        }
+      ]
+    },
+    {
+      "name": "in_map_literal",
+      "description": "Set membership tests using map literals and the 'in' operator",
+      "test": [
+        {
+          "name": "key_not_in_empty_map",
+          "expr": "'empty' in {}",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "key_in_map",
+          "expr": "'key' in {'key':'1', 'other':'2'}",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "key_not_in_map",
+          "expr": "'key' in {'lock':1, 'gate':2}",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "key_in_mixed_key_type_map",
+          "description": "Map keys are of mixed type, but since the key is present the result is true.",
+          "expr": "'key' in {3:3.0, 'key':2u}",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "key_in_mixed_key_type_map_cross_type",
+          "expr": "'key' in {1u:'str', 2:b'bytes'}",
+          "value": {
+            "boolValue": false
+          }
+        }
+      ]
+    },
+    {
+      "name": "bound",
+      "description": "Comparing bound variables with literals or other variables",
+      "test": [
+        {
+          "name": "bytes_gt_left_false",
+          "expr": "x > b'\u0000'",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "primitive": "BYTES"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "bytesValue": "AA=="
+              }
+            }
+          },
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "int_lte_right_true",
+          "expr": "123 <= x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "primitive": "INT64"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "int64Value": "124"
+              }
+            }
+          },
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "bool_lt_right_true",
+          "expr": "false < x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "primitive": "BOOL"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "boolValue": true
+              }
+            }
+          },
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "double_ne_left_false",
+          "expr": "x != 9.8",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "primitive": "DOUBLE"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "doubleValue": 9.8
+              }
+            }
+          },
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_ne_right_false",
+          "expr": "{'a':'b','c':'d'} != x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "mapType": {
+                    "keyType": {
+                      "primitive": "STRING"
+                    },
+                    "valueType": {
+                      "primitive": "STRING"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "mapValue": {
+                  "entries": [
+                    {
+                      "key": {
+                        "stringValue": "c"
+                      },
+                      "value": {
+                        "stringValue": "d"
+                      }
+                    },
+                    {
+                      "key": {
+                        "stringValue": "a"
+                      },
+                      "value": {
+                        "stringValue": "b"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "null_eq_left_true",
+          "description": "A comparison _==_ against null only binds if the type is determined to be null or we skip the type checking",
+          "expr": "x == null",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "null": null
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "nullValue": null
+              }
+            }
+          },
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "list_eq_right_false",
+          "expr": "[1, 2] == x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "listType": {
+                    "elemType": {
+                      "primitive": "INT64"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "listValue": {
+                  "values": [
+                    {
+                      "int64Value": "2"
+                    },
+                    {
+                      "int64Value": "1"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "string_gte_right_true",
+          "expr": "'abcd' >= x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "primitive": "STRING"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "stringValue": "abc"
+              }
+            }
+          },
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "uint_eq_right_false",
+          "expr": "999u == x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "primitive": "UINT64"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "uint64Value": "1000"
+              }
+            }
+          },
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "null_lt_right_no_such_overload",
+          "description": "There is no _<_ operation for null, even if both operands are null",
+          "expr": "null < x",
+          "disableCheck": true,
+          "bindings": {
+            "x": {
+              "value": {
+                "nullValue": null
+              }
+            }
+          },
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/conversions.json
+++ b/packages/cel-spec/src/testdata/json/conversions.json
@@ -1,0 +1,881 @@
+{
+  "name": "conversions",
+  "description": "Tests for type conversions.",
+  "section": [
+    {
+      "name": "bytes",
+      "description": "Conversions to bytes.",
+      "test": [
+        {
+          "name": "string_empty",
+          "expr": "bytes('')",
+          "value": {
+            "bytesValue": ""
+          }
+        },
+        {
+          "name": "string",
+          "expr": "bytes('abc')",
+          "value": {
+            "bytesValue": "YWJj"
+          }
+        },
+        {
+          "name": "string_unicode",
+          "expr": "bytes('ÿ')",
+          "value": {
+            "bytesValue": "w78="
+          }
+        },
+        {
+          "name": "string_unicode_vs_literal",
+          "expr": "bytes('\\377') == b'\\377'",
+          "value": {
+            "boolValue": false
+          }
+        }
+      ]
+    },
+    {
+      "name": "double",
+      "description": "Conversions to double.",
+      "test": [
+        {
+          "name": "int_zero",
+          "expr": "double(0)",
+          "value": {
+            "doubleValue": 0
+          }
+        },
+        {
+          "name": "int_pos",
+          "expr": "double(1000000000000)",
+          "value": {
+            "doubleValue": 1000000000000
+          }
+        },
+        {
+          "name": "int_neg",
+          "expr": "double(-1000000000000000)",
+          "value": {
+            "doubleValue": -1000000000000000
+          }
+        },
+        {
+          "name": "int_min_exact",
+          "description": "Smallest contiguous representable int (-2^53).",
+          "expr": "double(-9007199254740992)",
+          "value": {
+            "doubleValue": -9007199254740992
+          }
+        },
+        {
+          "name": "int_max_exact",
+          "description": "Largest contiguous representable int (2^53).",
+          "expr": "double(9007199254740992)",
+          "value": {
+            "doubleValue": 9007199254740992
+          }
+        },
+        {
+          "name": "int_range",
+          "description": "Largest signed 64-bit. Rounds to nearest double.",
+          "expr": "double(9223372036854775807)",
+          "value": {
+            "doubleValue": 9223372036854776000
+          }
+        },
+        {
+          "name": "uint_zero",
+          "expr": "double(0u)",
+          "value": {
+            "doubleValue": 0
+          }
+        },
+        {
+          "name": "uint_pos",
+          "expr": "double(123u)",
+          "value": {
+            "doubleValue": 123
+          }
+        },
+        {
+          "name": "uint_max_exact",
+          "description": "Largest contiguous representable int (2^53).",
+          "expr": "double(9007199254740992u)",
+          "value": {
+            "doubleValue": 9007199254740992
+          }
+        },
+        {
+          "name": "uint_range",
+          "description": "Largest unsigned 64-bit.",
+          "expr": "double(18446744073709551615u)",
+          "value": {
+            "doubleValue": 18446744073709552000
+          }
+        },
+        {
+          "name": "string_zero",
+          "expr": "double('0')",
+          "value": {
+            "doubleValue": 0
+          }
+        },
+        {
+          "name": "string_zero_dec",
+          "expr": "double('0.0')",
+          "value": {
+            "doubleValue": 0
+          }
+        },
+        {
+          "name": "string_neg_zero",
+          "expr": "double('-0.0')",
+          "value": {
+            "doubleValue": 0
+          }
+        },
+        {
+          "name": "string_no_dec",
+          "expr": "double('123')",
+          "value": {
+            "doubleValue": 123
+          }
+        },
+        {
+          "name": "string_pos",
+          "expr": "double('123.456')",
+          "value": {
+            "doubleValue": 123.456
+          }
+        },
+        {
+          "name": "string_neg",
+          "expr": "double('-987.654')",
+          "value": {
+            "doubleValue": -987.654
+          }
+        },
+        {
+          "name": "string_exp_pos_pos",
+          "expr": "double('6.02214e23')",
+          "value": {
+            "doubleValue": 6.02214e23
+          }
+        },
+        {
+          "name": "string_exp_pos_neg",
+          "expr": "double('1.38e-23')",
+          "value": {
+            "doubleValue": 1.38e-23
+          }
+        },
+        {
+          "name": "string_exp_neg_pos",
+          "expr": "double('-84.32e7')",
+          "value": {
+            "doubleValue": -843200000
+          }
+        },
+        {
+          "name": "string_exp_neg_neg",
+          "expr": "double('-5.43e-21')",
+          "value": {
+            "doubleValue": -5.43e-21
+          }
+        }
+      ]
+    },
+    {
+      "name": "dyn",
+      "description": "Tests for dyn annotation.",
+      "test": [
+        {
+          "name": "dyn_heterogeneous_list",
+          "description": "No need to disable type checking.",
+          "expr": "type(dyn([1, 'one']))",
+          "value": {
+            "typeValue": "list"
+          }
+        }
+      ]
+    },
+    {
+      "name": "int",
+      "description": "Conversions to int.",
+      "test": [
+        {
+          "name": "uint",
+          "expr": "int(42u)",
+          "value": {
+            "int64Value": "42"
+          }
+        },
+        {
+          "name": "uint_zero",
+          "expr": "int(0u)",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "uint_max_exact",
+          "expr": "int(9223372036854775807u)",
+          "value": {
+            "int64Value": "9223372036854775807"
+          }
+        },
+        {
+          "name": "uint_range",
+          "expr": "int(18446744073709551615u)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range error"
+              }
+            ]
+          }
+        },
+        {
+          "name": "double_round_neg",
+          "expr": "int(-123.456)",
+          "value": {
+            "int64Value": "-123"
+          }
+        },
+        {
+          "name": "double_truncate",
+          "expr": "int(1.9)",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "double_truncate_neg",
+          "expr": "int(-7.9)",
+          "value": {
+            "int64Value": "-7"
+          }
+        },
+        {
+          "name": "double_half_pos",
+          "expr": "int(11.5)",
+          "value": {
+            "int64Value": "11"
+          }
+        },
+        {
+          "name": "double_half_neg",
+          "expr": "int(-3.5)",
+          "value": {
+            "int64Value": "-3"
+          }
+        },
+        {
+          "name": "double_big_exact",
+          "description": "Beyond exact range (2^53), but no loss of precision (2^55).",
+          "expr": "int(double(36028797018963968))",
+          "value": {
+            "int64Value": "36028797018963968"
+          }
+        },
+        {
+          "name": "double_big_precision",
+          "description": "Beyond exact range (2^53), but loses precision (2^55 + 1).",
+          "expr": "int(double(36028797018963969))",
+          "value": {
+            "int64Value": "36028797018963968"
+          }
+        },
+        {
+          "name": "double_int_max_range",
+          "description": "The double(2^63-1) cast produces a floating point value outside the int range",
+          "expr": "int(9223372036854775807.0)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "double_int_min_range",
+          "description": "The double(-2^63) cast produces a floating point value outside the int range",
+          "expr": "int(-9223372036854775808.0)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "double_range",
+          "expr": "int(1e99)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "string",
+          "expr": "int('987')",
+          "value": {
+            "int64Value": "987"
+          }
+        },
+        {
+          "name": "timestamp",
+          "expr": "int(timestamp('2004-09-16T23:59:59Z'))",
+          "value": {
+            "int64Value": "1095379199"
+          }
+        }
+      ]
+    },
+    {
+      "name": "string",
+      "description": "Conversions to string.",
+      "test": [
+        {
+          "name": "int",
+          "expr": "string(123)",
+          "value": {
+            "stringValue": "123"
+          }
+        },
+        {
+          "name": "int_neg",
+          "expr": "string(-456)",
+          "value": {
+            "stringValue": "-456"
+          }
+        },
+        {
+          "name": "uint",
+          "expr": "string(9876u)",
+          "value": {
+            "stringValue": "9876"
+          }
+        },
+        {
+          "name": "double",
+          "expr": "string(123.456)",
+          "value": {
+            "stringValue": "123.456"
+          }
+        },
+        {
+          "name": "double_hard",
+          "expr": "string(-4.5e-3)",
+          "value": {
+            "stringValue": "-0.0045"
+          }
+        },
+        {
+          "name": "bytes",
+          "expr": "string(b'abc')",
+          "value": {
+            "stringValue": "abc"
+          }
+        },
+        {
+          "name": "bytes_unicode",
+          "expr": "string(b'\\303\\277')",
+          "value": {
+            "stringValue": "ÿ"
+          }
+        },
+        {
+          "name": "bytes_invalid",
+          "expr": "string(b'\\000\\xff')",
+          "evalError": {
+            "errors": [
+              {
+                "message": "invalid UTF-8"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "type",
+      "description": "Type reflection tests.",
+      "test": [
+        {
+          "name": "bool",
+          "expr": "type(true)",
+          "value": {
+            "typeValue": "bool"
+          }
+        },
+        {
+          "name": "bool_denotation",
+          "expr": "bool",
+          "value": {
+            "typeValue": "bool"
+          }
+        },
+        {
+          "name": "dyn_no_denotation",
+          "expr": "dyn",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "unknown variable"
+              }
+            ]
+          }
+        },
+        {
+          "name": "int",
+          "expr": "type(0)",
+          "value": {
+            "typeValue": "int"
+          }
+        },
+        {
+          "name": "int_denotation",
+          "expr": "int",
+          "value": {
+            "typeValue": "int"
+          }
+        },
+        {
+          "name": "eq_same",
+          "expr": "type(true) == type(false)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "uint",
+          "expr": "type(64u)",
+          "value": {
+            "typeValue": "uint"
+          }
+        },
+        {
+          "name": "uint_denotation",
+          "expr": "uint",
+          "value": {
+            "typeValue": "uint"
+          }
+        },
+        {
+          "name": "double",
+          "expr": "type(3.14)",
+          "value": {
+            "typeValue": "double"
+          }
+        },
+        {
+          "name": "double_denotation",
+          "expr": "double",
+          "value": {
+            "typeValue": "double"
+          }
+        },
+        {
+          "name": "null_type",
+          "expr": "type(null)",
+          "value": {
+            "typeValue": "null_type"
+          }
+        },
+        {
+          "name": "null_type_denotation",
+          "expr": "null_type",
+          "value": {
+            "typeValue": "null_type"
+          }
+        },
+        {
+          "name": "string",
+          "expr": "type('foo')",
+          "value": {
+            "typeValue": "string"
+          }
+        },
+        {
+          "name": "string_denotation",
+          "expr": "string",
+          "value": {
+            "typeValue": "string"
+          }
+        },
+        {
+          "name": "bytes",
+          "expr": "type(b'\\xff')",
+          "value": {
+            "typeValue": "bytes"
+          }
+        },
+        {
+          "name": "bytes_denotation",
+          "expr": "bytes",
+          "value": {
+            "typeValue": "bytes"
+          }
+        },
+        {
+          "name": "list",
+          "expr": "type([1, 2, 3])",
+          "value": {
+            "typeValue": "list"
+          }
+        },
+        {
+          "name": "list_denotation",
+          "expr": "list",
+          "value": {
+            "typeValue": "list"
+          }
+        },
+        {
+          "name": "lists_monomorphic",
+          "expr": "type([1, 2, 3]) == type(['one', 'two', 'three'])",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map",
+          "expr": "type({4: 16})",
+          "value": {
+            "typeValue": "map"
+          }
+        },
+        {
+          "name": "map_denotation",
+          "expr": "map",
+          "value": {
+            "typeValue": "map"
+          }
+        },
+        {
+          "name": "map_monomorphic",
+          "expr": "type({'one': 1}) == type({1: 'one'})",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_diff",
+          "expr": "type(7) == type(7u)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "neq_same",
+          "expr": "type(0.0) != type(-0.0)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "neq_diff",
+          "expr": "type(0.0) != type(0)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "meta",
+          "expr": "type(type(7)) == type(type(7u))",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "type",
+          "expr": "type(int)",
+          "value": {
+            "typeValue": "type"
+          }
+        },
+        {
+          "name": "type_denotation",
+          "expr": "type",
+          "value": {
+            "typeValue": "type"
+          }
+        },
+        {
+          "name": "type_type",
+          "expr": "type(type)",
+          "value": {
+            "typeValue": "type"
+          }
+        }
+      ]
+    },
+    {
+      "name": "uint",
+      "description": "Conversions to uint.",
+      "test": [
+        {
+          "name": "int",
+          "expr": "uint(1729)",
+          "value": {
+            "uint64Value": "1729"
+          }
+        },
+        {
+          "name": "int_max",
+          "expr": "uint(9223372036854775807)",
+          "value": {
+            "uint64Value": "9223372036854775807"
+          }
+        },
+        {
+          "name": "int_neg",
+          "expr": "uint(-1)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "double",
+          "expr": "uint(3.14159265)",
+          "value": {
+            "uint64Value": "3"
+          }
+        },
+        {
+          "name": "double_truncate",
+          "expr": "uint(1.9)",
+          "value": {
+            "uint64Value": "1"
+          }
+        },
+        {
+          "name": "double_half",
+          "expr": "uint(25.5)",
+          "value": {
+            "uint64Value": "25"
+          }
+        },
+        {
+          "name": "double_big_exact",
+          "description": "Beyond exact range (2^53), but no loss of precision (2^55).",
+          "expr": "uint(double(36028797018963968u))",
+          "value": {
+            "uint64Value": "36028797018963968"
+          }
+        },
+        {
+          "name": "double_big_precision",
+          "description": "Beyond exact range (2^53), but loses precision (2^55 + 1).",
+          "expr": "uint(double(36028797018963969u))",
+          "value": {
+            "uint64Value": "36028797018963968"
+          }
+        },
+        {
+          "name": "double_uint_max_range",
+          "description": "The exact conversion of uint max as a double does not round trip.",
+          "expr": "int(18446744073709551615.0)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "double_range_beyond_uint",
+          "expr": "uint(6.022e23)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "string",
+          "expr": "uint('300')",
+          "value": {
+            "uint64Value": "300"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bool",
+      "description": "Conversions to bool",
+      "test": [
+        {
+          "name": "string_1",
+          "expr": "bool('1')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "string_t",
+          "expr": "bool('t')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "string_true_lowercase",
+          "expr": "bool('true')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "string_true_uppercase",
+          "expr": "bool('TRUE')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "string_true_pascalcase",
+          "expr": "bool('True')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "string_0",
+          "expr": "bool('0')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "string_f",
+          "expr": "bool('f')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "string_false_lowercase",
+          "expr": "bool('false')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "string_false_uppercase",
+          "expr": "bool('FALSE')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "string_false_pascalcase",
+          "expr": "bool('False')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "string_true_badcase",
+          "expr": "bool('TrUe')",
+          "evalError": {
+            "errors": [
+              {
+                "message": "Type conversion error"
+              }
+            ]
+          }
+        },
+        {
+          "name": "string_false_badcase",
+          "expr": "bool('FaLsE')",
+          "evalError": {
+            "errors": [
+              {
+                "message": "Type conversion error"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "identity",
+      "description": "Identity functions",
+      "test": [
+        {
+          "name": "bool",
+          "expr": "bool(true)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "int",
+          "expr": "int(1)",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "uint",
+          "expr": "uint(1u)",
+          "value": {
+            "uint64Value": "1"
+          }
+        },
+        {
+          "name": "double",
+          "expr": "double(5.5)",
+          "value": {
+            "doubleValue": 5.5
+          }
+        },
+        {
+          "name": "string",
+          "expr": "string('hello')",
+          "value": {
+            "stringValue": "hello"
+          }
+        },
+        {
+          "name": "bytes",
+          "expr": "bytes(b'abc')",
+          "value": {
+            "bytesValue": "YWJj"
+          }
+        },
+        {
+          "name": "duration",
+          "expr": "duration(duration('100s')) == duration('100s')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "timestamp",
+          "expr": "timestamp(timestamp(1000000000)) == timestamp(1000000000)",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/dynamic.json
+++ b/packages/cel-spec/src/testdata/json/dynamic.json
@@ -1,0 +1,2854 @@
+{
+  "name": "dynamic",
+  "description": "Tests for 'dynamic' proto behavior, including JSON, wrapper, and Any messages.",
+  "section": [
+    {
+      "name": "int32",
+      "description": "Tests for int32 conversion.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "google.protobuf.Int32Value{value: -123}",
+          "value": {
+            "int64Value": "-123"
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "google.protobuf.Int32Value{value: -123}.value",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_zero",
+          "expr": "google.protobuf.Int32Value{}",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.Int32Value"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.Int32Value",
+                  "value": 2000000
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "2000000"
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{single_int32_wrapper: 432}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleInt32Wrapper": 432
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_zero",
+          "expr": "TestAllTypes{single_int32_wrapper: 0}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleInt32Wrapper": 0
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_max",
+          "expr": "TestAllTypes{single_int32_wrapper: 2147483647}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleInt32Wrapper": 2147483647
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_min",
+          "expr": "TestAllTypes{single_int32_wrapper: -2147483648}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleInt32Wrapper": -2147483648
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_range",
+          "expr": "TestAllTypes{single_int32_wrapper: 12345678900}",
+          "container": "cel.expr.conformance.proto2",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range error"
+              }
+            ]
+          }
+        },
+        {
+          "name": "field_read_proto2",
+          "expr": "TestAllTypes{single_int32_wrapper: 642}.single_int32_wrapper",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "int64Value": "642"
+          }
+        },
+        {
+          "name": "field_read_proto2_zero",
+          "expr": "TestAllTypes{single_int32_wrapper: 0}.single_int32_wrapper",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "field_read_proto2_unset",
+          "expr": "TestAllTypes{}.single_int32_wrapper",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "nullValue": null
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{single_int32_wrapper: -975}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleInt32Wrapper": -975
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_zero",
+          "expr": "TestAllTypes{single_int32_wrapper: 0}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleInt32Wrapper": 0
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_max",
+          "expr": "TestAllTypes{single_int32_wrapper: 2147483647}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleInt32Wrapper": 2147483647
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_min",
+          "expr": "TestAllTypes{single_int32_wrapper: -2147483648}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleInt32Wrapper": -2147483648
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_range",
+          "expr": "TestAllTypes{single_int32_wrapper: -998877665544332211}",
+          "container": "cel.expr.conformance.proto3",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range error"
+              }
+            ]
+          }
+        },
+        {
+          "name": "field_read_proto3",
+          "expr": "TestAllTypes{single_int32_wrapper: 642}.single_int32_wrapper",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "int64Value": "642"
+          }
+        },
+        {
+          "name": "field_read_proto3_zero",
+          "expr": "TestAllTypes{single_int32_wrapper: 0}.single_int32_wrapper",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "field_read_proto3_unset",
+          "expr": "TestAllTypes{}.single_int32_wrapper",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "nullValue": null
+          }
+        }
+      ]
+    },
+    {
+      "name": "int64",
+      "description": "Tests for int64 conversion.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "google.protobuf.Int64Value{value: -123}",
+          "value": {
+            "int64Value": "-123"
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "google.protobuf.Int64Value{value: -123}.value",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_zero",
+          "expr": "google.protobuf.Int64Value{}",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.Int64Value"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.Int64Value",
+                  "value": "2000000"
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "2000000"
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{single_int64_wrapper: 432}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleInt64Wrapper": "432"
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_zero",
+          "expr": "TestAllTypes{single_int64_wrapper: 0}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleInt64Wrapper": "0"
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{single_int64_wrapper: -975}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleInt64Wrapper": "-975"
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_zero",
+          "expr": "TestAllTypes{single_int64_wrapper: 0}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleInt64Wrapper": "0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "uint32",
+      "description": "Tests for uint32 conversion.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "google.protobuf.UInt32Value{value: 123u}",
+          "value": {
+            "uint64Value": "123"
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "google.protobuf.UInt32Value{value: 123u}.value",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_zero",
+          "expr": "google.protobuf.UInt32Value{}",
+          "value": {
+            "uint64Value": "0"
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.UInt32Value"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.UInt32Value",
+                  "value": 2000000
+                }
+              }
+            }
+          },
+          "value": {
+            "uint64Value": "2000000"
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{single_uint32_wrapper: 432u}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleUint32Wrapper": 432
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_zero",
+          "expr": "TestAllTypes{single_uint32_wrapper: 0u}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleUint32Wrapper": 0
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_max",
+          "expr": "TestAllTypes{single_uint32_wrapper: 4294967295u}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleUint32Wrapper": 4294967295
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_range",
+          "expr": "TestAllTypes{single_uint32_wrapper: 6111222333u}",
+          "container": "cel.expr.conformance.proto2",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range error"
+              }
+            ]
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{single_uint32_wrapper: 975u}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleUint32Wrapper": 975
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_zero",
+          "expr": "TestAllTypes{single_uint32_wrapper: 0u}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleUint32Wrapper": 0
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_max",
+          "expr": "TestAllTypes{single_uint32_wrapper: 4294967295u}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleUint32Wrapper": 4294967295
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_range",
+          "expr": "TestAllTypes{single_uint32_wrapper: 6111222333u}",
+          "container": "cel.expr.conformance.proto3",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range error"
+              }
+            ]
+          }
+        },
+        {
+          "name": "field_read_proto2",
+          "expr": "TestAllTypes{single_uint32_wrapper: 258u}.single_uint32_wrapper",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "uint64Value": "258"
+          }
+        },
+        {
+          "name": "field_read_proto2_zero",
+          "expr": "TestAllTypes{single_uint32_wrapper: 0u}.single_uint32_wrapper",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "uint64Value": "0"
+          }
+        },
+        {
+          "name": "field_read_proto2_unset",
+          "expr": "TestAllTypes{}.single_uint32_wrapper",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "nullValue": null
+          }
+        }
+      ]
+    },
+    {
+      "name": "uint64",
+      "description": "Tests for uint64 conversion.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "google.protobuf.UInt64Value{value: 123u}",
+          "value": {
+            "uint64Value": "123"
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "google.protobuf.UInt64Value{value: 123u}.value",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_zero",
+          "expr": "google.protobuf.UInt64Value{}",
+          "value": {
+            "uint64Value": "0"
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.UInt64Value"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.UInt64Value",
+                  "value": "2000000"
+                }
+              }
+            }
+          },
+          "value": {
+            "uint64Value": "2000000"
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{single_uint64_wrapper: 432u}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleUint64Wrapper": "432"
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_zero",
+          "expr": "TestAllTypes{single_uint64_wrapper: 0u}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleUint64Wrapper": "0"
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{single_uint64_wrapper: 975u}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleUint64Wrapper": "975"
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_zero",
+          "expr": "TestAllTypes{single_uint64_wrapper: 0u}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleUint64Wrapper": "0"
+            }
+          }
+        },
+        {
+          "name": "field_read_proto2",
+          "expr": "TestAllTypes{single_uint64_wrapper: 5123123123u}.single_uint64_wrapper",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "uint64Value": "5123123123"
+          }
+        },
+        {
+          "name": "field_read_proto2_zero",
+          "expr": "TestAllTypes{single_uint64_wrapper: 0u}.single_uint64_wrapper",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "uint64Value": "0"
+          }
+        },
+        {
+          "name": "field_read_proto2_unset",
+          "expr": "TestAllTypes{}.single_uint64_wrapper",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "nullValue": null
+          }
+        }
+      ]
+    },
+    {
+      "name": "float",
+      "description": "Tests for float conversion.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "google.protobuf.FloatValue{value: -1.5e3}",
+          "value": {
+            "doubleValue": -1500
+          }
+        },
+        {
+          "name": "literal_not_double",
+          "description": "Use a number with no exact representation to make sure we actually narrow to a float.",
+          "expr": "google.protobuf.FloatValue{value: 1.333} == 1.333",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "google.protobuf.FloatValue{value: 3.1416}.value",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_zero",
+          "expr": "google.protobuf.FloatValue{}",
+          "value": {
+            "doubleValue": 0
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.FloatValue"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.FloatValue",
+                  "value": -1250000
+                }
+              }
+            }
+          },
+          "value": {
+            "doubleValue": -1250000
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{single_float_wrapper: 86.75}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleFloatWrapper": 86.75
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_zero",
+          "expr": "TestAllTypes{single_float_wrapper: 0.0}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleFloatWrapper": 0
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_subnorm",
+          "description": "Subnormal single floats range from ~1e-38 to ~1e-45.",
+          "expr": "TestAllTypes{single_float_wrapper: 1e-40}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleFloatWrapper": 1e-40
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_round_to_zero",
+          "description": "Subnormal single floats range from ~1e-38 to ~1e-45.",
+          "expr": "TestAllTypes{single_float_wrapper: 1e-50}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleFloatWrapper": 0
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_range",
+          "description": "Single float max is about 3.4e38",
+          "expr": "TestAllTypes{single_float_wrapper: 1.4e55}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleFloatWrapper": "Infinity"
+            }
+          }
+        },
+        {
+          "name": "field_read_proto2",
+          "expr": "TestAllTypes{single_float_wrapper: -12.375}.single_float_wrapper",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "doubleValue": -12.375
+          }
+        },
+        {
+          "name": "field_read_proto2_zero",
+          "expr": "TestAllTypes{single_float_wrapper: 0.0}.single_float_wrapper",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "doubleValue": 0
+          }
+        },
+        {
+          "name": "field_read_proto2_unset",
+          "expr": "TestAllTypes{}.single_float_wrapper",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "nullValue": null
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{single_float_wrapper: -9.75}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleFloatWrapper": -9.75
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_zero",
+          "expr": "TestAllTypes{single_float_wrapper: 0.0}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleFloatWrapper": 0
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_subnorm",
+          "description": "Subnormal single floats range from ~1e-38 to ~1e-45.",
+          "expr": "TestAllTypes{single_float_wrapper: 1e-40}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleFloatWrapper": 1e-40
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_round_to_zero",
+          "expr": "TestAllTypes{single_float_wrapper: -9.9e-100}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleFloatWrapper": 0
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_range",
+          "description": "Single float min is about -3.4e38",
+          "expr": "TestAllTypes{single_float_wrapper: -9.9e100}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleFloatWrapper": "-Infinity"
+            }
+          }
+        },
+        {
+          "name": "field_read_proto3",
+          "expr": "TestAllTypes{single_float_wrapper: 64.25}.single_float_wrapper",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "doubleValue": 64.25
+          }
+        },
+        {
+          "name": "field_read_proto3_zero",
+          "expr": "TestAllTypes{single_float_wrapper: 0.0}.single_float_wrapper",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "doubleValue": 0
+          }
+        },
+        {
+          "name": "field_read_proto3_unset",
+          "expr": "TestAllTypes{}.single_float_wrapper",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "nullValue": null
+          }
+        }
+      ]
+    },
+    {
+      "name": "double",
+      "description": "Tests for double conversion.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "google.protobuf.DoubleValue{value: -1.5e3}",
+          "value": {
+            "doubleValue": -1500
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "google.protobuf.DoubleValue{value: 3.1416}.value",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_zero",
+          "expr": "google.protobuf.DoubleValue{}",
+          "value": {
+            "doubleValue": 0
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.DoubleValue"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.DoubleValue",
+                  "value": -1250000
+                }
+              }
+            }
+          },
+          "value": {
+            "doubleValue": -1250000
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{single_double_wrapper: 86.75}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleDoubleWrapper": 86.75
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_zero",
+          "expr": "TestAllTypes{single_double_wrapper: 0.0}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleDoubleWrapper": 0
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_range",
+          "expr": "TestAllTypes{single_double_wrapper: 1.4e55}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleDoubleWrapper": 1.4e55
+            }
+          }
+        },
+        {
+          "name": "field_read_proto2",
+          "expr": "TestAllTypes{single_double_wrapper: -12.375}.single_double_wrapper",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "doubleValue": -12.375
+          }
+        },
+        {
+          "name": "field_read_proto2_zero",
+          "expr": "TestAllTypes{single_int32_wrapper: 0}.single_int32_wrapper",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "field_read_proto2_unset",
+          "expr": "TestAllTypes{}.single_double_wrapper",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "nullValue": null
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{single_double_wrapper: -9.75}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleDoubleWrapper": -9.75
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_zero",
+          "expr": "TestAllTypes{single_double_wrapper: 0.0}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleDoubleWrapper": 0
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_range",
+          "expr": "TestAllTypes{single_double_wrapper: -9.9e100}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleDoubleWrapper": -9.9e100
+            }
+          }
+        },
+        {
+          "name": "field_read_proto3",
+          "expr": "TestAllTypes{single_double_wrapper: 64.25}.single_double_wrapper",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "doubleValue": 64.25
+          }
+        },
+        {
+          "name": "field_read_proto3_zero",
+          "expr": "TestAllTypes{single_double_wrapper: 0.0}.single_double_wrapper",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "doubleValue": 0
+          }
+        },
+        {
+          "name": "field_read_proto3_unset",
+          "expr": "TestAllTypes{}.single_double_wrapper",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "nullValue": null
+          }
+        }
+      ]
+    },
+    {
+      "name": "bool",
+      "description": "Tests for bool conversion.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "google.protobuf.BoolValue{value: true}",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "google.protobuf.BoolValue{value: true}.value",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_empty",
+          "expr": "google.protobuf.BoolValue{}",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.BoolValue"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.BoolValue",
+                  "value": true
+                }
+              }
+            }
+          },
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{single_bool_wrapper: true}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleBoolWrapper": true
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_false",
+          "expr": "TestAllTypes{single_bool_wrapper: false}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleBoolWrapper": false
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{single_bool_wrapper: true}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleBoolWrapper": true
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_false",
+          "expr": "TestAllTypes{single_bool_wrapper: false}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleBoolWrapper": false
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "string",
+      "description": "Tests for string conversion.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "google.protobuf.StringValue{value: 'foo'}",
+          "value": {
+            "stringValue": "foo"
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "google.protobuf.StringValue{value: 'foo'}.value",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_empty",
+          "expr": "google.protobuf.StringValue{}",
+          "value": {
+            "stringValue": ""
+          }
+        },
+        {
+          "name": "literal_unicode",
+          "expr": "google.protobuf.StringValue{value: 'flambé'}",
+          "value": {
+            "stringValue": "flambé"
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.StringValue"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.StringValue",
+                  "value": "bar"
+                }
+              }
+            }
+          },
+          "value": {
+            "stringValue": "bar"
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{single_string_wrapper: 'baz'}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleStringWrapper": "baz"
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_empty",
+          "expr": "TestAllTypes{single_string_wrapper: ''}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleStringWrapper": ""
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{single_string_wrapper: 'bletch'}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleStringWrapper": "bletch"
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_empty",
+          "expr": "TestAllTypes{single_string_wrapper: ''}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleStringWrapper": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "bytes",
+      "description": "Tests for bytes conversion.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "google.protobuf.BytesValue{value: b'foo\\123'}",
+          "value": {
+            "bytesValue": "Zm9vUw=="
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "google.protobuf.BytesValue{value: b'foo'}.value",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_empty",
+          "expr": "google.protobuf.BytesValue{}",
+          "value": {
+            "bytesValue": ""
+          }
+        },
+        {
+          "name": "literal_unicode",
+          "expr": "google.protobuf.BytesValue{value: b'flambé'}",
+          "value": {
+            "bytesValue": "ZmxhbWLDqQ=="
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.BytesValue"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.BytesValue",
+                  "value": "YmFy"
+                }
+              }
+            }
+          },
+          "value": {
+            "bytesValue": "YmFy"
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{single_bytes_wrapper: b'baz'}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleBytesWrapper": "YmF6"
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_empty",
+          "expr": "TestAllTypes{single_bytes_wrapper: b''}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleBytesWrapper": ""
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{single_bytes_wrapper: b'bletch'}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleBytesWrapper": "YmxldGNo"
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_empty",
+          "expr": "TestAllTypes{single_bytes_wrapper: b''}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleBytesWrapper": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "list",
+      "description": "Tests for list conversion.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "google.protobuf.ListValue{values: [3.0, 'foo', null]}",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "doubleValue": 3
+                },
+                {
+                  "stringValue": "foo"
+                },
+                {
+                  "nullValue": null
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "google.protobuf.ListValue{values: [3.0, 'foo', null]}.values",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_empty",
+          "expr": "google.protobuf.ListValue{values: []}",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.ListValue"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.ListValue",
+                  "value": ["bar", ["a", "b"]]
+                }
+              }
+            }
+          },
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "stringValue": "bar"
+                },
+                {
+                  "listValue": {
+                    "values": [
+                      {
+                        "stringValue": "a"
+                      },
+                      {
+                        "stringValue": "b"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{list_value: [1.0, 'one']}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "listValue": [1, "one"]
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_empty",
+          "expr": "TestAllTypes{list_value: []}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "listValue": []
+            }
+          }
+        },
+        {
+          "name": "field_read_proto2",
+          "expr": "TestAllTypes{list_value: [1.0, 'one']}.list_value",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "doubleValue": 1
+                },
+                {
+                  "stringValue": "one"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "field_read_proto2_empty",
+          "expr": "TestAllTypes{list_value: []}.list_value",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "field_read_proto2_unset",
+          "description": "Not a wrapper type, so doesn't convert to null.",
+          "expr": "TestAllTypes{}.list_value",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{list_value: [1.0, 'one']}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "listValue": [1, "one"]
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_empty",
+          "expr": "TestAllTypes{list_value: []}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "listValue": []
+            }
+          }
+        },
+        {
+          "name": "field_read_proto3",
+          "expr": "TestAllTypes{list_value: [1.0, 'one']}.list_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "doubleValue": 1
+                },
+                {
+                  "stringValue": "one"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "field_read_proto3_empty",
+          "expr": "TestAllTypes{list_value: []}.list_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "field_read_proto3_unset",
+          "description": "Not a wrapper type, so doesn't convert to null.",
+          "expr": "TestAllTypes{}.list_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "listValue": {}
+          }
+        }
+      ]
+    },
+    {
+      "name": "struct",
+      "description": "Tests for struct conversion.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "google.protobuf.Struct{fields: {'uno': 1.0, 'dos': 2.0}}",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "uno"
+                  },
+                  "value": {
+                    "doubleValue": 1
+                  }
+                },
+                {
+                  "key": {
+                    "stringValue": "dos"
+                  },
+                  "value": {
+                    "doubleValue": 2
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "google.protobuf.Struct{fields: {'uno': 1.0, 'dos': 2.0}}.fields",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_empty",
+          "expr": "google.protobuf.Struct{fields: {}}",
+          "value": {
+            "mapValue": {}
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.Struct"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.Struct",
+                  "value": {
+                    "first": "Abraham",
+                    "last": "Lincoln"
+                  }
+                }
+              }
+            }
+          },
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "first"
+                  },
+                  "value": {
+                    "stringValue": "Abraham"
+                  }
+                },
+                {
+                  "key": {
+                    "stringValue": "last"
+                  },
+                  "value": {
+                    "stringValue": "Lincoln"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{single_struct: {'un': 1.0, 'deux': 2.0}}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleStruct": {
+                "deux": 2,
+                "un": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_empty",
+          "expr": "TestAllTypes{single_struct: {}}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleStruct": {}
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_bad",
+          "expr": "TestAllTypes{single_struct: {1: 'uno'}}",
+          "disableCheck": true,
+          "container": "cel.expr.conformance.proto2",
+          "evalError": {
+            "errors": [
+              {
+                "message": "bad key type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "field_read_proto2",
+          "expr": "TestAllTypes{single_struct: {'one': 1.0}}.single_struct",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "one"
+                  },
+                  "value": {
+                    "doubleValue": 1
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "field_read_proto2_empty",
+          "expr": "TestAllTypes{single_struct: {}}.single_struct",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "mapValue": {}
+          }
+        },
+        {
+          "name": "field_read_proto2_unset",
+          "description": "Not a wrapper type, so doesn't convert to null.",
+          "expr": "TestAllTypes{}.single_struct",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "mapValue": {}
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{single_struct: {'un': 1.0, 'deux': 2.0}}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleStruct": {
+                "deux": 2,
+                "un": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_empty",
+          "expr": "TestAllTypes{single_struct: {}}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleStruct": {}
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_bad",
+          "expr": "TestAllTypes{single_struct: {1: 'uno'}}",
+          "disableCheck": true,
+          "container": "cel.expr.conformance.proto3",
+          "evalError": {
+            "errors": [
+              {
+                "message": "bad key type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "field_read_proto3",
+          "expr": "TestAllTypes{single_struct: {'one': 1.0}}.single_struct",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "one"
+                  },
+                  "value": {
+                    "doubleValue": 1
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "field_read_proto3_empty",
+          "expr": "TestAllTypes{single_struct: {}}.single_struct",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "mapValue": {}
+          }
+        },
+        {
+          "name": "field_read_proto3_unset",
+          "description": "Not a wrapper type, so doesn't convert to null.",
+          "expr": "TestAllTypes{}.single_struct",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "mapValue": {}
+          }
+        }
+      ]
+    },
+    {
+      "name": "value_null",
+      "description": "Tests for null conversions.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "Value{null_value: NullValue.NULL_VALUE}",
+          "container": "google.protobuf",
+          "value": {
+            "nullValue": null
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "Value{null_value: NullValue.NULL_VALUE}.null_value",
+          "disableCheck": true,
+          "container": "google.protobuf",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_unset",
+          "expr": "google.protobuf.Value{}",
+          "value": {
+            "nullValue": null
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.Value"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.Value",
+                  "value": null
+                }
+              }
+            }
+          },
+          "value": {
+            "nullValue": null
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{single_value: null}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleValue": null
+            }
+          }
+        },
+        {
+          "name": "field_read_proto2",
+          "expr": "TestAllTypes{single_value: null}.single_value",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "nullValue": null
+          }
+        },
+        {
+          "name": "field_read_proto2_unset",
+          "expr": "TestAllTypes{}.single_value",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "nullValue": null
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{single_value: null}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleValue": null
+            }
+          }
+        },
+        {
+          "name": "field_read_proto3",
+          "expr": "TestAllTypes{single_value: null}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "nullValue": null
+          }
+        },
+        {
+          "name": "field_read_proto3_unset",
+          "expr": "TestAllTypes{}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "nullValue": null
+          }
+        }
+      ]
+    },
+    {
+      "name": "value_number",
+      "description": "Tests for number conversions in Value.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "google.protobuf.Value{number_value: 12.5}",
+          "value": {
+            "doubleValue": 12.5
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "google.protobuf.Value{number_value: 12.5}.number_value",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_zero",
+          "expr": "google.protobuf.Value{number_value: 0.0}",
+          "value": {
+            "doubleValue": 0
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.Value"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.Value",
+                  "value": -26.375
+                }
+              }
+            }
+          },
+          "value": {
+            "doubleValue": -26.375
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{single_value: 7e23}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleValue": 7e23
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_zero",
+          "expr": "TestAllTypes{single_value: 0.0}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleValue": 0
+            }
+          }
+        },
+        {
+          "name": "field_read_proto2",
+          "expr": "TestAllTypes{single_value: 7e23}.single_value",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "doubleValue": 7e23
+          }
+        },
+        {
+          "name": "field_read_proto2_zero",
+          "expr": "TestAllTypes{single_value: 0.0}.single_value",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "doubleValue": 0
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{single_value: 7e23}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleValue": 7e23
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_zero",
+          "expr": "TestAllTypes{single_value: 0.0}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleValue": 0
+            }
+          }
+        },
+        {
+          "name": "field_read_proto3",
+          "expr": "TestAllTypes{single_value: 7e23}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "doubleValue": 7e23
+          }
+        },
+        {
+          "name": "field_read_proto3_zero",
+          "expr": "TestAllTypes{single_value: 0.0}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "doubleValue": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "value_string",
+      "description": "Tests for string conversions in Value.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "google.protobuf.Value{string_value: 'foo'}",
+          "value": {
+            "stringValue": "foo"
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "google.protobuf.Value{string_value: 'foo'}.string_value",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_empty",
+          "expr": "google.protobuf.Value{string_value: ''}",
+          "value": {
+            "stringValue": ""
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.Value"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.Value",
+                  "value": "bar"
+                }
+              }
+            }
+          },
+          "value": {
+            "stringValue": "bar"
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{single_value: 'baz'}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleValue": "baz"
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_empty",
+          "expr": "TestAllTypes{single_value: ''}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleValue": ""
+            }
+          }
+        },
+        {
+          "name": "field_read_proto2",
+          "expr": "TestAllTypes{single_value: 'bletch'}.single_value",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "stringValue": "bletch"
+          }
+        },
+        {
+          "name": "field_read_proto2_zero",
+          "expr": "TestAllTypes{single_value: ''}.single_value",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "stringValue": ""
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{single_value: 'baz'}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleValue": "baz"
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_empty",
+          "expr": "TestAllTypes{single_value: ''}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleValue": ""
+            }
+          }
+        },
+        {
+          "name": "field_read_proto3",
+          "expr": "TestAllTypes{single_value: 'bletch'}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "stringValue": "bletch"
+          }
+        },
+        {
+          "name": "field_read_proto3_zero",
+          "expr": "TestAllTypes{single_value: ''}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "stringValue": ""
+          }
+        }
+      ]
+    },
+    {
+      "name": "value_bool",
+      "description": "Tests for boolean conversions in Value.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "google.protobuf.Value{bool_value: true}",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "google.protobuf.Value{bool_value: true}.bool_value",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_false",
+          "expr": "google.protobuf.Value{bool_value: false}",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.Value"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.Value",
+                  "value": true
+                }
+              }
+            }
+          },
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{single_value: true}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleValue": true
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_false",
+          "expr": "TestAllTypes{single_value: false}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleValue": false
+            }
+          }
+        },
+        {
+          "name": "field_read_proto2",
+          "expr": "TestAllTypes{single_value: true}.single_value",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "field_read_proto2_false",
+          "expr": "TestAllTypes{single_value: false}.single_value",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{single_value: true}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleValue": true
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_false",
+          "expr": "TestAllTypes{single_value: false}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleValue": false
+            }
+          }
+        },
+        {
+          "name": "field_read_proto3",
+          "expr": "TestAllTypes{single_value: true}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "field_read_proto3_false",
+          "expr": "TestAllTypes{single_value: false}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        }
+      ]
+    },
+    {
+      "name": "value_struct",
+      "description": "Tests for struct conversions in Value.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "google.protobuf.Value{struct_value: {'a': 1.0, 'b': 'two'}}",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "a"
+                  },
+                  "value": {
+                    "doubleValue": 1
+                  }
+                },
+                {
+                  "key": {
+                    "stringValue": "b"
+                  },
+                  "value": {
+                    "stringValue": "two"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "google.protobuf.Value{struct_value: {'a': 1.0, 'b': 'two'}}.struct_value",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_empty",
+          "expr": "google.protobuf.Value{struct_value: {}}",
+          "value": {
+            "mapValue": {}
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.Value"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.Value",
+                  "value": {
+                    "x": null,
+                    "y": false
+                  }
+                }
+              }
+            }
+          },
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "x"
+                  },
+                  "value": {
+                    "nullValue": null
+                  }
+                },
+                {
+                  "key": {
+                    "stringValue": "y"
+                  },
+                  "value": {
+                    "boolValue": false
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{single_value: {'un': 1.0, 'deux': 2.0}}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleValue": {
+                "deux": 2,
+                "un": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_empty",
+          "expr": "TestAllTypes{single_value: {}}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleValue": {}
+            }
+          }
+        },
+        {
+          "name": "field_read_proto2",
+          "expr": "TestAllTypes{single_value: {'i': true}}.single_value",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "i"
+                  },
+                  "value": {
+                    "boolValue": true
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "field_read_proto2_empty",
+          "expr": "TestAllTypes{single_value: {}}.single_value",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "mapValue": {}
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{single_value: {'un': 1.0, 'deux': 2.0}}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleValue": {
+                "deux": 2,
+                "un": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_empty",
+          "expr": "TestAllTypes{single_value: {}}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleValue": {}
+            }
+          }
+        },
+        {
+          "name": "field_read_proto3",
+          "expr": "TestAllTypes{single_value: {'i': true}}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "i"
+                  },
+                  "value": {
+                    "boolValue": true
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "field_read_proto3_empty",
+          "expr": "TestAllTypes{single_value: {}}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "mapValue": {}
+          }
+        }
+      ]
+    },
+    {
+      "name": "value_list",
+      "description": "Tests for list conversions in Value.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "google.protobuf.Value{list_value: ['a', 3.0]}",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "stringValue": "a"
+                },
+                {
+                  "doubleValue": 3
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "google.protobuf.Value{list_value: []}.list_value",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_empty",
+          "expr": "google.protobuf.Value{list_value: []}",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.Value"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.Value",
+                  "value": [1, true, "hi"]
+                }
+              }
+            }
+          },
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "doubleValue": 1
+                },
+                {
+                  "boolValue": true
+                },
+                {
+                  "stringValue": "hi"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{single_value: ['un', 1.0]}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleValue": ["un", 1]
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2_empty",
+          "expr": "TestAllTypes{single_value: []}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleValue": []
+            }
+          }
+        },
+        {
+          "name": "field_read_proto2",
+          "expr": "TestAllTypes{single_value: ['i', true]}.single_value",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "stringValue": "i"
+                },
+                {
+                  "boolValue": true
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "field_read_proto2_empty",
+          "expr": "TestAllTypes{single_value: []}.single_value",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{single_value: ['un', 1.0]}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleValue": ["un", 1]
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3_empty",
+          "expr": "TestAllTypes{single_value: []}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleValue": []
+            }
+          }
+        },
+        {
+          "name": "field_read_proto3",
+          "expr": "TestAllTypes{single_value: ['i', true]}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "stringValue": "i"
+                },
+                {
+                  "boolValue": true
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "field_read_proto3_empty",
+          "expr": "TestAllTypes{single_value: []}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "listValue": {}
+          }
+        }
+      ]
+    },
+    {
+      "name": "any",
+      "description": "Tests for Any conversion.",
+      "test": [
+        {
+          "name": "literal",
+          "expr": "google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\x08\\x96\\x01'}",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleInt32": 150
+            }
+          }
+        },
+        {
+          "name": "literal_no_field_access",
+          "expr": "google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\x08\\x96\\x01'}.type_url",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_matching_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "literal_empty",
+          "expr": "google.protobuf.Any{}",
+          "evalError": {
+            "errors": [
+              {
+                "message": "conversion"
+              }
+            ]
+          }
+        },
+        {
+          "name": "var",
+          "expr": "x",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.Any"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.Any",
+                  "value": {
+                    "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                    "singleInt32": 150
+                  }
+                }
+              }
+            }
+          },
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleInt32": 150
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto2",
+          "expr": "TestAllTypes{single_any: TestAllTypes{single_int32: 150}}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleAny": {
+                "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                "singleInt32": 150
+              }
+            }
+          }
+        },
+        {
+          "name": "field_read_proto2",
+          "expr": "TestAllTypes{single_any: TestAllTypes{single_int32: 150}}.single_any",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleInt32": 150
+            }
+          }
+        },
+        {
+          "name": "field_assign_proto3",
+          "expr": "TestAllTypes{single_any: TestAllTypes{single_int32: 150}}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleAny": {
+                "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                "singleInt32": 150
+              }
+            }
+          }
+        },
+        {
+          "name": "field_read_proto3",
+          "expr": "TestAllTypes{single_any: TestAllTypes{single_int32: 150}}.single_any",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleInt32": 150
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "complex",
+      "description": "Tests combining various dynamic conversions.",
+      "test": [
+        {
+          "name": "any_list_map",
+          "expr": "TestAllTypes{single_any: [{'almost': 'done'}]}.single_any",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "mapValue": {
+                    "entries": [
+                      {
+                        "key": {
+                          "stringValue": "almost"
+                        },
+                        "value": {
+                          "stringValue": "done"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/encoders_ext.json
+++ b/packages/cel-spec/src/testdata/json/encoders_ext.json
@@ -1,0 +1,49 @@
+{
+  "name": "encoders_ext",
+  "description": "Tests for the encoders extension library.",
+  "section": [
+    {
+      "name": "encode",
+      "test": [
+        {
+          "name": "hello",
+          "expr": "base64.encode(b'hello')",
+          "value": {
+            "stringValue": "aGVsbG8="
+          }
+        }
+      ]
+    },
+    {
+      "name": "decode",
+      "test": [
+        {
+          "name": "hello",
+          "expr": "base64.decode('aGVsbG8=')",
+          "value": {
+            "bytesValue": "aGVsbG8="
+          }
+        },
+        {
+          "name": "hello_without_padding",
+          "expr": "base64.decode('aGVsbG8')",
+          "value": {
+            "bytesValue": "aGVsbG8="
+          }
+        }
+      ]
+    },
+    {
+      "name": "round_trip",
+      "test": [
+        {
+          "name": "hello",
+          "expr": "base64.decode(base64.encode(b'Hello World!'))",
+          "value": {
+            "bytesValue": "SGVsbG8gV29ybGQh"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/enums.json
+++ b/packages/cel-spec/src/testdata/json/enums.json
@@ -1,0 +1,1006 @@
+{
+  "name": "enums",
+  "description": "Tests for enum types.",
+  "section": [
+    {
+      "name": "legacy_proto2",
+      "description": "Legacy semantics where all enums are ints, proto2.",
+      "test": [
+        {
+          "name": "literal_global",
+          "expr": "GlobalEnum.GAZ",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "int64Value": "2"
+          }
+        },
+        {
+          "name": "literal_nested",
+          "expr": "TestAllTypes.NestedEnum.BAR",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "literal_zero",
+          "expr": "GlobalEnum.GOO",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "comparison",
+          "expr": "GlobalEnum.GAR == 1",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "arithmetic",
+          "expr": "TestAllTypes.NestedEnum.BAR + 3",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "int64Value": "4"
+          }
+        },
+        {
+          "name": "type_global",
+          "expr": "type(GlobalEnum.GOO)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "typeValue": "int"
+          }
+        },
+        {
+          "name": "type_nested",
+          "expr": "type(TestAllTypes.NestedEnum.BAZ)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "typeValue": "int"
+          }
+        },
+        {
+          "name": "select_default",
+          "expr": "TestAllTypes{}.standalone_enum",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "field_type",
+          "expr": "type(TestAllTypes{}.standalone_enum)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "typeValue": "int"
+          }
+        },
+        {
+          "name": "assign_standalone_name",
+          "expr": "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.BAZ}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "standaloneEnum": "BAZ"
+            }
+          }
+        },
+        {
+          "name": "assign_standalone_int",
+          "expr": "TestAllTypes{standalone_enum: 1}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "standaloneEnum": "BAR"
+            }
+          }
+        },
+        {
+          "name": "assign_standalone_int_too_big",
+          "expr": "TestAllTypes{standalone_enum: 5000000000}",
+          "container": "cel.expr.conformance.proto2",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "assign_standalone_int_too_neg",
+          "expr": "TestAllTypes{standalone_enum: -7000000000}",
+          "container": "cel.expr.conformance.proto2",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "access_repeated_enum",
+          "expr": "TestAllTypes{}.repeated_nested_enum",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "assign_repeated_enum",
+          "expr": "TestAllTypes{  repeated_nested_enum: [    TestAllTypes.NestedEnum.FOO,    TestAllTypes.NestedEnum.BAR]}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "repeatedNestedEnum": ["FOO", "BAR"]
+            }
+          }
+        },
+        {
+          "name": "list_enum_as_list_int",
+          "expr": "0 in TestAllTypes{  repeated_nested_enum: [    TestAllTypes.NestedEnum.FOO,    TestAllTypes.NestedEnum.BAR]}.repeated_nested_enum",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "enum_as_int",
+          "expr": "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.FOO}.standalone_enum in [0]",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "legacy_proto3",
+      "description": "Legacy semantics where all enums are ints, proto3",
+      "test": [
+        {
+          "name": "literal_global",
+          "expr": "GlobalEnum.GAZ",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "int64Value": "2"
+          }
+        },
+        {
+          "name": "literal_nested",
+          "expr": "TestAllTypes.NestedEnum.BAR",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "literal_zero",
+          "expr": "GlobalEnum.GOO",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "comparison",
+          "expr": "GlobalEnum.GAR == 1",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "arithmetic",
+          "expr": "TestAllTypes.NestedEnum.BAR + 3",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "int64Value": "4"
+          }
+        },
+        {
+          "name": "type_global",
+          "expr": "type(GlobalEnum.GOO)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "typeValue": "int"
+          }
+        },
+        {
+          "name": "type_nested",
+          "expr": "type(TestAllTypes.NestedEnum.BAZ)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "typeValue": "int"
+          }
+        },
+        {
+          "name": "select_default",
+          "expr": "TestAllTypes{}.standalone_enum",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "select",
+          "expr": "x.standalone_enum",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "container": "cel.expr.conformance.proto3",
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "standaloneEnum": "BAZ"
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "2"
+          }
+        },
+        {
+          "name": "select_big",
+          "expr": "x.standalone_enum",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "container": "cel.expr.conformance.proto3",
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "standaloneEnum": 108
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "108"
+          }
+        },
+        {
+          "name": "select_neg",
+          "expr": "x.standalone_enum",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "container": "cel.expr.conformance.proto3",
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "standaloneEnum": -3
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "-3"
+          }
+        },
+        {
+          "name": "field_type",
+          "expr": "type(TestAllTypes{}.standalone_enum)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "typeValue": "int"
+          }
+        },
+        {
+          "name": "assign_standalone_name",
+          "expr": "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.BAZ}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "standaloneEnum": "BAZ"
+            }
+          }
+        },
+        {
+          "name": "assign_standalone_int",
+          "expr": "TestAllTypes{standalone_enum: 1}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "standaloneEnum": "BAR"
+            }
+          }
+        },
+        {
+          "name": "assign_standalone_int_big",
+          "expr": "TestAllTypes{standalone_enum: 99}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "standaloneEnum": 99
+            }
+          }
+        },
+        {
+          "name": "assign_standalone_int_neg",
+          "expr": "TestAllTypes{standalone_enum: -1}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "standaloneEnum": -1
+            }
+          }
+        },
+        {
+          "name": "assign_standalone_int_too_big",
+          "expr": "TestAllTypes{standalone_enum: 5000000000}",
+          "container": "cel.expr.conformance.proto3",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "assign_standalone_int_too_neg",
+          "expr": "TestAllTypes{standalone_enum: -7000000000}",
+          "container": "cel.expr.conformance.proto3",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "access_repeated_enum",
+          "expr": "TestAllTypes{}.repeated_nested_enum",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "assign_repeated_enum",
+          "expr": "TestAllTypes{  repeated_nested_enum: [    TestAllTypes.NestedEnum.FOO,    TestAllTypes.NestedEnum.BAR]}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "repeatedNestedEnum": ["FOO", "BAR"]
+            }
+          }
+        },
+        {
+          "name": "list_enum_as_list_int",
+          "expr": "0 in TestAllTypes{  repeated_nested_enum: [    TestAllTypes.NestedEnum.FOO,    TestAllTypes.NestedEnum.BAR]}.repeated_nested_enum",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "enum_as_int",
+          "expr": "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.FOO}.standalone_enum in [0]",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "strong_proto2",
+      "description": "String semantics where enums are distinct types, proto2.",
+      "test": [
+        {
+          "name": "literal_global",
+          "expr": "GlobalEnum.GAZ",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto2.GlobalEnum",
+              "value": 2
+            }
+          }
+        },
+        {
+          "name": "literal_nested",
+          "expr": "TestAllTypes.NestedEnum.BAR",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto2.TestAllTypes.NestedEnum",
+              "value": 1
+            }
+          }
+        },
+        {
+          "name": "literal_zero",
+          "expr": "GlobalEnum.GOO",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto2.GlobalEnum"
+            }
+          }
+        },
+        {
+          "name": "comparison_true",
+          "expr": "GlobalEnum.GAR == GlobalEnum.GAR",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "comparison_false",
+          "expr": "GlobalEnum.GAR == GlobalEnum.GAZ",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "type_global",
+          "expr": "type(GlobalEnum.GOO)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "typeValue": "cel.expr.conformance.proto2.GlobalEnum"
+          }
+        },
+        {
+          "name": "type_nested",
+          "expr": "type(TestAllTypes.NestedEnum.BAZ)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "typeValue": "cel.expr.conformance.proto2.TestAllTypes.NestedEnum"
+          }
+        },
+        {
+          "name": "select_default",
+          "expr": "TestAllTypes{}.standalone_enum",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto2.TestAllTypes.NestedEnum"
+            }
+          }
+        },
+        {
+          "name": "field_type",
+          "expr": "type(TestAllTypes{}.standalone_enum)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "typeValue": "cel.expr.conformance.proto2.TestAllTypes.NestedEnum"
+          }
+        },
+        {
+          "name": "assign_standalone_name",
+          "expr": "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.BAZ}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "standaloneEnum": "BAZ"
+            }
+          }
+        },
+        {
+          "name": "assign_standalone_int",
+          "expr": "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum(1)}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "standaloneEnum": "BAR"
+            }
+          }
+        },
+        {
+          "name": "convert_symbol_to_int",
+          "expr": "int(GlobalEnum.GAZ)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "int64Value": "2"
+          }
+        },
+        {
+          "name": "convert_unnamed_to_int",
+          "description": "Disable check - missing way to declare enums.",
+          "expr": "int(x)",
+          "disableCheck": true,
+          "bindings": {
+            "x": {
+              "value": {
+                "enumValue": {
+                  "type": "cel.expr.conformance.proto2.GlobalEnum",
+                  "value": 444
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "444"
+          }
+        },
+        {
+          "name": "convert_int_inrange",
+          "expr": "TestAllTypes.NestedEnum(2)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto2.TestAllTypes.NestedEnum",
+              "value": 2
+            }
+          }
+        },
+        {
+          "name": "convert_int_big",
+          "expr": "TestAllTypes.NestedEnum(20000)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto2.TestAllTypes.NestedEnum",
+              "value": 20000
+            }
+          }
+        },
+        {
+          "name": "convert_int_neg",
+          "expr": "GlobalEnum(-33)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto2.GlobalEnum",
+              "value": -33
+            }
+          }
+        },
+        {
+          "name": "convert_int_too_big",
+          "expr": "TestAllTypes.NestedEnum(5000000000)",
+          "container": "cel.expr.conformance.proto2",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "convert_int_too_neg",
+          "expr": "TestAllTypes.NestedEnum(-7000000000)",
+          "container": "cel.expr.conformance.proto2",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "convert_string",
+          "expr": "TestAllTypes.NestedEnum('BAZ')",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto2.TestAllTypes.NestedEnum",
+              "value": 2
+            }
+          }
+        },
+        {
+          "name": "convert_string_bad",
+          "expr": "TestAllTypes.NestedEnum('BLETCH')",
+          "container": "cel.expr.conformance.proto2",
+          "evalError": {
+            "errors": [
+              {
+                "message": "invalid"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "strong_proto3",
+      "description": "String semantics where enums are distinct types, proto3.",
+      "test": [
+        {
+          "name": "literal_global",
+          "expr": "GlobalEnum.GAZ",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto3.GlobalEnum",
+              "value": 2
+            }
+          }
+        },
+        {
+          "name": "literal_nested",
+          "expr": "TestAllTypes.NestedEnum.BAR",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto3.TestAllTypes.NestedEnum",
+              "value": 1
+            }
+          }
+        },
+        {
+          "name": "literal_zero",
+          "expr": "GlobalEnum.GOO",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto3.GlobalEnum"
+            }
+          }
+        },
+        {
+          "name": "comparison_true",
+          "expr": "GlobalEnum.GAR == GlobalEnum.GAR",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "comparison_false",
+          "expr": "GlobalEnum.GAR == GlobalEnum.GAZ",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "type_global",
+          "expr": "type(GlobalEnum.GOO)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "typeValue": "cel.expr.conformance.proto3.GlobalEnum"
+          }
+        },
+        {
+          "name": "type_nested",
+          "expr": "type(TestAllTypes.NestedEnum.BAZ)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "typeValue": "cel.expr.conformance.proto3.TestAllTypes.NestedEnum"
+          }
+        },
+        {
+          "name": "select_default",
+          "expr": "TestAllTypes{}.standalone_enum",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto3.TestAllTypes.NestedEnum"
+            }
+          }
+        },
+        {
+          "name": "select",
+          "expr": "x.standalone_enum",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "container": "cel.expr.conformance.proto3",
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "standaloneEnum": "BAZ"
+                }
+              }
+            }
+          },
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto3.TestAllTypes.NestedEnum",
+              "value": 2
+            }
+          }
+        },
+        {
+          "name": "select_big",
+          "expr": "x.standalone_enum",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "container": "cel.expr.conformance.proto3",
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "standaloneEnum": 108
+                }
+              }
+            }
+          },
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto3.TestAllTypes.NestedEnum",
+              "value": 108
+            }
+          }
+        },
+        {
+          "name": "select_neg",
+          "expr": "x.standalone_enum",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "container": "cel.expr.conformance.proto3",
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "standaloneEnum": -3
+                }
+              }
+            }
+          },
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto3.TestAllTypes.NestedEnum",
+              "value": -3
+            }
+          }
+        },
+        {
+          "name": "field_type",
+          "expr": "type(TestAllTypes{}.standalone_enum)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "typeValue": "cel.expr.conformance.proto3.TestAllTypes.NestedEnum"
+          }
+        },
+        {
+          "name": "assign_standalone_name",
+          "expr": "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.BAZ}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "standaloneEnum": "BAZ"
+            }
+          }
+        },
+        {
+          "name": "assign_standalone_int",
+          "expr": "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum(1)}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "standaloneEnum": "BAR"
+            }
+          }
+        },
+        {
+          "name": "assign_standalone_int_big",
+          "expr": "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum(99)}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "standaloneEnum": 99
+            }
+          }
+        },
+        {
+          "name": "assign_standalone_int_neg",
+          "expr": "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum(-1)}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "standaloneEnum": -1
+            }
+          }
+        },
+        {
+          "name": "convert_symbol_to_int",
+          "expr": "int(GlobalEnum.GAZ)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "int64Value": "2"
+          }
+        },
+        {
+          "name": "convert_unnamed_to_int",
+          "description": "Disable check - missing way to declare enums.",
+          "expr": "int(x)",
+          "disableCheck": true,
+          "bindings": {
+            "x": {
+              "value": {
+                "enumValue": {
+                  "type": "cel.expr.conformance.proto3.GlobalEnum",
+                  "value": 444
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "444"
+          }
+        },
+        {
+          "name": "convert_unnamed_to_int_select",
+          "expr": "int(x.standalone_enum)",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "standaloneEnum": -987
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "-987"
+          }
+        },
+        {
+          "name": "convert_int_inrange",
+          "expr": "TestAllTypes.NestedEnum(2)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto3.TestAllTypes.NestedEnum",
+              "value": 2
+            }
+          }
+        },
+        {
+          "name": "convert_int_big",
+          "expr": "TestAllTypes.NestedEnum(20000)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto3.TestAllTypes.NestedEnum",
+              "value": 20000
+            }
+          }
+        },
+        {
+          "name": "convert_int_neg",
+          "expr": "GlobalEnum(-33)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto3.GlobalEnum",
+              "value": -33
+            }
+          }
+        },
+        {
+          "name": "convert_int_too_big",
+          "expr": "TestAllTypes.NestedEnum(5000000000)",
+          "container": "cel.expr.conformance.proto3",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "convert_int_too_neg",
+          "expr": "TestAllTypes.NestedEnum(-7000000000)",
+          "container": "cel.expr.conformance.proto3",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "convert_string",
+          "expr": "TestAllTypes.NestedEnum('BAZ')",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "enumValue": {
+              "type": "cel.expr.conformance.proto3.TestAllTypes.NestedEnum",
+              "value": 2
+            }
+          }
+        },
+        {
+          "name": "convert_string_bad",
+          "expr": "TestAllTypes.NestedEnum('BLETCH')",
+          "container": "cel.expr.conformance.proto3",
+          "evalError": {
+            "errors": [
+              {
+                "message": "invalid"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/fields.json
+++ b/packages/cel-spec/src/testdata/json/fields.json
@@ -1,0 +1,961 @@
+{
+  "name": "fields",
+  "description": "Tests for field access in maps.",
+  "section": [
+    {
+      "name": "map_fields",
+      "description": "select an element in a map",
+      "test": [
+        {
+          "name": "map_key_int64",
+          "expr": "{0:1,2:2,5:true}[5]",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_key_uint64",
+          "expr": "{0u:1u,2u:'happy',5u:3u}[2u]",
+          "value": {
+            "stringValue": "happy"
+          }
+        },
+        {
+          "name": "map_key_string",
+          "expr": "{'name':100u}['name']",
+          "value": {
+            "uint64Value": "100"
+          }
+        },
+        {
+          "name": "map_key_bool",
+          "expr": "{true:5}[true]",
+          "value": {
+            "int64Value": "5"
+          }
+        },
+        {
+          "name": "map_key_mixed_type",
+          "expr": "{true:1,2:2,5u:3}[true]",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "map_key_mixed_numbers_double_key",
+          "expr": "{1u: 1.0, 2: 2.0, 3u: 3.0}[3.0]",
+          "value": {
+            "doubleValue": 3
+          }
+        },
+        {
+          "name": "map_key_mixed_numbers_lossy_double_key",
+          "expr": "{1u: 1.0, 2: 2.0, 3u: 3.0}[3.1]",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such key"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_key_mixed_numbers_uint_key",
+          "expr": "{1u: 1.0, 2: 2.0, 3u: 3.0}[2u]",
+          "value": {
+            "doubleValue": 2
+          }
+        },
+        {
+          "name": "map_key_mixed_numbers_int_key",
+          "expr": "{1u: 1.0, 2: 2.0, 3u: 3.0}[1]",
+          "value": {
+            "doubleValue": 1
+          }
+        },
+        {
+          "name": "map_field_access",
+          "expr": "x.name",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "mapType": {
+                    "keyType": {
+                      "primitive": "STRING"
+                    },
+                    "valueType": {
+                      "primitive": "INT64"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "mapValue": {
+                  "entries": [
+                    {
+                      "key": {
+                        "stringValue": "name"
+                      },
+                      "value": {
+                        "int64Value": "1024"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "1024"
+          }
+        },
+        {
+          "name": "map_no_such_key",
+          "expr": "{0:1,2:2,5:3}[1]",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such key"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_no_such_key_or_false",
+          "expr": "dyn({0:1,2:2,5:3}[1]) || false",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such key"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_no_such_key_or_true",
+          "expr": "dyn({0:1,2:2,5:3}[1]) || true",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_no_such_key_and_false",
+          "expr": "dyn({0:1,2:2,5:3}[1]) && false",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_no_such_key_and_true",
+          "expr": "dyn({0:1,2:2,5:3}[1]) && true",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such key"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_bad_key_type",
+          "expr": "{0:1,2:2,5:3}[dyn(b'')]",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such key"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_bad_key_type_or_false",
+          "expr": "dyn({0:1,2:2,5:3}[dyn(b'')]) || false",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such key"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_bad_key_type_or_true",
+          "expr": "dyn({0:1,2:2,5:3}[dyn(b'')]) || true",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_bad_key_type_and_false",
+          "expr": "dyn({0:1,2:2,5:3}[dyn(b'')]) && false",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_bad_key_type_and_true",
+          "expr": "dyn({0:1,2:2,5:3}[dyn(b'')]) && true",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such key"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_field_select_no_such_key",
+          "expr": "x.name",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "mapType": {
+                    "keyType": {
+                      "primitive": "STRING"
+                    },
+                    "valueType": {
+                      "primitive": "STRING"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "mapValue": {
+                  "entries": [
+                    {
+                      "key": {
+                        "stringValue": "holiday"
+                      },
+                      "value": {
+                        "stringValue": "field"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such key: 'name'"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_field_select_no_such_key_or_false",
+          "expr": "dyn(x.name) || false",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "mapType": {
+                    "keyType": {
+                      "primitive": "STRING"
+                    },
+                    "valueType": {
+                      "primitive": "STRING"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "mapValue": {
+                  "entries": [
+                    {
+                      "key": {
+                        "stringValue": "holiday"
+                      },
+                      "value": {
+                        "stringValue": "field"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such key: 'name'"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_field_select_no_such_key_or_true",
+          "expr": "dyn(x.name) || true",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "mapType": {
+                    "keyType": {
+                      "primitive": "STRING"
+                    },
+                    "valueType": {
+                      "primitive": "STRING"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "mapValue": {
+                  "entries": [
+                    {
+                      "key": {
+                        "stringValue": "holiday"
+                      },
+                      "value": {
+                        "stringValue": "field"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_field_select_no_such_key_and_false",
+          "expr": "dyn(x.name) && false",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "mapType": {
+                    "keyType": {
+                      "primitive": "STRING"
+                    },
+                    "valueType": {
+                      "primitive": "STRING"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "mapValue": {
+                  "entries": [
+                    {
+                      "key": {
+                        "stringValue": "holiday"
+                      },
+                      "value": {
+                        "stringValue": "field"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_field_select_no_such_key_and_true",
+          "expr": "dyn(x.name) && true",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "mapType": {
+                    "keyType": {
+                      "primitive": "STRING"
+                    },
+                    "valueType": {
+                      "primitive": "STRING"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "mapValue": {
+                  "entries": [
+                    {
+                      "key": {
+                        "stringValue": "holiday"
+                      },
+                      "value": {
+                        "stringValue": "field"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such key: 'name'"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_value_null",
+          "expr": "{true:null}[true]",
+          "value": {
+            "nullValue": null
+          }
+        },
+        {
+          "name": "map_value_bool",
+          "expr": "{27:false}[27]",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_value_string",
+          "expr": "{'n':'x'}['n']",
+          "value": {
+            "stringValue": "x"
+          }
+        },
+        {
+          "name": "map_value_float",
+          "expr": "{3:15.15}[3]",
+          "value": {
+            "doubleValue": 15.15
+          }
+        },
+        {
+          "name": "map_value_uint64",
+          "expr": "{0u:1u,2u:2u,5u:3u}[0u]",
+          "value": {
+            "uint64Value": "1"
+          }
+        },
+        {
+          "name": "map_value_int64",
+          "expr": "{true:1,false:2}[true]",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "map_value_bytes",
+          "expr": "{0:b''}[0]",
+          "value": {
+            "bytesValue": ""
+          }
+        },
+        {
+          "name": "map_value_list",
+          "expr": "{0u:[1]}[0u]",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "int64Value": "1"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "map_value_map",
+          "expr": "{'map': {'k': 'v'}}['map']",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "k"
+                  },
+                  "value": {
+                    "stringValue": "v"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "map_value_mix_type",
+          "expr": "{'map': {'k': 'v'}, 'list': [1]}['map']",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "k"
+                  },
+                  "value": {
+                    "stringValue": "v"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "map_has",
+      "description": "Has macro for map entries.",
+      "test": [
+        {
+          "name": "has",
+          "expr": "has({'a': 1, 'b': 2}.a)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "has_not",
+          "expr": "has({'a': 1, 'b': 2}.c)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "has_empty",
+          "expr": "has({}.a)",
+          "value": {
+            "boolValue": false
+          }
+        }
+      ]
+    },
+    {
+      "name": "quoted_map_fields",
+      "description": "Field accesses using the quote syntax",
+      "test": [
+        {
+          "name": "field_access_slash",
+          "expr": "{'/api/v1': true, '/api/v2': false}.`/api/v1`",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "field_access_dash",
+          "expr": "{'content-type': 'application/json', 'content-length': 145}.`content-type` == 'application/json'",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "field_access_dot",
+          "expr": "{'foo.txt': 32, 'bar.csv': 1024}.`foo.txt`",
+          "value": {
+            "int64Value": "32"
+          }
+        },
+        {
+          "name": "has_field_slash",
+          "expr": "has({'/api/v1': true, '/api/v2': false}.`/api/v3`)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "has_field_dash",
+          "expr": "has({'content-type': 'application/json', 'content-length': 145}.`content-type`)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "has_field_dot",
+          "expr": "has({'foo.txt': 32, 'bar.csv': 1024}.`foo.txt`)",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "qualified_identifier_resolution",
+      "description": "Tests for qualified identifier resolution.",
+      "test": [
+        {
+          "name": "qualified_ident",
+          "expr": "a.b.c",
+          "typeEnv": [
+            {
+              "name": "a.b.c",
+              "ident": {
+                "type": {
+                  "primitive": "STRING"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "a.b.c": {
+              "value": {
+                "stringValue": "yeah"
+              }
+            }
+          },
+          "value": {
+            "stringValue": "yeah"
+          }
+        },
+        {
+          "name": "map_field_select",
+          "expr": "a.b.c",
+          "typeEnv": [
+            {
+              "name": "a.b",
+              "ident": {
+                "type": {
+                  "mapType": {
+                    "keyType": {
+                      "primitive": "STRING"
+                    },
+                    "valueType": {
+                      "primitive": "STRING"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "a.b": {
+              "value": {
+                "mapValue": {
+                  "entries": [
+                    {
+                      "key": {
+                        "stringValue": "c"
+                      },
+                      "value": {
+                        "stringValue": "yeah"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "value": {
+            "stringValue": "yeah"
+          }
+        },
+        {
+          "name": "qualified_identifier_resolution_unchecked",
+          "description": "namespace resolution should try to find the longest prefix for the evaluator.",
+          "expr": "a.b.c",
+          "disableCheck": true,
+          "typeEnv": [
+            {
+              "name": "a.b.c",
+              "ident": {
+                "type": {
+                  "primitive": "STRING"
+                }
+              }
+            },
+            {
+              "name": "a.b",
+              "ident": {
+                "type": {
+                  "mapType": {
+                    "keyType": {
+                      "primitive": "STRING"
+                    },
+                    "valueType": {
+                      "primitive": "STRING"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "a.b": {
+              "value": {
+                "mapValue": {
+                  "entries": [
+                    {
+                      "key": {
+                        "stringValue": "c"
+                      },
+                      "value": {
+                        "stringValue": "oops"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "a.b.c": {
+              "value": {
+                "stringValue": "yeah"
+              }
+            }
+          },
+          "value": {
+            "stringValue": "yeah"
+          }
+        },
+        {
+          "name": "list_field_select_unsupported",
+          "expr": "a.b.pancakes",
+          "disableCheck": true,
+          "typeEnv": [
+            {
+              "name": "a.b",
+              "ident": {
+                "type": {
+                  "listType": {
+                    "elemType": {
+                      "primitive": "STRING"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "a.b": {
+              "value": {
+                "listValue": {
+                  "values": [
+                    {
+                      "stringValue": "pancakes"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "evalError": {
+            "errors": [
+              {
+                "message": "type 'list_type:<elem_type:<primitive:STRING > > ' does not support field selection"
+              }
+            ]
+          }
+        },
+        {
+          "name": "int64_field_select_unsupported",
+          "expr": "a.pancakes",
+          "disableCheck": true,
+          "typeEnv": [
+            {
+              "name": "a",
+              "ident": {
+                "type": {
+                  "primitive": "INT64"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "a": {
+              "value": {
+                "int64Value": "15"
+              }
+            }
+          },
+          "evalError": {
+            "errors": [
+              {
+                "message": "type 'int64_type' does not support field selection"
+              }
+            ]
+          }
+        },
+        {
+          "name": "ident_with_longest_prefix_check",
+          "description": "namespace resolution should try to find the longest prefix for the checker.",
+          "expr": "a.b.c",
+          "typeEnv": [
+            {
+              "name": "a.b.c",
+              "ident": {
+                "type": {
+                  "primitive": "STRING"
+                }
+              }
+            },
+            {
+              "name": "a.b",
+              "ident": {
+                "type": {
+                  "mapType": {
+                    "keyType": {
+                      "primitive": "STRING"
+                    },
+                    "valueType": {
+                      "primitive": "STRING"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "a.b": {
+              "value": {
+                "mapValue": {
+                  "entries": [
+                    {
+                      "key": {
+                        "stringValue": "c"
+                      },
+                      "value": {
+                        "stringValue": "oops"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "a.b.c": {
+              "value": {
+                "stringValue": "yeah"
+              }
+            }
+          },
+          "value": {
+            "stringValue": "yeah"
+          }
+        },
+        {
+          "name": "map_key_float",
+          "description": "map should not support float as the key.",
+          "expr": "{3.3:15.15, 1.0: 5}[1.0]",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "unsupported key type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_key_null",
+          "description": "map should not support null as the key.",
+          "expr": "{null:false}[null]",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "unsupported key type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_value_repeat_key",
+          "description": "map should not support repeated key.",
+          "expr": "{true:1,false:2,true:3}[true]",
+          "evalError": {
+            "errors": [
+              {
+                "message": "Failed with repeated key"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_value_repeat_key_heterogeneous",
+          "description": "map should not support repeated key.",
+          "expr": "{0: 1, 0u: 2}[0.0]",
+          "evalError": {
+            "errors": [
+              {
+                "message": "Failed with repeated key"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "in",
+      "description": "Tests for 'in' operator for maps.",
+      "test": [
+        {
+          "name": "empty",
+          "expr": "7 in {}",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "singleton",
+          "expr": "true in {true: 1}",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "present",
+          "expr": "'George' in {'John': 'smart', 'Paul': 'cute', 'George': 'quiet', 'Ringo': 'funny'}",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "absent",
+          "expr": "'spider' in {'ant': 6, 'fly': 6, 'centipede': 100}",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "mixed_numbers_and_keys_present",
+          "expr": "3.0 in {1: 1, 2: 2, 3u: 3} && 2u in {1u: 1, 2: 2} && 1 in {1u: 1, 2: 2}",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "mixed_numbers_and_keys_absent",
+          "expr": "3.1 in {1: 1, 2: 2, 3u: 3}",
+          "value": {
+            "boolValue": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/fp_math.json
+++ b/packages/cel-spec/src/testdata/json/fp_math.json
@@ -1,0 +1,230 @@
+{
+  "name": "fp_math",
+  "description": "Tests for floating-point math.",
+  "section": [
+    {
+      "name": "fp_math",
+      "description": "Simple tests for floating point.",
+      "test": [
+        {
+          "name": "add_positive_positive",
+          "expr": "4.25 + 15.25",
+          "value": {
+            "doubleValue": 19.5
+          }
+        },
+        {
+          "name": "add_positive_negative",
+          "expr": "17.75 + (-7.75)",
+          "value": {
+            "doubleValue": 10
+          }
+        },
+        {
+          "name": "add_negative_negative",
+          "expr": "-4.125 + (-2.125)",
+          "value": {
+            "doubleValue": -6.25
+          }
+        },
+        {
+          "name": "sub_positive_positive",
+          "expr": "42.0 - 12.0",
+          "value": {
+            "doubleValue": 30
+          }
+        },
+        {
+          "name": "sub_positive_negative",
+          "expr": "42.875 - (-22.0)",
+          "value": {
+            "doubleValue": 64.875
+          }
+        },
+        {
+          "name": "sub_negative_negative",
+          "expr": "-4.875 - (-0.125)",
+          "value": {
+            "doubleValue": -4.75
+          }
+        },
+        {
+          "name": "multiply_positive_positive",
+          "expr": "42.5 * 0.2",
+          "value": {
+            "doubleValue": 8.5
+          }
+        },
+        {
+          "name": "multiply_positive_negative",
+          "expr": "40.75 * (-2.25)",
+          "value": {
+            "doubleValue": -91.6875
+          }
+        },
+        {
+          "name": "multiply_negative_negative",
+          "expr": "-3.0 * (-2.5)",
+          "value": {
+            "doubleValue": 7.5
+          }
+        },
+        {
+          "name": "divide_positive_positive",
+          "expr": "0.0625 / 0.002",
+          "value": {
+            "doubleValue": 31.25
+          }
+        },
+        {
+          "name": "divide_positive_negative",
+          "expr": "-2.0 / 2.0",
+          "value": {
+            "doubleValue": -1
+          }
+        },
+        {
+          "name": "divide_negative_negative",
+          "expr": "-8.875 / (-0.0625)",
+          "value": {
+            "doubleValue": 142
+          }
+        },
+        {
+          "name": "mod_not_support",
+          "expr": "47.5 % 5.5",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "found no matching overload for '_%_' applied to '(double, double)'"
+              }
+            ]
+          }
+        },
+        {
+          "name": "negative",
+          "expr": "-(4.5)",
+          "value": {
+            "doubleValue": -4.5
+          }
+        },
+        {
+          "name": "double_negative",
+          "expr": "-(-1.25)",
+          "value": {
+            "doubleValue": 1.25
+          }
+        },
+        {
+          "name": "negative_zero",
+          "expr": "-(0.0)",
+          "value": {
+            "doubleValue": 0
+          }
+        },
+        {
+          "name": "divide_zero",
+          "expr": "15.75 / 0.0",
+          "value": {
+            "doubleValue": "Infinity"
+          }
+        },
+        {
+          "name": "multiply_zero",
+          "expr": "15.36 * 0.0",
+          "value": {
+            "doubleValue": 0
+          }
+        },
+        {
+          "name": "add_left_identity",
+          "expr": "0.0 + 1.75",
+          "value": {
+            "doubleValue": 1.75
+          }
+        },
+        {
+          "name": "add_right_identity",
+          "expr": " 2.5 + 0.0",
+          "value": {
+            "doubleValue": 2.5
+          }
+        },
+        {
+          "name": "add_commutative",
+          "expr": "7.5 + 1.5 == 1.5 + 7.5",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "add_associative",
+          "expr": "5.625 + (15.75 + 2.0) == (5.625 + 15.75) + 2.0",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "mul_left_identity",
+          "expr": "1.0 * 45.25",
+          "value": {
+            "doubleValue": 45.25
+          }
+        },
+        {
+          "name": "mul_right_identity",
+          "expr": "-25.25 * 1.0",
+          "value": {
+            "doubleValue": -25.25
+          }
+        },
+        {
+          "name": "mul_commutative",
+          "expr": "1.5 * 25.875 == 25.875 * 1.5",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "mul_associative",
+          "expr": "1.5 * (23.625 * 0.75) == (1.5 * 23.625) * 0.75",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "add_mul_distribute",
+          "expr": "5.75 * (1.5 + 2.5)  == 5.75 * 1.5 + 5.75 * 2.5",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "fp_overflow_positive",
+          "description": "DBL_MAX(2^1023) times two",
+          "expr": "2.0 * 8.988466e+307 ",
+          "value": {
+            "doubleValue": "Infinity"
+          }
+        },
+        {
+          "name": "fp_overflow_negative",
+          "description": "-DBL_MAX(-2^1023) times two",
+          "expr": "2.0 * -8.988466e+307 ",
+          "value": {
+            "doubleValue": "-Infinity"
+          }
+        },
+        {
+          "name": "fp_underflow",
+          "description": "DBL_MIN(2^-1074) divided by two",
+          "expr": "1e-324  / 2.0",
+          "value": {
+            "doubleValue": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/integer_math.json
+++ b/packages/cel-spec/src/testdata/json/integer_math.json
@@ -1,0 +1,557 @@
+{
+  "name": "integer_math",
+  "description": "Tests for int and uint math.",
+  "section": [
+    {
+      "name": "int64_math",
+      "description": "Simple tests for int64.",
+      "test": [
+        {
+          "name": "add_positive_positive",
+          "expr": "40 + 2",
+          "value": {
+            "int64Value": "42"
+          }
+        },
+        {
+          "name": "add_positive_negative",
+          "expr": "42 + (-7)",
+          "value": {
+            "int64Value": "35"
+          }
+        },
+        {
+          "name": "add_negative_negative",
+          "expr": "-4 + (-2)",
+          "value": {
+            "int64Value": "-6"
+          }
+        },
+        {
+          "name": "sub_positive_positive",
+          "expr": "42 - 12",
+          "value": {
+            "int64Value": "30"
+          }
+        },
+        {
+          "name": "sub_positive_negative",
+          "expr": "42 - (-22)",
+          "value": {
+            "int64Value": "64"
+          }
+        },
+        {
+          "name": "sub_negative_negative",
+          "expr": "-42 - (-12)",
+          "value": {
+            "int64Value": "-30"
+          }
+        },
+        {
+          "name": "multiply_positive_positive",
+          "expr": "42 * 2",
+          "value": {
+            "int64Value": "84"
+          }
+        },
+        {
+          "name": "multiply_positive_negative",
+          "expr": "40 * (-2)",
+          "value": {
+            "int64Value": "-80"
+          }
+        },
+        {
+          "name": "multiply_negative_negative",
+          "expr": "-30 * (-2)",
+          "value": {
+            "int64Value": "60"
+          }
+        },
+        {
+          "name": "divide_positive_positive",
+          "expr": "42 / 2",
+          "value": {
+            "int64Value": "21"
+          }
+        },
+        {
+          "name": "divide_positive_negative",
+          "expr": "-20 / 2",
+          "value": {
+            "int64Value": "-10"
+          }
+        },
+        {
+          "name": "divide_negative_negative",
+          "expr": "-80 / (-2)",
+          "value": {
+            "int64Value": "40"
+          }
+        },
+        {
+          "name": "mod_positive_positive",
+          "expr": "47 % 5",
+          "value": {
+            "int64Value": "2"
+          }
+        },
+        {
+          "name": "mod_positive_negative",
+          "expr": "43 % (-5)",
+          "value": {
+            "int64Value": "3"
+          }
+        },
+        {
+          "name": "mod_negative_negative",
+          "expr": "-42 % (-5)",
+          "value": {
+            "int64Value": "-2"
+          }
+        },
+        {
+          "name": "mod_negative_positive",
+          "expr": "-3 % 5",
+          "value": {
+            "int64Value": "-3"
+          }
+        },
+        {
+          "name": "unary_minus_pos",
+          "expr": "-(42)",
+          "value": {
+            "int64Value": "-42"
+          }
+        },
+        {
+          "name": "unary_minus_neg",
+          "expr": "-(-42)",
+          "value": {
+            "int64Value": "42"
+          }
+        },
+        {
+          "name": "unary_minus_no_overload",
+          "expr": "-(42u)",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_such_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "unary_minus_not_bool",
+          "expr": "-false",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_such_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "mod_zero",
+          "expr": "34 % 0",
+          "evalError": {
+            "errors": [
+              {
+                "message": "modulus by zero"
+              }
+            ]
+          }
+        },
+        {
+          "name": "negative_zero",
+          "expr": "-(0)",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "double_negative",
+          "expr": "-(-42)",
+          "value": {
+            "int64Value": "42"
+          }
+        },
+        {
+          "name": "divide_zero",
+          "expr": "15 / 0",
+          "evalError": {
+            "errors": [
+              {
+                "message": "divide by zero"
+              }
+            ]
+          }
+        },
+        {
+          "name": "multiply_zero",
+          "expr": "15 * 0",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "add_left_identity",
+          "expr": "0 + 17",
+          "value": {
+            "int64Value": "17"
+          }
+        },
+        {
+          "name": "add_right_identity",
+          "expr": " 29 + 0",
+          "value": {
+            "int64Value": "29"
+          }
+        },
+        {
+          "name": "add_commutative",
+          "expr": "75 + 15 == 15 + 75",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "add_associative",
+          "expr": "5 + (15 + 20) == (5 + 15) + 20",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "mul_left_identity",
+          "expr": "1 * 45",
+          "value": {
+            "int64Value": "45"
+          }
+        },
+        {
+          "name": "mul_right_identity",
+          "expr": "-25 * 1",
+          "value": {
+            "int64Value": "-25"
+          }
+        },
+        {
+          "name": "mul_commutative",
+          "expr": "15 * 25 == 25 * 15",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "mul_associative",
+          "expr": "15 * (23 * 88) == (15 * 23) * 88",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "add_mul_distribute",
+          "expr": "5 * (15 + 25)  == 5 * 15 + 5 * 25",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "int64_overflow_positive",
+          "description": "LLONG_MAX plus one.",
+          "expr": "9223372036854775807 + 1",
+          "evalError": {
+            "errors": [
+              {
+                "message": "return error for overflow"
+              }
+            ]
+          }
+        },
+        {
+          "name": "int64_overflow_negative",
+          "description": "LLONG_MIN minus one.",
+          "expr": "-9223372036854775808 - 1",
+          "evalError": {
+            "errors": [
+              {
+                "message": "return error for overflow"
+              }
+            ]
+          }
+        },
+        {
+          "name": "int64_overflow_add_negative",
+          "description": "negative overflow via addition",
+          "expr": "-9223372036854775808 + (-1)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "return error for overflow"
+              }
+            ]
+          }
+        },
+        {
+          "name": "int64_overflow_sub_positive",
+          "description": "positive overflow via subtraction",
+          "expr": "1 - (-9223372036854775807)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "return error for overflow"
+              }
+            ]
+          }
+        },
+        {
+          "name": "int64_min_negate",
+          "description": "Negated LLONG_MIN is not representable.",
+          "expr": "-(-9223372036854775808)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "return error for overflow"
+              }
+            ]
+          }
+        },
+        {
+          "name": "int64_min_negate_mul",
+          "description": "Negate LLONG_MIN via multiplication",
+          "expr": "(-9223372036854775808) * -1",
+          "evalError": {
+            "errors": [
+              {
+                "message": "return error for overflow"
+              }
+            ]
+          }
+        },
+        {
+          "name": "int64_min_negate_div",
+          "description": "Negate LLONG_MIN via division.",
+          "expr": "(-9223372036854775808)/-1",
+          "evalError": {
+            "errors": [
+              {
+                "message": "return error for overflow"
+              }
+            ]
+          }
+        },
+        {
+          "name": "int64_overflow_mul_positive",
+          "description": "Overflow via multiplication.",
+          "expr": "5000000000 * 5000000000",
+          "evalError": {
+            "errors": [
+              {
+                "message": "return error for overflow"
+              }
+            ]
+          }
+        },
+        {
+          "name": "int64_overflow_mul_negative",
+          "description": "Overflow via multiplication.",
+          "expr": "(-5000000000) * 5000000000",
+          "evalError": {
+            "errors": [
+              {
+                "message": "return error for overflow"
+              }
+            ]
+          }
+        },
+        {
+          "name": "uint64_overflow_positive",
+          "description": "ULLONG_MAX plus one.",
+          "expr": "18446744073709551615u + 1u",
+          "evalError": {
+            "errors": [
+              {
+                "message": "return error for overflow"
+              }
+            ]
+          }
+        },
+        {
+          "name": "uint64_overflow_negative",
+          "description": "zero minus one.",
+          "expr": "0u - 1u",
+          "evalError": {
+            "errors": [
+              {
+                "message": "return error for overflow"
+              }
+            ]
+          }
+        },
+        {
+          "name": "uint64_overflow_mul_positive",
+          "description": "Overflow via multiplication.",
+          "expr": "5000000000u * 5000000000u",
+          "evalError": {
+            "errors": [
+              {
+                "message": "return error for overflow"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "uint64_math",
+      "description": "Simple tests for uint64.",
+      "test": [
+        {
+          "name": "add",
+          "expr": "42u + 2u",
+          "value": {
+            "uint64Value": "44"
+          }
+        },
+        {
+          "name": "sub",
+          "expr": "42u - 12u",
+          "value": {
+            "uint64Value": "30"
+          }
+        },
+        {
+          "name": "multiply",
+          "expr": "40u * 2u",
+          "value": {
+            "uint64Value": "80"
+          }
+        },
+        {
+          "name": "divide",
+          "expr": "60u / 2u",
+          "value": {
+            "uint64Value": "30"
+          }
+        },
+        {
+          "name": "mod",
+          "expr": "42u % 5u",
+          "value": {
+            "uint64Value": "2"
+          }
+        },
+        {
+          "name": "negative_no_overload",
+          "expr": "-(5u)",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "mod_zero",
+          "expr": "34u % 0u",
+          "evalError": {
+            "errors": [
+              {
+                "message": "modulus by zero"
+              }
+            ]
+          }
+        },
+        {
+          "name": "divide_zero",
+          "expr": "15u / 0u",
+          "evalError": {
+            "errors": [
+              {
+                "message": "divide by zero"
+              }
+            ]
+          }
+        },
+        {
+          "name": "multiply_zero",
+          "expr": "15u * 0u",
+          "value": {
+            "uint64Value": "0"
+          }
+        },
+        {
+          "name": "add_left_identity",
+          "expr": "0u + 17u",
+          "value": {
+            "uint64Value": "17"
+          }
+        },
+        {
+          "name": "add_right_identity",
+          "expr": " 29u + 0u",
+          "value": {
+            "uint64Value": "29"
+          }
+        },
+        {
+          "name": "add_commutative",
+          "expr": "75u + 15u == 15u + 75u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "add_associative",
+          "expr": "5u + (15u + 20u) == (5u + 15u) + 20u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "mul_left_identity",
+          "expr": "1u * 45u",
+          "value": {
+            "uint64Value": "45"
+          }
+        },
+        {
+          "name": "mul_right_identity",
+          "expr": "25u * 1u",
+          "value": {
+            "uint64Value": "25"
+          }
+        },
+        {
+          "name": "mul_commutative",
+          "expr": "15u * 25u == 25u * 15u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "mul_associative",
+          "expr": "15u * (23u * 88u) == (15u * 23u) * 88u",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "add_mul_distribute",
+          "expr": "5u * (15u + 25u)  == 5u * 15u + 5u * 25u",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/lists.json
+++ b/packages/cel-spec/src/testdata/json/lists.json
@@ -1,0 +1,358 @@
+{
+  "name": "lists",
+  "description": "Tests for list operations.",
+  "section": [
+    {
+      "name": "concatenation",
+      "description": "Tests for list concatenation.",
+      "test": [
+        {
+          "name": "list_append",
+          "expr": "[0, 1, 2] + [3, 4, 5] == [0, 1, 2, 3, 4, 5]",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "list_not_commutative",
+          "expr": "[0, 1, 2] + [3, 4, 5] == [3, 4, 5, 0, 1, 2]",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_repeat",
+          "expr": "[2] + [2]",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "int64Value": "2"
+                },
+                {
+                  "int64Value": "2"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "empty_empty",
+          "expr": "[] + []",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "left_unit",
+          "expr": "[] + [3, 4]",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "int64Value": "3"
+                },
+                {
+                  "int64Value": "4"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "right_unit",
+          "expr": "[1, 2] + []",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "int64Value": "1"
+                },
+                {
+                  "int64Value": "2"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "index",
+      "description": "List indexing tests.",
+      "test": [
+        {
+          "name": "zero_based",
+          "expr": "[7, 8, 9][0]",
+          "value": {
+            "int64Value": "7"
+          }
+        },
+        {
+          "name": "zero_based_double",
+          "expr": "[7, 8, 9][dyn(0.0)]",
+          "value": {
+            "int64Value": "7"
+          }
+        },
+        {
+          "name": "zero_based_double_error",
+          "expr": "[7, 8, 9][dyn(0.1)]",
+          "evalError": {
+            "errors": [
+              {
+                "message": "invalid_argument"
+              }
+            ]
+          }
+        },
+        {
+          "name": "zero_based_uint",
+          "expr": "[7, 8, 9][dyn(0u)]",
+          "value": {
+            "int64Value": "7"
+          }
+        },
+        {
+          "name": "singleton",
+          "expr": "['foo'][0]",
+          "value": {
+            "stringValue": "foo"
+          }
+        },
+        {
+          "name": "middle",
+          "expr": "[0, 1, 1, 2, 3, 5, 8, 13][4]",
+          "value": {
+            "int64Value": "3"
+          }
+        },
+        {
+          "name": "last",
+          "expr": "['George', 'John', 'Paul', 'Ringo'][3]",
+          "value": {
+            "stringValue": "Ringo"
+          }
+        },
+        {
+          "name": "index_out_of_bounds",
+          "expr": "[1, 2, 3][3]",
+          "evalError": {
+            "errors": [
+              {
+                "message": "invalid_argument"
+              }
+            ]
+          }
+        },
+        {
+          "name": "index_out_of_bounds_or_false",
+          "expr": "dyn([1, 2, 3][3]) || false",
+          "evalError": {
+            "errors": [
+              {
+                "message": "invalid_argument"
+              }
+            ]
+          }
+        },
+        {
+          "name": "index_out_of_bounds_or_true",
+          "expr": "dyn([1, 2, 3][3]) || true",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "index_out_of_bounds_and_false",
+          "expr": "dyn([1, 2, 3][3]) && false",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "index_out_of_bounds_and_true",
+          "expr": "dyn([1, 2, 3][3]) && true",
+          "evalError": {
+            "errors": [
+              {
+                "message": "invalid_argument"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bad_index_type",
+          "expr": "[1, 2, 3][dyn('')]",
+          "evalError": {
+            "errors": [
+              {
+                "message": "invalid_argument"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bad_index_type_or_false",
+          "expr": "dyn([1, 2, 3][dyn('')]) || false",
+          "evalError": {
+            "errors": [
+              {
+                "message": "invalid_argument"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bad_index_type_or_true",
+          "expr": "dyn([1, 2, 3][dyn('')]) || true",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "bad_index_type_and_false",
+          "expr": "dyn([1, 2, 3][dyn('')]) && false",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "bad_index_type_and_true",
+          "expr": "dyn([1, 2, 3][dyn('')]) && true",
+          "evalError": {
+            "errors": [
+              {
+                "message": "invalid_argument"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "in",
+      "description": "List membership tests.",
+      "test": [
+        {
+          "name": "empty",
+          "expr": "7 in []",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "singleton",
+          "expr": "4u in [4u]",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "first",
+          "expr": "'alpha' in ['alpha', 'beta', 'gamma']",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "middle",
+          "expr": "3 in [5, 4, 3, 2, 1]",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "last",
+          "expr": "20u in [4u, 6u, 8u, 12u, 20u]",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "double_in_ints",
+          "expr": "dyn(3.0) in [5, 4, 3, 2, 1]",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "uint_in_ints",
+          "expr": "dyn(3u) in [5, 4, 3, 2, 1]",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "int_in_doubles",
+          "expr": "dyn(3) in [5.0, 4.0, 3.0, 2.0, 1.0]",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "uint_in_doubles",
+          "expr": "dyn(3u) in [5.0, 4.0, 3.0, 2.0, 1.0]",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "int_in_uints",
+          "expr": "dyn(3) in [5u, 4u, 3u, 2u, 1u]",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "double_in_uints",
+          "expr": "dyn(3.0) in [5u, 4u, 3u, 2u, 1u]",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "missing",
+          "expr": "'hawaiian' in ['meat', 'veggie', 'margarita', 'cheese']",
+          "value": {
+            "boolValue": false
+          }
+        }
+      ]
+    },
+    {
+      "name": "size",
+      "description": "List and map size tests.",
+      "test": [
+        {
+          "name": "list_empty",
+          "expr": "size([])",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "list",
+          "expr": "size([1, 2, 3])",
+          "value": {
+            "int64Value": "3"
+          }
+        },
+        {
+          "name": "map_empty",
+          "expr": "size({})",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "map",
+          "expr": "size({1: 'one', 2: 'two', 3: 'three'})",
+          "value": {
+            "int64Value": "3"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/logic.json
+++ b/packages/cel-spec/src/testdata/json/logic.json
@@ -1,0 +1,285 @@
+{
+  "name": "logic",
+  "description": "Tests for logical special operators.",
+  "section": [
+    {
+      "name": "conditional",
+      "description": "Tests for the conditional operator.",
+      "test": [
+        {
+          "name": "true_case",
+          "expr": "true ? 1 : 2",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "false_case",
+          "expr": "false ? 'foo' : 'bar'",
+          "value": {
+            "stringValue": "bar"
+          }
+        },
+        {
+          "name": "error_case",
+          "expr": "2 / 0 > 4 ? 'baz' : 'quux'",
+          "evalError": {
+            "errors": [
+              {
+                "message": "division by zero"
+              }
+            ]
+          }
+        },
+        {
+          "name": "mixed_type",
+          "expr": "true ? 'cows' : 17",
+          "disableCheck": true,
+          "value": {
+            "stringValue": "cows"
+          }
+        },
+        {
+          "name": "bad_type",
+          "expr": "'cows' ? false : 17",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no matching overload"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "AND",
+      "description": "Tests for logical AND.",
+      "test": [
+        {
+          "name": "all_true",
+          "expr": "true && true",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "all_false",
+          "expr": "false && false",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "false_left",
+          "expr": "false && true",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "false_right",
+          "expr": "true && false",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "short_circuit_type_left",
+          "expr": "false && 32",
+          "disableCheck": true,
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "short_circuit_type_right",
+          "expr": "'horses' && false",
+          "disableCheck": true,
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "short_circuit_error_left",
+          "expr": "false && (2 / 0 > 3 ? false : true)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "short_circuit_error_right",
+          "expr": "(2 / 0 > 3 ? false : true) && false",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "error_right",
+          "expr": "true && 1/0 != 0",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no matching overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "error_left",
+          "expr": "1/0 != 0 && true",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no matching overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "no_overload",
+          "expr": "'less filling' && 'tastes great'",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no matching overload"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "OR",
+      "description": "Tests for logical OR",
+      "test": [
+        {
+          "name": "all_true",
+          "expr": "true || true",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "all_false",
+          "expr": "false || false",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "false_left",
+          "expr": "false || true",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "false_right",
+          "expr": "true || false",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "short_circuit_type_left",
+          "expr": "true || 32",
+          "disableCheck": true,
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "short_circuit_type_right",
+          "expr": "'horses' || true",
+          "disableCheck": true,
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "short_circuit_error_left",
+          "expr": "true || (2 / 0 > 3 ? false : true)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "short_circuit_error_right",
+          "expr": "(2 / 0 > 3 ? false : true) || true",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "error_right",
+          "expr": "false || 1/0 != 0",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no matching overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "error_left",
+          "expr": "1/0 != 0 || false",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no matching overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "no_overload",
+          "expr": "'less filling' || 'tastes great'",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no matching overload"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "NOT",
+      "description": "Tests for logical NOT.",
+      "test": [
+        {
+          "name": "not_true",
+          "expr": "!true",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "not_false",
+          "expr": "!false",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "no_overload",
+          "expr": "!0",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no matching overload"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/macros.json
+++ b/packages/cel-spec/src/testdata/json/macros.json
@@ -1,0 +1,430 @@
+{
+  "name": "macros",
+  "description": "Tests for CEL macros.",
+  "section": [
+    {
+      "name": "exists",
+      "description": "Tests for the .exists() macro, which is equivalent to joining the evaluated elements with logical-OR.",
+      "test": [
+        {
+          "name": "list_elem_all_true",
+          "expr": "[1, 2, 3].exists(e, e > 0)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "list_elem_some_true",
+          "expr": "[1, 2, 3].exists(e, e == 2)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "list_elem_none_true",
+          "expr": "[1, 2, 3].exists(e, e > 3)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_elem_type_shortcircuit",
+          "description": "Exists filter is true for the last element.",
+          "expr": "[1, 'foo', 3].exists(e, e != '1')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "list_elem_type_exhaustive",
+          "description": "Exists filter is never true, but heterogenous equality ensure the result is false.",
+          "expr": "[1, 'foo', 3].exists(e, e == '10')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_elem_exists_error",
+          "expr": "[1, 2, 3].exists(e, e / 0 == 17)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "divide by zero"
+              }
+            ]
+          }
+        },
+        {
+          "name": "list_empty",
+          "expr": "[].exists(e, e == 2)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_key",
+          "expr": "{'key1':1, 'key2':2}.exists(k, k == 'key2')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_map_key",
+          "expr": "!{'key1':1, 'key2':2}.exists(k, k == 'key3')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_key_type_shortcircuit",
+          "description": "Exists filter is true for the second key",
+          "expr": "{'key':1, 1:21}.exists(k, k != 2)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_key_type_exhaustive",
+          "description": "Exists filter is never true, but heterogeneous equality ensures the result is false.",
+          "expr": "!{'key':1, 1:42}.exists(k, k == 2)",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "all",
+      "description": "Tests for the .all() macro, which is equivalent to joining the evaluated elements with logical-AND.",
+      "test": [
+        {
+          "name": "list_elem_all_true",
+          "expr": "[1, 2, 3].all(e, e > 0)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "list_elem_some_true",
+          "expr": "[1, 2, 3].all(e, e == 2)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_elem_none_true",
+          "expr": "[1, 2, 3].all(e, e == 17)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_elem_type_shortcircuit",
+          "expr": "[1, 'foo', 3].all(e, e == 1)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_elem_type_exhaustive",
+          "expr": "[1, 'foo', 3].all(e, e % 2 == 1)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_such_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "list_elem_error_shortcircuit",
+          "expr": "[1, 2, 3].all(e, 6 / (2 - e) == 6)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_elem_error_exhaustive",
+          "expr": "[1, 2, 3].all(e, e / 0 != 17)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "divide by zero"
+              }
+            ]
+          }
+        },
+        {
+          "name": "list_empty",
+          "expr": "[].all(e, e > 0)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_key",
+          "expr": "{'key1':1, 'key2':2}.all(k, k == 'key2')",
+          "value": {
+            "boolValue": false
+          }
+        }
+      ]
+    },
+    {
+      "name": "exists_one",
+      "description": "Tests for exists_one() macro. An expression 'L.exists_one(I, E)' is equivalent to 'size(L.filter(I, E)) == 1'.",
+      "test": [
+        {
+          "name": "list_empty",
+          "expr": "[].exists_one(a, a == 7)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_one_true",
+          "expr": "[7].exists_one(a, a == 7)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "list_one_false",
+          "expr": "[8].exists_one(a, a == 7)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_none",
+          "expr": "[1, 2, 3].exists_one(x, x > 20)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_one",
+          "expr": "[6, 7, 8].exists_one(foo, foo % 5 == 2)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "list_many",
+          "expr": "[0, 1, 2, 3, 4].exists_one(n, n % 2 == 1)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_all",
+          "expr": "['foal', 'foo', 'four'].exists_one(n, n.startsWith('fo'))",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_no_shortcircuit",
+          "description": "Errors invalidate everything, even if already false.",
+          "expr": "[3, 2, 1, 0].exists_one(n, 12 / n > 1)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "divide by zero"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_one",
+          "expr": "{6: 'six', 7: 'seven', 8: 'eight'}.exists_one(foo, foo % 5 == 2)",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "map",
+      "description": "Tests for map() macro.",
+      "test": [
+        {
+          "name": "list_empty",
+          "expr": "[].map(n, n / 2)",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "list_one",
+          "expr": "[3].map(n, n * n)",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "int64Value": "9"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "list_many",
+          "expr": "[2, 4, 6].map(n, n / 2)",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "int64Value": "1"
+                },
+                {
+                  "int64Value": "2"
+                },
+                {
+                  "int64Value": "3"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "list_error",
+          "expr": "[2, 1, 0].map(n, 4 / n)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "divide by zero"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_extract_keys",
+          "expr": "{'John': 'smart'}.map(key, key) == ['John']",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "filter",
+      "description": "Tests for filter() macro.",
+      "test": [
+        {
+          "name": "list_empty",
+          "expr": "[].filter(n, n % 2 == 0)",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "list_one_true",
+          "expr": "[2].filter(n, n == 2)",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "int64Value": "2"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "list_one_false",
+          "expr": "[1].filter(n, n > 3)",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "list_none",
+          "expr": "[1, 2, 3].filter(e, e > 3)",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "list_some",
+          "expr": "[0, 1, 2, 3, 4].filter(x, x % 2 == 1)",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "int64Value": "1"
+                },
+                {
+                  "int64Value": "3"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "list_all",
+          "expr": "[1, 2, 3].filter(n, n > 0)",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "int64Value": "1"
+                },
+                {
+                  "int64Value": "2"
+                },
+                {
+                  "int64Value": "3"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "list_no_shortcircuit",
+          "expr": "[3, 2, 1, 0].filter(n, 12 / n > 4)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "divide by zero"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_filter_keys",
+          "expr": "{'John': 'smart', 'Paul': 'cute', 'George': 'quiet', 'Ringo': 'funny'}.filter(key, key == 'Ringo') == ['Ringo']",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "nested",
+      "description": "Tests with nested macros.",
+      "test": [
+        {
+          "name": "filter_all",
+          "expr": "['signer'].filter(signer, ['artifact'].all(artifact, true))",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "stringValue": "signer"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "all_all",
+          "expr": "['signer'].all(signer, ['artifact'].all(artifact, true))",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/macros2.json
+++ b/packages/cel-spec/src/testdata/json/macros2.json
@@ -1,0 +1,491 @@
+{
+  "name": "macros2",
+  "description": "Tests for CEL comprehensions v2",
+  "section": [
+    {
+      "name": "exists",
+      "description": "Tests for the .exists() macro, which is equivalent to joining the evaluated elements with logical-OR.",
+      "test": [
+        {
+          "name": "list_elem_all_true",
+          "expr": "[1, 2, 3].exists(i, v, i > -1 && v > 0)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "list_elem_some_true",
+          "expr": "[1, 2, 3].exists(i, v, i == 1 && v == 2)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "list_elem_none_true",
+          "expr": "[1, 2, 3].exists(i, v, i > 2 && v > 3)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_elem_type_shortcircuit",
+          "expr": "[1, 'foo', 3].exists(i, v, i == 1 && v != '1')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "list_elem_type_exhaustive",
+          "expr": "[1, 'foo', 3].exists(i, v, i == 3 || v == '10')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_elem_exists_error",
+          "expr": "[1, 2, 3].exists(i, v, v / i == 17)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "divide by zero"
+              }
+            ]
+          }
+        },
+        {
+          "name": "list_empty",
+          "expr": "[].exists(i, v, i == 0 || v == 2)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_key",
+          "expr": "{'key1':1, 'key2':2}.exists(k, v, k == 'key2' && v == 2)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_map_key",
+          "expr": "!{'key1':1, 'key2':2}.exists(k, v, k == 'key3' || v == 3)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_key_type_shortcircuit",
+          "expr": "{'key':1, 1:21}.exists(k, v, k != 2 && v != 22)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_key_type_exhaustive",
+          "expr": "!{'key':1, 1:42}.exists(k, v, k == 2 && v == 43)",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "all",
+      "description": "Tests for the .all() macro, which is equivalent to joining the evaluated elements with logical-AND.",
+      "test": [
+        {
+          "name": "list_elem_all_true",
+          "expr": "[1, 2, 3].all(i, v, i > -1 && v > 0)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "list_elem_some_true",
+          "expr": "[1, 2, 3].all(i, v, i == 1 && v == 2)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_elem_none_true",
+          "expr": "[1, 2, 3].all(i, v, i == 3 || v == 4)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_elem_type_shortcircuit",
+          "expr": "[1, 'foo', 3].all(i, v, i == 0 || v == 1)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_elem_type_exhaustive",
+          "expr": "[0, 'foo', 3].all(i, v, v % 2 == i)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_elem_type_error_exhaustive",
+          "expr": "[0, 'foo', 5].all(i, v, v % 3 == i)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_such_overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "list_elem_error_shortcircuit",
+          "expr": "[1, 2, 3].all(i, v, 6 / (2 - v) == i)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_elem_error_exhaustive",
+          "expr": "[1, 2, 3].all(i, v, v / i != 17)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "divide by zero"
+              }
+            ]
+          }
+        },
+        {
+          "name": "list_empty",
+          "expr": "[].all(i, v, i > -1 || v > 0)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_key",
+          "expr": "{'key1':1, 'key2':2}.all(k, v, k == 'key2' && v == 2)",
+          "value": {
+            "boolValue": false
+          }
+        }
+      ]
+    },
+    {
+      "name": "existsOne",
+      "description": "Tests for existsOne() macro. An expression 'L.existsOne(I, E)' is equivalent to 'size(L.filter(I, E)) == 1'.",
+      "test": [
+        {
+          "name": "list_empty",
+          "expr": "[].existsOne(i, v, i == 3 || v == 7)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_one_true",
+          "expr": "[7].existsOne(i, v, i == 0 && v == 7)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "list_one_false",
+          "expr": "[8].existsOne(i, v, i == 0 && v == 7)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_none",
+          "expr": "[1, 2, 3].existsOne(i, v, i > 2 || v > 3)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_one",
+          "expr": "[5, 7, 8].existsOne(i, v, v % 5 == i)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "list_many",
+          "expr": "[0, 1, 2, 3, 4].existsOne(i, v, v % 2 == i)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_all",
+          "expr": "['foal', 'foo', 'four'].existsOne(i, v, i > -1 && v.startsWith('fo'))",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_no_shortcircuit",
+          "expr": "[3, 2, 1, 0].existsOne(i, v, v / i > 1)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "divide by zero"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_one",
+          "expr": "{6: 'six', 7: 'seven', 8: 'eight'}.existsOne(k, v, k % 5 == 2 && v == 'seven')",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "transformList",
+      "description": "Tests for transformList() macro.",
+      "test": [
+        {
+          "name": "empty",
+          "expr": "[].transformList(i, v, i / v)",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "empty_filter",
+          "expr": "[].transformList(i, v, i > v, i / v)",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "one",
+          "expr": "[3].transformList(i, v, v * v + i)",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "int64Value": "9"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "one_filter",
+          "expr": "[3].transformList(i, v, i == 0 && v == 3, v * v + i)",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "int64Value": "9"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "many",
+          "expr": "[2, 4, 6].transformList(i, v, v / 2 + i)",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "int64Value": "1"
+                },
+                {
+                  "int64Value": "3"
+                },
+                {
+                  "int64Value": "5"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "many_filter",
+          "expr": "[2, 4, 6].transformList(i, v, i != 1 && v != 4, v / 2 + i)",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "int64Value": "1"
+                },
+                {
+                  "int64Value": "5"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "error",
+          "expr": "[2, 1, 0].transformList(i, v, v / i)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "divide by zero"
+              }
+            ]
+          }
+        },
+        {
+          "name": "error_filter",
+          "expr": "[2, 1, 0].transformList(i, v, v / i > 0, v)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "divide by zero"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "transformMap",
+      "description": "Tests for transformMap() macro.",
+      "test": [
+        {
+          "name": "empty",
+          "expr": "{}.transformMap(k, v, k + v)",
+          "value": {
+            "mapValue": {}
+          }
+        },
+        {
+          "name": "empty_filter",
+          "expr": "{}.transformMap(k, v, k == 'foo' && v == 'bar', k + v)",
+          "value": {
+            "mapValue": {}
+          }
+        },
+        {
+          "name": "one",
+          "expr": "{'foo': 'bar'}.transformMap(k, v, k + v)",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "foo"
+                  },
+                  "value": {
+                    "stringValue": "foobar"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "one_filter",
+          "expr": "{'foo': 'bar'}.transformMap(k, v, k == 'foo' && v == 'bar', k + v)",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "foo"
+                  },
+                  "value": {
+                    "stringValue": "foobar"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "many",
+          "expr": "{'foo': 'bar', 'baz': 'bux', 'hello': 'world'}.transformMap(k, v, k + v)",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "foo"
+                  },
+                  "value": {
+                    "stringValue": "foobar"
+                  }
+                },
+                {
+                  "key": {
+                    "stringValue": "baz"
+                  },
+                  "value": {
+                    "stringValue": "bazbux"
+                  }
+                },
+                {
+                  "key": {
+                    "stringValue": "hello"
+                  },
+                  "value": {
+                    "stringValue": "helloworld"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "many_filter",
+          "expr": "{'foo': 'bar', 'baz': 'bux', 'hello': 'world'}.transformMap(k, v, k != 'baz' && v != 'bux', k + v)",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "foo"
+                  },
+                  "value": {
+                    "stringValue": "foobar"
+                  }
+                },
+                {
+                  "key": {
+                    "stringValue": "hello"
+                  },
+                  "value": {
+                    "stringValue": "helloworld"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "error",
+          "expr": "{'foo': 2, 'bar': 1, 'baz': 0}.transformMap(k, v, 4 / v)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "divide by zero"
+              }
+            ]
+          }
+        },
+        {
+          "name": "error_filter",
+          "expr": "{'foo': 2, 'bar': 1, 'baz': 0}.transformMap(k, v, k == 'baz' && 4 / v == 0, v)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "divide by zero"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/math_ext.json
+++ b/packages/cel-spec/src/testdata/json/math_ext.json
@@ -1,0 +1,1323 @@
+{
+  "name": "math_ext",
+  "description": "Tests for the math extension library.",
+  "section": [
+    {
+      "name": "greatest_int_result",
+      "test": [
+        {
+          "name": "unary_negative",
+          "expr": "math.greatest(-5)",
+          "value": {
+            "int64Value": "-5"
+          }
+        },
+        {
+          "name": "unary_positive",
+          "expr": "math.greatest(5)",
+          "value": {
+            "int64Value": "5"
+          }
+        },
+        {
+          "name": "binary_same_args",
+          "expr": "math.greatest(1, 1)",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "binary_with_decimal",
+          "expr": "math.greatest(1, 1.0) == 1"
+        },
+        {
+          "name": "binary_with_uint",
+          "expr": "math.greatest(1, 1u) == 1"
+        },
+        {
+          "name": "binary_first_arg_greater",
+          "expr": "math.greatest(3, -3)",
+          "value": {
+            "int64Value": "3"
+          }
+        },
+        {
+          "name": "binary_second_arg_greater",
+          "expr": "math.greatest(-7, 5)",
+          "value": {
+            "int64Value": "5"
+          }
+        },
+        {
+          "name": "binary_first_arg_int_max",
+          "expr": "math.greatest(9223372036854775807, 1)",
+          "value": {
+            "int64Value": "9223372036854775807"
+          }
+        },
+        {
+          "name": "binary_second_arg_int_max",
+          "expr": "math.greatest(1, 9223372036854775807)",
+          "value": {
+            "int64Value": "9223372036854775807"
+          }
+        },
+        {
+          "name": "binary_first_arg_int_min",
+          "expr": "math.greatest(-9223372036854775808, 1)",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "binary_second_arg_int_min",
+          "expr": "math.greatest(1, -9223372036854775808)",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "ternary_same_args",
+          "expr": "math.greatest(1, 1, 1) == 1"
+        },
+        {
+          "name": "ternary_with_decimal",
+          "expr": "math.greatest(1, 1.0, 1.0) == 1"
+        },
+        {
+          "name": "ternary_with_uint",
+          "expr": "math.greatest(1, 1u, 1u) == 1"
+        },
+        {
+          "name": "ternary_first_arg_greatest",
+          "expr": "math.greatest(10, 1, 3) == 10"
+        },
+        {
+          "name": "ternary_third_arg_greatest",
+          "expr": "math.greatest(1, 3, 10) == 10"
+        },
+        {
+          "name": "ternary_with_negatives",
+          "expr": "math.greatest(-1, -2, -3) == -1"
+        },
+        {
+          "name": "ternary_int_max",
+          "expr": "math.greatest(9223372036854775807, 1, 5) == 9223372036854775807"
+        },
+        {
+          "name": "ternary_int_min",
+          "expr": "math.greatest(-9223372036854775807, -1, -5) == -1"
+        },
+        {
+          "name": "quaternary_mixed",
+          "expr": "math.greatest(5.4, 10, 3u, -5.0, 9223372036854775807) == 9223372036854775807"
+        },
+        {
+          "name": "quaternary_mixed_array",
+          "expr": "math.greatest([5.4, 10, 3u, -5.0, 3.5]) == 10"
+        },
+        {
+          "name": "quaternary_mixed_dyn_array",
+          "expr": "math.greatest([dyn(5.4), dyn(10), dyn(3u), dyn(-5.0), dyn(3.5)]) == 10"
+        }
+      ]
+    },
+    {
+      "name": "greatest_double_result",
+      "test": [
+        {
+          "name": "unary_negative",
+          "expr": "math.greatest(-5.0)",
+          "value": {
+            "doubleValue": -5
+          }
+        },
+        {
+          "name": "unary_positive",
+          "expr": "math.greatest(5.0)",
+          "value": {
+            "doubleValue": 5
+          }
+        },
+        {
+          "name": "binary_same_args",
+          "expr": "math.greatest(1.0, 1.0)",
+          "value": {
+            "doubleValue": 1
+          }
+        },
+        {
+          "name": "binary_with_int",
+          "expr": "math.greatest(1.0, 1) == 1.0"
+        },
+        {
+          "name": "binary_with_uint",
+          "expr": "math.greatest(1.0, 1u) == 1.0"
+        },
+        {
+          "name": "binary_first_arg_greater",
+          "expr": "math.greatest(5.0, -7.0)",
+          "value": {
+            "doubleValue": 5
+          }
+        },
+        {
+          "name": "binary_second_arg_greater",
+          "expr": "math.greatest(-3.0, 3.0)",
+          "value": {
+            "doubleValue": 3
+          }
+        },
+        {
+          "name": "binary_first_arg_double_max",
+          "expr": "math.greatest(1.797693e308, 1)",
+          "value": {
+            "doubleValue": 1.797693e308
+          }
+        },
+        {
+          "name": "binary_second_arg_double_max",
+          "expr": "math.greatest(1, 1.797693e308)",
+          "value": {
+            "doubleValue": 1.797693e308
+          }
+        },
+        {
+          "name": "binary_first_arg_double_min",
+          "expr": "math.greatest(-1.797693e308, 1.5)",
+          "value": {
+            "doubleValue": 1.5
+          }
+        },
+        {
+          "name": "binary_second_arg_double_min",
+          "expr": "math.greatest(1.5, -1.797693e308)",
+          "value": {
+            "doubleValue": 1.5
+          }
+        },
+        {
+          "name": "ternary_same_args",
+          "expr": "math.greatest(1.0, 1.0, 1.0) == 1.0"
+        },
+        {
+          "name": "ternary_with_int",
+          "expr": "math.greatest(1.0, 1, 1) == 1.0"
+        },
+        {
+          "name": "ternary_with_uint",
+          "expr": "math.greatest(1.0, 1u, 1u) == 1.0"
+        },
+        {
+          "name": "ternary_first_arg_greatest",
+          "expr": "math.greatest(10.5, 1.5, 3.5) == 10.5"
+        },
+        {
+          "name": "ternary_third_arg_greatest",
+          "expr": "math.greatest(1.5, 3.5, 10.5) == 10.5"
+        },
+        {
+          "name": "ternary_with_negatives",
+          "expr": "math.greatest(-1.5, -2.5, -3.5) == -1.5"
+        },
+        {
+          "name": "ternary_double_max",
+          "expr": "math.greatest(1.797693e308, 1, 5) == 1.797693e308"
+        },
+        {
+          "name": "ternary_double_min",
+          "expr": "math.greatest(-1.797693e308, -1, -5) == -1"
+        },
+        {
+          "name": "quaternary_mixed",
+          "expr": "math.greatest(5.4, 10, 3u, -5.0, 1.797693e308) == 1.797693e308"
+        },
+        {
+          "name": "quaternary_mixed_array",
+          "expr": "math.greatest([5.4, 10.5, 3u, -5.0, 3.5]) == 10.5"
+        },
+        {
+          "name": "quaternary_mixed_dyn_array",
+          "expr": "math.greatest([dyn(5.4), dyn(10.5), dyn(3u), dyn(-5.0), dyn(3.5)]) == 10.5"
+        }
+      ]
+    },
+    {
+      "name": "greatest_uint_result",
+      "test": [
+        {
+          "name": "unary",
+          "expr": "math.greatest(5u)",
+          "value": {
+            "uint64Value": "5"
+          }
+        },
+        {
+          "name": "binary_same_args",
+          "expr": "math.greatest(1u, 1u)",
+          "value": {
+            "uint64Value": "1"
+          }
+        },
+        {
+          "name": "binary_with_decimal",
+          "expr": "math.greatest(1u, 1.0) == 1"
+        },
+        {
+          "name": "binary_with_int",
+          "expr": "math.greatest(1u, 1) == 1u"
+        },
+        {
+          "name": "binary_first_arg_greater",
+          "expr": "math.greatest(5u, -7)",
+          "value": {
+            "uint64Value": "5"
+          }
+        },
+        {
+          "name": "binary_second_arg_greater",
+          "expr": "math.greatest(-3, 3u)",
+          "value": {
+            "uint64Value": "3"
+          }
+        },
+        {
+          "name": "binary_first_arg_uint_max",
+          "expr": "math.greatest(18446744073709551615u, 1u)",
+          "value": {
+            "uint64Value": "18446744073709551615"
+          }
+        },
+        {
+          "name": "binary_second_arg_uint_max",
+          "expr": "math.greatest(1u, 18446744073709551615u)",
+          "value": {
+            "uint64Value": "18446744073709551615"
+          }
+        },
+        {
+          "name": "ternary_same_args",
+          "expr": "math.greatest(1u, 1u, 1u) == 1u"
+        },
+        {
+          "name": "ternary_with_decimal",
+          "expr": "math.greatest(1u, 1.0, 1.0) == 1u"
+        },
+        {
+          "name": "ternary_with_int",
+          "expr": "math.greatest(1u, 1, 1) == 1u"
+        },
+        {
+          "name": "ternary_first_arg_greatest",
+          "expr": "math.greatest(10u, 1u, 3u) == 10u"
+        },
+        {
+          "name": "ternary_third_arg_greatest",
+          "expr": "math.greatest(1u, 3u, 10u) == 10u"
+        },
+        {
+          "name": "ternary_int_max",
+          "expr": "math.greatest(18446744073709551615u, 1u, 5u) == 18446744073709551615u"
+        },
+        {
+          "name": "quaternary_mixed",
+          "expr": "math.greatest(5.4, 10, 3u, -5.0, 18446744073709551615u) == 18446744073709551615u"
+        },
+        {
+          "name": "quaternary_mixed_array",
+          "expr": "math.greatest([5.4, 10u, 3u, -5.0, 3.5]) == 10u"
+        },
+        {
+          "name": "quaternary_mixed_dyn_array",
+          "expr": "math.greatest([dyn(5.4), dyn(10u), dyn(3u), dyn(-5.0), dyn(3.5)]) == 10u"
+        }
+      ]
+    },
+    {
+      "name": "least_int_result",
+      "test": [
+        {
+          "name": "unary_negative",
+          "expr": "math.least(-5)",
+          "value": {
+            "int64Value": "-5"
+          }
+        },
+        {
+          "name": "unary_positive",
+          "expr": "math.least(5)",
+          "value": {
+            "int64Value": "5"
+          }
+        },
+        {
+          "name": "binary_same_args",
+          "expr": "math.least(1, 1)",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "binary_with_decimal",
+          "expr": "math.least(1, 1.0) == 1"
+        },
+        {
+          "name": "binary_with_uint",
+          "expr": "math.least(1, 1u) == 1"
+        },
+        {
+          "name": "binary_first_arg_least",
+          "expr": "math.least(-3, 3)",
+          "value": {
+            "int64Value": "-3"
+          }
+        },
+        {
+          "name": "binary_second_arg_least",
+          "expr": "math.least(5, -7)",
+          "value": {
+            "int64Value": "-7"
+          }
+        },
+        {
+          "name": "binary_first_arg_int_max",
+          "expr": "math.least(9223372036854775807, 1)",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "binary_second_arg_int_max",
+          "expr": "math.least(1, 9223372036854775807)",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "binary_first_arg_int_min",
+          "expr": "math.least(-9223372036854775808, 1)",
+          "value": {
+            "int64Value": "-9223372036854775808"
+          }
+        },
+        {
+          "name": "binary_second_arg_int_min",
+          "expr": "math.least(1, -9223372036854775808)",
+          "value": {
+            "int64Value": "-9223372036854775808"
+          }
+        },
+        {
+          "name": "ternary_same_args",
+          "expr": "math.least(1, 1, 1) == 1"
+        },
+        {
+          "name": "ternary_with_decimal",
+          "expr": "math.least(1, 1.0, 1.0) == 1"
+        },
+        {
+          "name": "ternary_with_uint",
+          "expr": "math.least(1, 1u, 1u) == 1"
+        },
+        {
+          "name": "ternary_first_arg_least",
+          "expr": "math.least(0, 1, 3) == 0"
+        },
+        {
+          "name": "ternary_third_arg_least",
+          "expr": "math.least(1, 3, 0) == 0"
+        },
+        {
+          "name": "ternary_with_negatives",
+          "expr": "math.least(-1, -2, -3) == -3"
+        },
+        {
+          "name": "ternary_int_max",
+          "expr": "math.least(9223372036854775807, 1, 5) == 1"
+        },
+        {
+          "name": "ternary_int_min",
+          "expr": "math.least(-9223372036854775808, -1, -5) == -9223372036854775808"
+        },
+        {
+          "name": "quaternary_mixed",
+          "expr": "math.least(5.4, 10, 3u, -5.0, 9223372036854775807) == -5.0"
+        },
+        {
+          "name": "quaternary_mixed_array",
+          "expr": "math.least([5.4, 10, 3u, -5.0, 3.5]) == -5.0"
+        },
+        {
+          "name": "quaternary_mixed_dyn_array",
+          "expr": "math.least([dyn(5.4), dyn(10), dyn(3u), dyn(-5.0), dyn(3.5)]) == -5.0"
+        }
+      ]
+    },
+    {
+      "name": "least_double_result",
+      "test": [
+        {
+          "name": "unary_negative",
+          "expr": "math.least(-5.5)",
+          "value": {
+            "doubleValue": -5.5
+          }
+        },
+        {
+          "name": "unary_positive",
+          "expr": "math.least(5.5)",
+          "value": {
+            "doubleValue": 5.5
+          }
+        },
+        {
+          "name": "binary_same_args",
+          "expr": "math.least(1.5, 1.5)",
+          "value": {
+            "doubleValue": 1.5
+          }
+        },
+        {
+          "name": "binary_with_int",
+          "expr": "math.least(1.0, 1) == 1"
+        },
+        {
+          "name": "binary_with_uint",
+          "expr": "math.least(1, 1u) == 1"
+        },
+        {
+          "name": "binary_first_arg_least",
+          "expr": "math.least(-3.5, 3.5)",
+          "value": {
+            "doubleValue": -3.5
+          }
+        },
+        {
+          "name": "binary_second_arg_least",
+          "expr": "math.least(5.5, -7.5)",
+          "value": {
+            "doubleValue": -7.5
+          }
+        },
+        {
+          "name": "binary_first_arg_double_max",
+          "expr": "math.least(1.797693e308, 1.5)",
+          "value": {
+            "doubleValue": 1.5
+          }
+        },
+        {
+          "name": "binary_second_arg_double_max",
+          "expr": "math.least(1.5, 1.797693e308)",
+          "value": {
+            "doubleValue": 1.5
+          }
+        },
+        {
+          "name": "binary_first_arg_double_min",
+          "expr": "math.least(-1.797693e308, 1.5)",
+          "value": {
+            "doubleValue": -1.797693e308
+          }
+        },
+        {
+          "name": "binary_second_arg_double_min",
+          "expr": "math.least(1.5, -1.797693e308)",
+          "value": {
+            "doubleValue": -1.797693e308
+          }
+        },
+        {
+          "name": "ternary_same_args",
+          "expr": "math.least(1.5, 1.5, 1.5) == 1.5"
+        },
+        {
+          "name": "ternary_with_int",
+          "expr": "math.least(1.0, 1, 1) == 1.0"
+        },
+        {
+          "name": "ternary_with_uint",
+          "expr": "math.least(1.0, 1u, 1u) == 1"
+        },
+        {
+          "name": "ternary_first_arg_least",
+          "expr": "math.least(0.5, 1.5, 3.5) == 0.5"
+        },
+        {
+          "name": "ternary_third_arg_least",
+          "expr": "math.least(1.5, 3.5, 0.5) == 0.5"
+        },
+        {
+          "name": "ternary_with_negatives",
+          "expr": "math.least(-1.5, -2.5, -3.5) == -3.5"
+        },
+        {
+          "name": "ternary_double_max",
+          "expr": "math.least(1.797693e308, 1, 5) == 1"
+        },
+        {
+          "name": "ternary_double_min",
+          "expr": "math.least(-1.797693e308, -1, -5) == -1.797693e308"
+        },
+        {
+          "name": "quaternary_mixed",
+          "expr": "math.least(5.4, 10, 3u, -5.0, 1.797693e308) == -5.0"
+        },
+        {
+          "name": "quaternary_mixed_array",
+          "expr": "math.least([5.4, 10.5, 3u, -5.0, 3.5]) == -5.0"
+        },
+        {
+          "name": "quaternary_mixed_dyn_array",
+          "expr": "math.least([dyn(5.4), dyn(10.5), dyn(3u), dyn(-5.0), dyn(3.5)]) == -5.0"
+        }
+      ]
+    },
+    {
+      "name": "least_uint_result",
+      "test": [
+        {
+          "name": "unary",
+          "expr": "math.least(5u)",
+          "value": {
+            "uint64Value": "5"
+          }
+        },
+        {
+          "name": "binary_same_args",
+          "expr": "math.least(1u, 1u)",
+          "value": {
+            "uint64Value": "1"
+          }
+        },
+        {
+          "name": "binary_with_decimal",
+          "expr": "math.least(1u, 1.0) == 1u"
+        },
+        {
+          "name": "binary_with_int",
+          "expr": "math.least(1u, 1) == 1u"
+        },
+        {
+          "name": "binary_first_arg_least",
+          "expr": "math.least(1u, 3u)",
+          "value": {
+            "uint64Value": "1"
+          }
+        },
+        {
+          "name": "binary_second_arg_least",
+          "expr": "math.least(5u, 2u)",
+          "value": {
+            "uint64Value": "2"
+          }
+        },
+        {
+          "name": "binary_first_arg_uint_max",
+          "expr": "math.least(18446744073709551615u, 1u)",
+          "value": {
+            "uint64Value": "1"
+          }
+        },
+        {
+          "name": "binary_second_arg_uint_max",
+          "expr": "math.least(1u, 18446744073709551615u)",
+          "value": {
+            "uint64Value": "1"
+          }
+        },
+        {
+          "name": "ternary_same_args",
+          "expr": "math.least(1u, 1u, 1u) == 1u"
+        },
+        {
+          "name": "ternary_with_decimal",
+          "expr": "math.least(1u, 1.0, 1.0) == 1u"
+        },
+        {
+          "name": "ternary_with_int",
+          "expr": "math.least(1u, 1, 1) == 1u"
+        },
+        {
+          "name": "ternary_first_arg_least",
+          "expr": "math.least(1u, 10u, 3u) == 1u"
+        },
+        {
+          "name": "ternary_third_arg_least",
+          "expr": "math.least(10u, 3u, 1u) == 1u"
+        },
+        {
+          "name": "ternary_uint_max",
+          "expr": "math.least(18446744073709551615u, 1u, 5u) == 1u"
+        },
+        {
+          "name": "quaternary_mixed",
+          "expr": "math.least(5.4, 10, 3u, 1u, 18446744073709551615u) == 1u"
+        },
+        {
+          "name": "quaternary_mixed_array",
+          "expr": "math.least([5.4, 10u, 3u, 1u, 3.5]) == 1u"
+        },
+        {
+          "name": "quaternary_mixed_dyn_array",
+          "expr": "math.least([dyn(5.4), dyn(10u), dyn(3u), dyn(1u), dyn(3.5)]) == 1u"
+        }
+      ]
+    },
+    {
+      "name": "ceil",
+      "test": [
+        {
+          "name": "negative",
+          "expr": "math.ceil(-1.2)",
+          "value": {
+            "doubleValue": -1
+          }
+        },
+        {
+          "name": "positive",
+          "expr": "math.ceil(1.2)",
+          "value": {
+            "doubleValue": 2
+          }
+        },
+        {
+          "name": "dyn_error",
+          "expr": "math.ceil(dyn(1))",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "floor",
+      "test": [
+        {
+          "name": "negative",
+          "expr": "math.floor(-1.2)",
+          "value": {
+            "doubleValue": -2
+          }
+        },
+        {
+          "name": "positive",
+          "expr": "math.floor(1.2)",
+          "value": {
+            "doubleValue": 1
+          }
+        },
+        {
+          "name": "dyn_error",
+          "expr": "math.floor(dyn(1))",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "round",
+      "test": [
+        {
+          "name": "negative_down",
+          "expr": "math.round(-1.6)",
+          "value": {
+            "doubleValue": -2
+          }
+        },
+        {
+          "name": "negative_up",
+          "expr": "math.round(-1.4)",
+          "value": {
+            "doubleValue": -1
+          }
+        },
+        {
+          "name": "negative_mid",
+          "expr": "math.round(-1.5)",
+          "value": {
+            "doubleValue": -2
+          }
+        },
+        {
+          "name": "positive_down",
+          "expr": "math.round(1.2)",
+          "value": {
+            "doubleValue": 1
+          }
+        },
+        {
+          "name": "positive_up",
+          "expr": "math.round(1.5)",
+          "value": {
+            "doubleValue": 2
+          }
+        },
+        {
+          "name": "nan",
+          "expr": "math.isNaN(math.round(0.0/0.0))"
+        },
+        {
+          "name": "dyn_error",
+          "expr": "math.round(dyn(1))",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "trunc",
+      "test": [
+        {
+          "name": "negative",
+          "expr": "math.trunc(-1.2)",
+          "value": {
+            "doubleValue": -1
+          }
+        },
+        {
+          "name": "positive",
+          "expr": "math.trunc(1.2)",
+          "value": {
+            "doubleValue": 1
+          }
+        },
+        {
+          "name": "nan",
+          "expr": "math.isNaN(math.trunc(0.0/0.0))"
+        },
+        {
+          "name": "dyn_error",
+          "expr": "math.trunc(dyn(1))",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "abs",
+      "test": [
+        {
+          "name": "uint",
+          "expr": "math.abs(1u)",
+          "value": {
+            "uint64Value": "1"
+          }
+        },
+        {
+          "name": "positive_int",
+          "expr": "math.abs(1)",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "negative_int",
+          "expr": "math.abs(-11)",
+          "value": {
+            "int64Value": "11"
+          }
+        },
+        {
+          "name": "positive_double",
+          "expr": "math.abs(1.5)",
+          "value": {
+            "doubleValue": 1.5
+          }
+        },
+        {
+          "name": "negative_double",
+          "expr": "math.abs(-11.5)",
+          "value": {
+            "doubleValue": 11.5
+          }
+        },
+        {
+          "name": "int_overflow",
+          "expr": "math.abs(-9223372036854775808)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "overflow"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "sign",
+      "test": [
+        {
+          "name": "positive_uint",
+          "expr": "math.sign(100u)",
+          "value": {
+            "uint64Value": "1"
+          }
+        },
+        {
+          "name": "zero_uint",
+          "expr": "math.sign(0u)",
+          "value": {
+            "uint64Value": "0"
+          }
+        },
+        {
+          "name": "positive_int",
+          "expr": "math.sign(100)",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "negative_int",
+          "expr": "math.sign(-11)",
+          "value": {
+            "int64Value": "-1"
+          }
+        },
+        {
+          "name": "zero_int",
+          "expr": "math.sign(0)",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "positive_double",
+          "expr": "math.sign(100.5)",
+          "value": {
+            "doubleValue": 1
+          }
+        },
+        {
+          "name": "negative_double",
+          "expr": "math.sign(-32.0)",
+          "value": {
+            "doubleValue": -1
+          }
+        },
+        {
+          "name": "zero_double",
+          "expr": "math.sign(0.0)",
+          "value": {
+            "doubleValue": 0
+          }
+        },
+        {
+          "name": "dyn_error",
+          "expr": "math.sign(dyn(true))",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "isNaN",
+      "test": [
+        {
+          "name": "true",
+          "expr": "math.isNaN(0.0/0.0)"
+        },
+        {
+          "name": "false",
+          "expr": "!math.isNaN(1.0/0.0)"
+        },
+        {
+          "name": "dyn_error",
+          "expr": "math.isNaN(dyn(true))",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "isInf",
+      "test": [
+        {
+          "name": "true",
+          "expr": "math.isInf(1.0/0.0)"
+        },
+        {
+          "name": "false",
+          "expr": "!math.isInf(0.0/0.0)"
+        },
+        {
+          "name": "dyn_error",
+          "expr": "math.isInf(dyn(true))",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "isFinite",
+      "test": [
+        {
+          "name": "true",
+          "expr": "math.isFinite(1.0/1.5)"
+        },
+        {
+          "name": "false_nan",
+          "expr": "!math.isFinite(0.0/0.0)"
+        },
+        {
+          "name": "false_inf",
+          "expr": "!math.isFinite(-1.0/0.0)"
+        },
+        {
+          "name": "dyn_error",
+          "expr": "math.isFinite(dyn(true))",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "bit_and",
+      "test": [
+        {
+          "name": "int_int_non_intersect",
+          "expr": "math.bitAnd(1, 2)",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "int_int_intersect",
+          "expr": "math.bitAnd(1, 3)",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "int_int_intersect_neg",
+          "expr": "math.bitAnd(1, -1)",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "uint_uint_non_intersect",
+          "expr": "math.bitAnd(1u, 2u)",
+          "value": {
+            "uint64Value": "0"
+          }
+        },
+        {
+          "name": "uint_uint_intersect",
+          "expr": "math.bitAnd(1u, 3u)",
+          "value": {
+            "uint64Value": "1"
+          }
+        },
+        {
+          "name": "int_dyn_error",
+          "expr": "math.bitAnd(2u, dyn(''))",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "bit_or",
+      "test": [
+        {
+          "name": "int_int_positive",
+          "expr": "math.bitOr(1, 2)",
+          "value": {
+            "int64Value": "3"
+          }
+        },
+        {
+          "name": "int_int_positive_negative",
+          "expr": "math.bitOr(4, -2)",
+          "value": {
+            "int64Value": "-2"
+          }
+        },
+        {
+          "name": "uint_uint",
+          "expr": "math.bitOr(1u, 4u)",
+          "value": {
+            "uint64Value": "5"
+          }
+        },
+        {
+          "name": "dyn_int_error",
+          "expr": "math.bitOr(dyn(1.2), 1)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "bit_xor",
+      "test": [
+        {
+          "name": "int_int_positive",
+          "expr": "math.bitXor(1, 3)",
+          "value": {
+            "int64Value": "2"
+          }
+        },
+        {
+          "name": "int_int_positive_negative",
+          "expr": "math.bitXor(4, -2)",
+          "value": {
+            "int64Value": "-6"
+          }
+        },
+        {
+          "name": "uint_uint",
+          "expr": "math.bitXor(1u, 3u)",
+          "value": {
+            "uint64Value": "2"
+          }
+        },
+        {
+          "name": "dyn_dyn_error",
+          "expr": "math.bitXor(dyn([]), dyn([1]))",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "bit_not",
+      "test": [
+        {
+          "name": "int_positive",
+          "expr": "math.bitNot(1)",
+          "value": {
+            "int64Value": "-2"
+          }
+        },
+        {
+          "name": "int_negative",
+          "expr": "math.bitNot(-1)",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "int_zero",
+          "expr": "math.bitNot(0)",
+          "value": {
+            "int64Value": "-1"
+          }
+        },
+        {
+          "name": "uint_positive",
+          "expr": "math.bitNot(1u)",
+          "value": {
+            "uint64Value": "18446744073709551614"
+          }
+        },
+        {
+          "name": "uint_zero",
+          "expr": "math.bitNot(0u)",
+          "value": {
+            "uint64Value": "18446744073709551615"
+          }
+        },
+        {
+          "name": "dyn_error",
+          "expr": "math.bitNot(dyn(''))",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "bit_shift_left",
+      "test": [
+        {
+          "name": "int",
+          "expr": "math.bitShiftLeft(1, 2)",
+          "value": {
+            "int64Value": "4"
+          }
+        },
+        {
+          "name": "int_large_shift",
+          "expr": "math.bitShiftLeft(1, 200)",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "int_negative_large_shift",
+          "expr": "math.bitShiftLeft(-1, 200)",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "uint",
+          "expr": "math.bitShiftLeft(1u, 2)",
+          "value": {
+            "uint64Value": "4"
+          }
+        },
+        {
+          "name": "uint_large_shift",
+          "expr": "math.bitShiftLeft(1u, 200)",
+          "value": {
+            "uint64Value": "0"
+          }
+        },
+        {
+          "name": "bad_shift",
+          "expr": "math.bitShiftLeft(1u, -1)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "negative offset"
+              }
+            ]
+          }
+        },
+        {
+          "name": "dyn_int_error",
+          "expr": "math.bitShiftLeft(dyn(4.3), 1)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "bit_shift_right",
+      "test": [
+        {
+          "name": "int",
+          "expr": "math.bitShiftRight(1024, 2)",
+          "value": {
+            "int64Value": "256"
+          }
+        },
+        {
+          "name": "int_large_shift",
+          "expr": "math.bitShiftRight(1024, 64)",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "int_negative",
+          "expr": "math.bitShiftRight(-1024, 3)",
+          "value": {
+            "int64Value": "2305843009213693824"
+          }
+        },
+        {
+          "name": "int_negative_large_shift",
+          "expr": "math.bitShiftRight(-1024, 64)",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "uint",
+          "expr": "math.bitShiftRight(1024u, 2)",
+          "value": {
+            "uint64Value": "256"
+          }
+        },
+        {
+          "name": "uint_large_shift",
+          "expr": "math.bitShiftRight(1024u, 200)",
+          "value": {
+            "uint64Value": "0"
+          }
+        },
+        {
+          "name": "bad_shift",
+          "expr": "math.bitShiftRight(1u, -1)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "negative offset"
+              }
+            ]
+          }
+        },
+        {
+          "name": "dyn_int_error",
+          "expr": "math.bitShiftRight(dyn(b'123'), 1)",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/namespace.json
+++ b/packages/cel-spec/src/testdata/json/namespace.json
@@ -1,0 +1,119 @@
+{
+  "name": "namespace",
+  "description": "Uses of qualified identifiers and namespaces.",
+  "section": [
+    {
+      "name": "qualified",
+      "description": "Qualified variable lookups.",
+      "test": [
+        {
+          "name": "self_eval_qualified_lookup",
+          "expr": "x.y",
+          "typeEnv": [
+            {
+              "name": "x.y",
+              "ident": {
+                "type": {
+                  "primitive": "BOOL"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x.y": {
+              "value": {
+                "boolValue": true
+              }
+            }
+          },
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "namespace",
+      "description": "Namespaced identifiers.",
+      "test": [
+        {
+          "name": "self_eval_container_lookup",
+          "expr": "y",
+          "typeEnv": [
+            {
+              "name": "x.y",
+              "ident": {
+                "type": {
+                  "primitive": "BOOL"
+                }
+              }
+            },
+            {
+              "name": "y",
+              "ident": {
+                "type": {
+                  "primitive": "STRING"
+                }
+              }
+            }
+          ],
+          "container": "x",
+          "bindings": {
+            "x.y": {
+              "value": {
+                "boolValue": true
+              }
+            },
+            "y": {
+              "value": {
+                "stringValue": "false"
+              }
+            }
+          },
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "self_eval_container_lookup_unchecked",
+          "expr": "y",
+          "disableCheck": true,
+          "typeEnv": [
+            {
+              "name": "x.y",
+              "ident": {
+                "type": {
+                  "primitive": "BOOL"
+                }
+              }
+            },
+            {
+              "name": "y",
+              "ident": {
+                "type": {
+                  "primitive": "BOOL"
+                }
+              }
+            }
+          ],
+          "container": "x",
+          "bindings": {
+            "x.y": {
+              "value": {
+                "boolValue": true
+              }
+            },
+            "y": {
+              "value": {
+                "boolValue": false
+              }
+            }
+          },
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/optionals.json
+++ b/packages/cel-spec/src/testdata/json/optionals.json
@@ -1,0 +1,606 @@
+{
+  "name": "optionals",
+  "description": "Tests for optionals.",
+  "section": [
+    {
+      "name": "optionals",
+      "test": [
+        {
+          "name": "null",
+          "expr": "optional.of(null).hasValue()",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "null_non_zero_value",
+          "expr": "optional.ofNonZeroValue(null).hasValue()",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "none_or_none_or_value",
+          "expr": "optional.none().or(optional.none()).orValue(42)",
+          "value": {
+            "int64Value": "42"
+          }
+        },
+        {
+          "name": "none_optMap_hasValue",
+          "expr": "optional.none().optMap(y, y + 1).hasValue()",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "empty_map_optFlatMap_hasValue",
+          "expr": "{}.?key.optFlatMap(k, k.?subkey).hasValue()",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_empty_submap_optFlatMap_hasValue",
+          "expr": "{'key': {}}.?key.optFlatMap(k, k.?subkey).hasValue()",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_null_entry_hasValue",
+          "expr": "{'null_key': dyn(null)}.?null_key.hasValue()",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_null_entry_no_such_key",
+          "expr": "{'null_key': dyn(null)}.?null_key.invalid.hasValue()",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such key"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_absent_key_absent_field_none",
+          "expr": "{true: dyn(0)}[?false].absent.hasValue()",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_present_key_invalid_field",
+          "expr": "{true: dyn(0)}[?true].absent.hasValue()",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such key"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map_undefined_entry_hasValue",
+          "expr": "{}.?null_key.invalid.hasValue()",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_submap_subkey_optFlatMap_value",
+          "expr": "{'key': {'subkey': 'subvalue'}}.?key.optFlatMap(k, k.?subkey).value()",
+          "value": {
+            "stringValue": "subvalue"
+          }
+        },
+        {
+          "name": "map_submap_optFlatMap_value",
+          "expr": "{'key': {'subkey': ''}}.?key.optFlatMap(k, k.?subkey).value()",
+          "value": {
+            "stringValue": ""
+          }
+        },
+        {
+          "name": "map_optindex_optFlatMap_optional_ofNonZeroValue_hasValue",
+          "expr": "{'key': {'subkey': ''}}.?key.optFlatMap(k, optional.ofNonZeroValue(k.subkey)).hasValue()",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "optional_of_optMap_value",
+          "expr": "optional.of(42).optMap(y, y + 1).value()",
+          "value": {
+            "int64Value": "43"
+          }
+        },
+        {
+          "name": "optional_ofNonZeroValue_or_optional_value",
+          "expr": "optional.ofNonZeroValue(42).or(optional.of(20)).value() == 42",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "ternary_optional_hasValue",
+          "expr": "(has({}.x) ? optional.of({}.x) : optional.none()).hasValue()",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_optindex_hasValue",
+          "expr": "{}.?x.hasValue()",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "has_map_optindex",
+          "expr": "has({}.?x.y)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "has_map_optindex_field",
+          "expr": "has({'x': {'y': 'z'}}.?x.y)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "type",
+          "expr": "type(optional.none()) == optional_type",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "optional_chaining_1",
+          "expr": "optional.ofNonZeroValue('').or(optional.of({'c': {'dashed-index': 'goodbye'}}.c['dashed-index'])).orValue('default value')",
+          "value": {
+            "stringValue": "goodbye"
+          }
+        },
+        {
+          "name": "optional_chaining_2",
+          "expr": "{'c': {'dashed-index': 'goodbye'}}.c[?'dashed-index'].orValue('default value')",
+          "value": {
+            "stringValue": "goodbye"
+          }
+        },
+        {
+          "name": "optional_chaining_3",
+          "expr": "{'c': {}}.c[?'missing-index'].orValue('default value')",
+          "value": {
+            "stringValue": "default value"
+          }
+        },
+        {
+          "name": "optional_chaining_4",
+          "expr": "optional.of({'c': {'index': 'goodbye'}}).c.index.orValue('default value')",
+          "value": {
+            "stringValue": "goodbye"
+          }
+        },
+        {
+          "name": "optional_chaining_5",
+          "expr": "optional.of({'c': {}}).c.missing.or(optional.none()[0]).orValue('default value')",
+          "value": {
+            "stringValue": "default value"
+          }
+        },
+        {
+          "name": "optional_chaining_6",
+          "expr": "optional.of({'c': {}}).c.missing.or(optional.of(['list-value'])[0]).orValue('default value')",
+          "value": {
+            "stringValue": "list-value"
+          }
+        },
+        {
+          "name": "optional_chaining_7",
+          "expr": "optional.of({'c': {'index': 'goodbye'}}).c['index'].orValue('default value')",
+          "value": {
+            "stringValue": "goodbye"
+          }
+        },
+        {
+          "name": "optional_chaining_8",
+          "expr": "optional.of({'c': {}}).c['missing'].orValue('default value')",
+          "value": {
+            "stringValue": "default value"
+          }
+        },
+        {
+          "name": "optional_chaining_9",
+          "expr": "has(optional.of({'c': {'entry': 'hello world'}}).c) && !has(optional.of({'c': {'entry': 'hello world'}}).c.missing)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "optional_chaining_10",
+          "expr": "optional.ofNonZeroValue({'c': {'dashed-index': 'goodbye'}}.a.z).orValue({'c': {'dashed-index': 'goodbye'}}.c['dashed-index'])",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such key"
+              }
+            ]
+          }
+        },
+        {
+          "name": "optional_chaining_11",
+          "expr": "{'c': {'dashed-index': 'goodbye'}}.?c.missing.or({'c': {'dashed-index': 'goodbye'}}.?c['dashed-index']).orValue('').size()",
+          "value": {
+            "int64Value": "7"
+          }
+        },
+        {
+          "name": "optional_chaining_12",
+          "expr": "{?'nested_map': optional.ofNonZeroValue({?'map': {'c': {'dashed-index': 'goodbye'}}.?c})}",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "nested_map"
+                  },
+                  "value": {
+                    "mapValue": {
+                      "entries": [
+                        {
+                          "key": {
+                            "stringValue": "map"
+                          },
+                          "value": {
+                            "mapValue": {
+                              "entries": [
+                                {
+                                  "key": {
+                                    "stringValue": "dashed-index"
+                                  },
+                                  "value": {
+                                    "stringValue": "goodbye"
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "optional_chaining_13",
+          "expr": "{?'nested_map': optional.ofNonZeroValue({?'map': {}.?c}), 'singleton': true}",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "singleton"
+                  },
+                  "value": {
+                    "boolValue": true
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "optional_chaining_14",
+          "expr": "[?{}.?c, ?optional.of(42), ?optional.none()]",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "int64Value": "42"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "optional_chaining_15",
+          "expr": "[?optional.ofNonZeroValue({'c': []}.?c.orValue(dyn({})))]",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "optional_chaining_16",
+          "expr": "optional.ofNonZeroValue({?'nested_map': optional.ofNonZeroValue({?'map': optional.of({}).?c})}).hasValue()",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "has_optional_ofNonZeroValue_struct_optional_ofNonZeroValue_map_optindex_field",
+          "expr": "has(TestAllTypes{?single_double_wrapper: optional.ofNonZeroValue(0.0)}.single_double_wrapper)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "optional_ofNonZeroValue_struct_optional_ofNonZeroValue_map_optindex_field",
+          "expr": "optional.ofNonZeroValue(TestAllTypes{?single_double_wrapper: optional.ofNonZeroValue(0.0)}).hasValue()",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "struct_map_optindex_field",
+          "expr": "TestAllTypes{?map_string_string: {'nested': {}}[?'nested']}.map_string_string",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "mapValue": {}
+          }
+        },
+        {
+          "name": "struct_optional_ofNonZeroValue_map_optindex_field",
+          "expr": "TestAllTypes{?map_string_string: optional.ofNonZeroValue({'nested': {}}[?'nested'].orValue({}))}.map_string_string",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "mapValue": {}
+          }
+        },
+        {
+          "name": "struct_map_optindex_field_nested",
+          "expr": "TestAllTypes{?map_string_string: {'nested': {'hello': 'world'}}[?'nested']}.map_string_string",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "hello"
+                  },
+                  "value": {
+                    "stringValue": "world"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "struct_list_optindex_field",
+          "expr": "TestAllTypes{repeated_string: ['greetings', ?{'nested': {'hello': 'world'}}.nested.?hello]}.repeated_string",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "stringValue": "greetings"
+                },
+                {
+                  "stringValue": "world"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "optional_empty_map_optindex_hasValue",
+          "expr": "optional.of({}).?c.hasValue()",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "empty_struct_optindex_hasValue",
+          "expr": "TestAllTypes{}.?repeated_string.hasValue()",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "optional_empty_struct_optindex_hasValue",
+          "expr": "optional.of(TestAllTypes{}).?repeated_string.hasValue()",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "optional_none_optselect_hasValue",
+          "expr": "optional.none().?repeated_string.hasValue()",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "struct_optindex_value",
+          "expr": "TestAllTypes{repeated_string: ['foo']}.?repeated_string.value()",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "stringValue": "foo"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "optional_struct_optindex_value",
+          "expr": "optional.of(TestAllTypes{repeated_string: ['foo']}).?repeated_string.value()",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "stringValue": "foo"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "optional_struct_optindex_index_value",
+          "expr": "optional.of(TestAllTypes{repeated_string: ['foo']}).?repeated_string[0].value()",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "stringValue": "foo"
+          }
+        },
+        {
+          "name": "empty_list_optindex_hasValue",
+          "expr": "[][?0].hasValue()",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "optional_empty_list_optindex_hasValue",
+          "expr": "optional.of([])[?0].hasValue()",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "optional_none_optindex_hasValue",
+          "expr": "optional.none()[?0].hasValue()",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "list_optindex_value",
+          "expr": "['foo'][?0].value()",
+          "value": {
+            "stringValue": "foo"
+          }
+        },
+        {
+          "name": "optional_list_optindex_value",
+          "expr": "optional.of(['foo'])[?0].value()",
+          "value": {
+            "stringValue": "foo"
+          }
+        },
+        {
+          "name": "map_key_mixed_type_optindex_value",
+          "expr": "{true: 1, 2: 2, 5u: 3}[?true].value()",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "map_key_mixed_numbers_double_key_optindex_value",
+          "expr": "{1u: 1.0, 2: 2.0, 3u: 3.0}[?3.0].value()",
+          "value": {
+            "doubleValue": 3
+          }
+        },
+        {
+          "name": "map_key_mixed_numbers_uint_key_optindex_value",
+          "expr": "{1u: 1.0, 2: 2.0, 3u: 3.0}[?2u].value()",
+          "value": {
+            "doubleValue": 2
+          }
+        },
+        {
+          "name": "map_key_mixed_numbers_int_key_optindex_value",
+          "expr": "{1u: 1.0, 2: 2.0, 3u: 3.0}[?1].value()",
+          "value": {
+            "doubleValue": 1
+          }
+        },
+        {
+          "name": "optional_eq_none_none",
+          "expr": "optional.none() == optional.none()",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "optional_eq_none_int",
+          "expr": "optional.none() == optional.of(1)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "optional_eq_int_none",
+          "expr": "optional.of(1) == optional.none()",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "optional_eq_int_int",
+          "expr": "optional.of(1) == optional.of(1)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "optional_ne_none_none",
+          "expr": "optional.none() != optional.none()",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "optional_ne_none_int",
+          "expr": "optional.none() != optional.of(1)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "optional_ne_int_none",
+          "expr": "optional.of(1) != optional.none()",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "optional_ne_int_int",
+          "expr": "optional.of(1) != optional.of(1)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_optional_has",
+          "expr": "has({'foo': optional.none()}.foo)",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_optional_select_has",
+          "expr": "has({'foo': optional.none()}.foo.bar)",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_optional_entry_has",
+          "expr": "has({?'foo': optional.none()}.foo)",
+          "value": {
+            "boolValue": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/parse.json
+++ b/packages/cel-spec/src/testdata/json/parse.json
@@ -1,0 +1,252 @@
+{
+  "name": "parse",
+  "description": "End-to-end parsing tests.",
+  "section": [
+    {
+      "name": "nest",
+      "description": "Deep parse trees which all implementations must support.",
+      "test": [
+        {
+          "name": "list_index",
+          "description": "Member = Member '[' Expr ']'. Nested indices are supported up to 12 times.",
+          "expr": "a[a[a[a[a[a[a[a[a[a[a[a[0]]]]]]]]]]]]",
+          "typeEnv": [
+            {
+              "name": "a",
+              "ident": {
+                "type": {
+                  "listType": {
+                    "elemType": {
+                      "primitive": "INT64"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "a": {
+              "value": {
+                "listValue": {
+                  "values": [
+                    {
+                      "int64Value": "0"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "message_literal",
+          "description": "Member = Member '{' [FieldInits] '}'. Nested messages supported up to 12 levels deep.",
+          "expr": "NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{payload: TestAllTypes{single_int64: 137}}}}}}}}}}}}.payload.single_int64",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "funcall",
+          "description": "Primary = ['.'] IDENT ['(' [ExprList] ')']. Nested function calls supported up to 12 levels deep.",
+          "expr": "int(uint(int(uint(int(uint(int(uint(int(uint(int(uint(7))))))))))))",
+          "value": {
+            "int64Value": "7"
+          }
+        },
+        {
+          "name": "list_literal",
+          "description": "Primary = '[' [ExprList] ']'. Nested list literals up to 12 levels deep.",
+          "expr": "size([[[[[[[[[[[[0]]]]]]]]]]]])",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "map_literal",
+          "description": "Primary = '{' [MapInits] '}'. Nested map literals up to 12 levels deep.",
+          "expr": "size({0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: 'foo'}}}}}}}}}}}})",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "parens",
+          "description": "Primary = '(' Expr ')'",
+          "expr": "((((((((((((((((((((((((((((((((7))))))))))))))))))))))))))))))))",
+          "value": {
+            "int64Value": "7"
+          }
+        }
+      ]
+    },
+    {
+      "name": "repeat",
+      "description": "Repetitive parse trees which all implementations must support.",
+      "test": [
+        {
+          "name": "conditional",
+          "description": "Expr = ConditionalOr ['?' ConditionalOr ':' Expr]. Chained ternary operators up to 24 levels.",
+          "expr": "true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : false",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "or",
+          "description": "ConditionalOr = [ConditionalOr '||'] ConditionalAnd. Logical OR statements with 32 conditions.",
+          "expr": "false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || true",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "and",
+          "description": "ConditionalAnd = [ConditionalAnd '&&'] Relation. Logical AND statements with 32 conditions.",
+          "expr": "true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && false",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "add_sub",
+          "description": "Addition = [Addition ('+' | '-')] Multiplication. Addition operators are supported up to 24 times consecutively.",
+          "expr": "3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3",
+          "value": {
+            "int64Value": "3"
+          }
+        },
+        {
+          "name": "mul_div",
+          "description": "Multiplication = [Multiplication ('*' | '/' | '%')] Unary. Multiplication operators are supported up to 24 times consecutively.",
+          "expr": "4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4",
+          "value": {
+            "int64Value": "4"
+          }
+        },
+        {
+          "name": "not",
+          "description": "Unary = '!' {'!'} Member",
+          "expr": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!true",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "unary_neg",
+          "description": "Unary = '-' {'-'} Member",
+          "expr": "--------------------------------19",
+          "value": {
+            "int64Value": "19"
+          }
+        },
+        {
+          "name": "select",
+          "description": "Member = Member '.' IDENT ['(' [ExprList] ')']. Selection is supported up to 12 times consecutively.",
+          "expr": "NestedTestAllTypes{}.child.child.child.child.child.child.child.child.child.child.payload.single_int32",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "index",
+          "description": "Member = Member '[' Expr ']'. Indexing is supported up to 12 times consecutively.",
+          "expr": "[[[[[[[[[[[['foo']]]]]]]]]]]][0][0][0][0][0][0][0][0][0][0][0][0]",
+          "value": {
+            "stringValue": "foo"
+          }
+        },
+        {
+          "name": "list_literal",
+          "description": "Primary = '[' [ExprList] ']'. List literals with up to 32 elements.",
+          "expr": "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31][17]",
+          "value": {
+            "int64Value": "17"
+          }
+        },
+        {
+          "name": "map_literal",
+          "description": "Primary = '{' [MapInits] '}'. Map literals with up to 32 entries.",
+          "expr": "{0: 'zero', 1: 'one', 2: 'two', 3: 'three', 4: 'four', 5: 'five', 6: 'six', 7: 'seven', 8: 'eight', 9: 'nine', 10: 'ten', 11: 'eleven', 12: 'twelve', 13: 'thirteen', 14: 'fourteen', 15: 'fifteen', 16: 'sixteen', 17: 'seventeen', 18: 'eighteen', 19: 'nineteen', 20: 'twenty', 21: 'twenty-one', 22: 'twenty-two', 23: 'twenty-three', 24: 'twenty-four', 25: 'twenty-five', 26: 'twenty-six', 27: 'twenty-seven', 28: 'twenty-eight', 29: 'twenty-nine', 30: 'thirty', 31: 'thirty-one'}[17]",
+          "value": {
+            "stringValue": "seventeen"
+          }
+        },
+        {
+          "name": "message_literal",
+          "description": "Member = Member '{' [FieldInits] '}'. Message literals with up to 32 fields.",
+          "expr": "TestAllTypes{single_int32: 5, single_int64: 10, single_uint32: 15u, single_uint64: 20u, single_sint32: 25, single_sint64: 30, single_fixed32: 35u, single_fixed64: 40u, single_float: 45.0, single_double: 50.0, single_bool: true, single_string: 'sixty', single_bytes: b'sixty-five', single_value: 70.0, single_int64_wrapper: 75, single_int32_wrapper: 80, single_double_wrapper: 85.0, single_float_wrapper: 90.0, single_uint64_wrapper: 95u, single_uint32_wrapper: 100u, single_string_wrapper: 'one hundred five', single_bool_wrapper: true, repeated_int32: [115], repeated_int64: [120], repeated_uint32: [125u], repeated_uint64: [130u], repeated_sint32: [135], repeated_sint64: [140], repeated_fixed32: [145u], repeated_fixed64: [150u], repeated_sfixed32: [155], repeated_float: [160.0]}.single_sint64",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "int64Value": "30"
+          }
+        }
+      ]
+    },
+    {
+      "name": "whitespace",
+      "description": "Check that whitespace is ignored by the grammar.",
+      "test": [
+        {
+          "name": "spaces",
+          "description": "Check that spaces are ignored.",
+          "expr": "[ . cel. expr .conformance. proto3. TestAllTypes { single_int64 : int ( 17 ) } . single_int64 ] [ 0 ] == ( 18 - 1 ) && ! false ? 1 : 2",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "tabs",
+          "description": "Check that tabs (`\\t`) are ignored.",
+          "expr": "[\t.\tcel.\texpr\t.conformance.\tproto3.\tTestAllTypes\t{\tsingle_int64\t:\tint\t(\t17\t)\t}\t.\tsingle_int64\t]\t[\t0\t]\t==\t(\t18\t-\t1\t)\t&&\t!\tfalse\t?\t1\t:\t2",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "new_lines",
+          "description": "Check that new lines (`\\n`) are ignored.",
+          "expr": "[\n.\ncel.\nexpr\n.conformance.\nproto3.\nTestAllTypes\n{\nsingle_int64\n:\nint\n(\n17\n)\n}\n.\nsingle_int64\n]\n[\n0\n]\n==\n(\n18\n-\n1\n)\n&&\n!\nfalse\n?\n1\n:\n2",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "new_pages",
+          "description": "Check that new pages (`\\f`) are ignored.",
+          "expr": "[\f.\fcel.\fexpr\f.conformance.\fproto3.\fTestAllTypes\f{\fsingle_int64\f:\fint\f(\f17\f)\f}\f.\fsingle_int64\f]\f[\f0\f]\f==\f(\f18\f-\f1\f)\f&&\f!\ffalse\f?\f1\f:\f2",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "carriage_returns",
+          "description": "Check that carriage returns (`\\r`) are ignored.",
+          "expr": "[\r.\rcel.\rexpr\r.conformance.\rproto3.\rTestAllTypes\r{\rsingle_int64\r:\rint\r(\r17\r)\r}\r.\rsingle_int64\r]\r[\r0\r]\r==\r(\r18\r-\r1\r)\r&&\r!\rfalse\r?\r1\r:\r2",
+          "value": {
+            "int64Value": "1"
+          }
+        }
+      ]
+    },
+    {
+      "name": "comments",
+      "description": "Check that comments are ignored by the grammar. Note that carriage returns alone cannot terminate comments.",
+      "test": [
+        {
+          "name": "new_line_terminated",
+          "description": "Check that new-line-terminated comments are ignored.",
+          "expr": "[// @\n.// @\ncel.// @\nexpr// @\n.conformance.// @\nproto3.// @\nTestAllTypes// @\n{// @\nsingle_int64// @\n:// @\nint// @\n(// @\n17// @\n)// @\n}// @\n.// @\nsingle_int64// @\n]// @\n[// @\n0// @\n]// @\n==// @\n(// @\n18// @\n-// @\n1// @\n)// @\n&&// @\n!// @\nfalse// @\n?// @\n1// @\n:// @\n2",
+          "value": {
+            "int64Value": "1"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/plumbing.json
+++ b/packages/cel-spec/src/testdata/json/plumbing.json
@@ -1,0 +1,110 @@
+{
+  "name": "plumbing",
+  "description": "Check that the ConformanceService server can accept all arguments and return all responses.",
+  "section": [
+    {
+      "name": "min",
+      "description": "Minimal programs.",
+      "test": [
+        {
+          "name": "min_program",
+          "description": "Smallest functionality: expr in, result out.",
+          "expr": "17",
+          "value": {
+            "int64Value": "17"
+          }
+        }
+      ]
+    },
+    {
+      "name": "eval_results",
+      "description": "All evaluation result kinds.",
+      "test": [
+        {
+          "name": "error_result",
+          "description": "Check that error results go through.",
+          "expr": "1 / 0",
+          "evalError": {
+            "errors": [
+              {
+                "message": "foo"
+              }
+            ]
+          }
+        },
+        {
+          "name": "eval_map_results",
+          "description": "Check that map literals results are order independent.",
+          "expr": "{\"k1\":\"v1\",\"k\":\"v\"}",
+          "value": {
+            "mapValue": {
+              "entries": [
+                {
+                  "key": {
+                    "stringValue": "k"
+                  },
+                  "value": {
+                    "stringValue": "v"
+                  }
+                },
+                {
+                  "key": {
+                    "stringValue": "k1"
+                  },
+                  "value": {
+                    "stringValue": "v1"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "check_inputs",
+      "description": "All inputs to Check phase.",
+      "test": [
+        {
+          "name": "skip_check",
+          "description": "Make sure we can skip type checking.",
+          "expr": "[17, 'pancakes']",
+          "disableCheck": true,
+          "value": {
+            "listValue": {
+              "values": [
+                {
+                  "int64Value": "17"
+                },
+                {
+                  "stringValue": "pancakes"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "eval_inputs",
+      "description": "All inputs to Eval phase.",
+      "test": [
+        {
+          "name": "one_ignored_value_arg",
+          "description": "Check that value bindings can be given, even if ignored.",
+          "expr": "'foo'",
+          "bindings": {
+            "x": {
+              "value": {
+                "int64Value": "17"
+              }
+            }
+          },
+          "value": {
+            "stringValue": "foo"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/proto2.json
+++ b/packages/cel-spec/src/testdata/json/proto2.json
@@ -1,0 +1,1403 @@
+{
+  "name": "proto2",
+  "description": "Protocol buffer version 2 tests.  See notes for the available set of protos for tests.",
+  "section": [
+    {
+      "name": "literal_singular",
+      "description": "Literals with singular fields set.",
+      "test": [
+        {
+          "name": "int64_nocontainer",
+          "expr": "cel.expr.conformance.proto2.TestAllTypes{single_int64: 17}",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleInt64": "17"
+            }
+          }
+        },
+        {
+          "name": "int32",
+          "expr": "TestAllTypes{single_int32: -34}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleInt32": -34
+            }
+          }
+        },
+        {
+          "name": "int32_eq_uint",
+          "expr": "Int32Value{value: 34} == dyn(UInt64Value{value: 34u})",
+          "container": "google.protobuf",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_int32_eq_uint",
+          "expr": "Int32Value{value: 34} == dyn(UInt64Value{value: 18446744073709551615u})",
+          "container": "google.protobuf",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "int32_eq_double",
+          "expr": "Int32Value{value: 34} == dyn(DoubleValue{value: 34.0})",
+          "container": "google.protobuf",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_int32_eq_double",
+          "expr": "Int32Value{value: 34} == dyn(DoubleValue{value: -9223372036854775809.0})",
+          "container": "google.protobuf",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "int64",
+          "expr": "TestAllTypes{single_int64: 17}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleInt64": "17"
+            }
+          }
+        },
+        {
+          "name": "uint32",
+          "expr": "TestAllTypes{single_uint32: 1u}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleUint32": 1
+            }
+          }
+        },
+        {
+          "name": "uint32_eq_int",
+          "expr": "UInt32Value{value: 34u} == dyn(Int64Value{value: 34})",
+          "container": "google.protobuf",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_uint32_eq_int",
+          "expr": "UInt32Value{value: 34u} == dyn(Int64Value{value: -1})",
+          "container": "google.protobuf",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "uint32_eq_double",
+          "expr": "UInt32Value{value: 34u} == dyn(DoubleValue{value: 34.0})",
+          "container": "google.protobuf",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_uint32_eq_double",
+          "expr": "UInt32Value{value: 34u} == dyn(DoubleValue{value: 18446744073709551616.0})",
+          "container": "google.protobuf",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "uint64",
+          "expr": "TestAllTypes{single_uint64: 9999u}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleUint64": "9999"
+            }
+          }
+        },
+        {
+          "name": "sint32",
+          "expr": "TestAllTypes{single_sint32: -3}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleSint32": -3
+            }
+          }
+        },
+        {
+          "name": "sint64",
+          "expr": "TestAllTypes{single_sint64: 255}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleSint64": "255"
+            }
+          }
+        },
+        {
+          "name": "fixed32",
+          "expr": "TestAllTypes{single_fixed32: 43u}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleFixed32": 43
+            }
+          }
+        },
+        {
+          "name": "fixed64",
+          "expr": "TestAllTypes{single_fixed64: 1880u}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleFixed64": "1880"
+            }
+          }
+        },
+        {
+          "name": "sfixed32",
+          "expr": "TestAllTypes{single_sfixed32: -404}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleSfixed32": -404
+            }
+          }
+        },
+        {
+          "name": "sfixed64",
+          "expr": "TestAllTypes{single_sfixed64: -1}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleSfixed64": "-1"
+            }
+          }
+        },
+        {
+          "name": "float",
+          "expr": "TestAllTypes{single_float: 3.1416}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleFloat": 3.1416
+            }
+          }
+        },
+        {
+          "name": "float_eq_int",
+          "expr": "FloatValue{value: 3.0} == dyn(Int64Value{value: 3})",
+          "container": "google.protobuf",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_float_eq_int",
+          "expr": "FloatValue{value: -1.14} == dyn(Int64Value{value: -1})",
+          "container": "google.protobuf",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "float_eq_uint",
+          "expr": "FloatValue{value: 34.0} == dyn(UInt64Value{value: 34u})",
+          "container": "google.protobuf",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "not_float_eq_uint",
+          "expr": "FloatValue{value: -1.0} == dyn(UInt64Value{value: 18446744073709551615u})",
+          "container": "google.protobuf",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "double",
+          "expr": "TestAllTypes{single_double: 6.022e23}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleDouble": 6.022e23
+            }
+          }
+        },
+        {
+          "name": "bool",
+          "expr": "TestAllTypes{single_bool: true}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleBool": true
+            }
+          }
+        },
+        {
+          "name": "string",
+          "expr": "TestAllTypes{single_string: 'foo'}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleString": "foo"
+            }
+          }
+        },
+        {
+          "name": "bytes",
+          "expr": "TestAllTypes{single_bytes: b'\\377'}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleBytes": "/w=="
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "literal_wellknown",
+      "description": "Literals with well-known fields set.",
+      "test": [
+        {
+          "name": "any",
+          "expr": "TestAllTypes{single_any: TestAllTypes{single_int32: 1}}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleAny": {
+                "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                "singleInt32": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "duration",
+          "expr": "TestAllTypes{single_duration: duration('123s')}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleDuration": "123s"
+            }
+          }
+        },
+        {
+          "name": "timestamp",
+          "expr": "TestAllTypes{single_timestamp: timestamp('2009-02-13T23:31:30Z')}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleTimestamp": "2009-02-13T23:31:30Z"
+            }
+          }
+        },
+        {
+          "name": "struct",
+          "expr": "TestAllTypes{single_struct: {'one': 1, 'two': 2}}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleStruct": {
+                "one": 1,
+                "two": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "value",
+          "expr": "TestAllTypes{single_value: 'foo'}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleValue": "foo"
+            }
+          }
+        },
+        {
+          "name": "int64_wrapper",
+          "expr": "TestAllTypes{single_int64_wrapper: -321}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleInt64Wrapper": "-321"
+            }
+          }
+        },
+        {
+          "name": "int32_wrapper",
+          "expr": "TestAllTypes{single_int32_wrapper: -456}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleInt32Wrapper": -456
+            }
+          }
+        },
+        {
+          "name": "double_wrapper",
+          "expr": "TestAllTypes{single_double_wrapper: 2.71828}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleDoubleWrapper": 2.71828
+            }
+          }
+        },
+        {
+          "name": "float_wrapper",
+          "expr": "TestAllTypes{single_float_wrapper: 2.99792e8}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleFloatWrapper": 299792000
+            }
+          }
+        },
+        {
+          "name": "uint64_wrapper",
+          "expr": "TestAllTypes{single_uint64_wrapper: 8675309u}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleUint64Wrapper": "8675309"
+            }
+          }
+        },
+        {
+          "name": "uint32_wrapper",
+          "expr": "TestAllTypes{single_uint32_wrapper: 987u}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleUint32Wrapper": 987
+            }
+          }
+        },
+        {
+          "name": "string_wrapper",
+          "expr": "TestAllTypes{single_string_wrapper: 'hubba'}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleStringWrapper": "hubba"
+            }
+          }
+        },
+        {
+          "name": "bool_wrapper",
+          "expr": "TestAllTypes{single_bool_wrapper: true}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleBoolWrapper": true
+            }
+          }
+        },
+        {
+          "name": "bytes_wrapper",
+          "expr": "TestAllTypes{single_bytes_wrapper: b'\\301\\103'}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+              "singleBytesWrapper": "wUM="
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "singular_bind",
+      "description": "Binding the singular fields.",
+      "test": [
+        {
+          "name": "int32",
+          "expr": "x.single_int32",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "singleInt32": 17
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "17"
+          }
+        },
+        {
+          "name": "int64",
+          "expr": "x.single_int64",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "singleInt64": "-99"
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "-99"
+          }
+        }
+      ]
+    },
+    {
+      "name": "empty_field",
+      "description": "Tests on empty fields.",
+      "test": [
+        {
+          "name": "scalar_with_default",
+          "expr": "TestAllTypes{}.single_int32",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "int64Value": "-32"
+          }
+        },
+        {
+          "name": "scalar_no_default",
+          "expr": "TestAllTypes{}.single_fixed32",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "uint64Value": "0"
+          }
+        },
+        {
+          "name": "nested_message",
+          "expr": "TestAllTypes{}.single_nested_message",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes.NestedMessage"
+            }
+          }
+        },
+        {
+          "name": "nested_message_subfield",
+          "expr": "TestAllTypes{}.single_nested_message.bb",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "wkt",
+          "expr": "TestAllTypes{}.single_int64_wrapper",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "nullValue": null
+          }
+        },
+        {
+          "name": "repeated_scalar",
+          "expr": "TestAllTypes{}.repeated_int64",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "repeated_enum",
+          "expr": "TestAllTypes{}.repeated_nested_enum",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "repeated_nested",
+          "expr": "TestAllTypes{}.repeated_nested_message",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "map",
+          "expr": "TestAllTypes{}.map_string_string",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "mapValue": {}
+          }
+        }
+      ]
+    },
+    {
+      "name": "has",
+      "description": "Tests for the has() macro on proto2 messages.",
+      "test": [
+        {
+          "name": "undefined",
+          "expr": "has(TestAllTypes{}.no_such_field)",
+          "disableCheck": true,
+          "container": "cel.expr.conformance.proto2",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_such_field"
+              }
+            ]
+          }
+        },
+        {
+          "name": "repeated_none_implicit",
+          "expr": "has(TestAllTypes{}.repeated_int32)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "repeated_none_explicit",
+          "expr": "has(TestAllTypes{repeated_int32: []}.repeated_int32)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "repeated_one",
+          "expr": "has(TestAllTypes{repeated_int32: [1]}.repeated_int32)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "repeated_many",
+          "expr": "has(TestAllTypes{repeated_int32: [1, 2, 3]}.repeated_int32)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_none_implicit",
+          "expr": "has(TestAllTypes{}.map_string_string)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_none_explicit",
+          "expr": "has(TestAllTypes{map_string_string: {}}.map_string_string)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_one_default",
+          "expr": "has(TestAllTypes{map_string_string: {'MT': ''}}.map_string_string)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_one",
+          "expr": "has(TestAllTypes{map_string_string: {'one': 'uno'}}.map_string_string)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_many",
+          "expr": "has(TestAllTypes{map_string_string: {'one': 'uno', 'two': 'dos'}}.map_string_string)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "required",
+          "expr": "has(TestRequired{required_int32: 4}.required_int32)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "optional_unset_no_default",
+          "expr": "has(TestAllTypes{}.single_sint32)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "optional_set_no_default",
+          "expr": "has(TestAllTypes{single_sint32: -4}.single_sint32)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "optional_unset_with_default",
+          "expr": "has(TestAllTypes{}.single_int32)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "optional_set_with_default",
+          "expr": "has(TestAllTypes{single_int32: 16}.single_int32)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "optional_set_to_default",
+          "expr": "has(TestAllTypes{single_int32: -32}.single_int32)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "optional_message_unset",
+          "expr": "has(TestAllTypes{}.standalone_message)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "optional_message_set",
+          "expr": "has(TestAllTypes{standalone_message: TestAllTypes.NestedMessage{}}.standalone_message)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "optional_enum_unset",
+          "expr": "has(TestAllTypes{}.standalone_enum)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "optional_enum_set",
+          "expr": "has(TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.BAR}.standalone_enum)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "optional_enum_set_zero",
+          "expr": "has(TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.FOO}.standalone_enum)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "oneof_unset",
+          "expr": "has(TestAllTypes{}.single_nested_message)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "oneof_other_set",
+          "expr": "has(TestAllTypes{single_nested_enum: TestAllTypes.NestedEnum.BAZ}.single_nested_message)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "oneof_set",
+          "expr": "has(TestAllTypes{single_nested_message: TestAllTypes.NestedMessage{}}.single_nested_message)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "oneof_set_default",
+          "expr": "has(TestAllTypes{single_nested_enum: TestAllTypes.NestedEnum.FOO}.single_nested_enum)",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "set_null",
+      "test": [
+        {
+          "name": "single_message",
+          "expr": "TestAllTypes{single_nested_message: null} == TestAllTypes{}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "single_any",
+          "expr": "TestAllTypes{single_any: null}.single_any",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "nullValue": null
+          }
+        },
+        {
+          "name": "single_value",
+          "expr": "TestAllTypes{single_value: null}.single_value",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "nullValue": null
+          }
+        },
+        {
+          "name": "single_duration",
+          "expr": "TestAllTypes{single_duration: null} == TestAllTypes{}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "single_timestamp",
+          "expr": "TestAllTypes{single_timestamp: null} == TestAllTypes{}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "single_scalar",
+          "expr": "TestAllTypes{single_bool: null} == TestAllTypes{}",
+          "disableCheck": true,
+          "container": "cel.expr.conformance.proto2",
+          "evalError": {
+            "errors": [
+              {
+                "message": "unsupported field type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "repeated",
+          "expr": "TestAllTypes{repeated_int32: null} == TestAllTypes{}",
+          "disableCheck": true,
+          "container": "cel.expr.conformance.proto2",
+          "evalError": {
+            "errors": [
+              {
+                "message": "unsupported field type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map",
+          "expr": "TestAllTypes{map_string_string: null} == TestAllTypes{}",
+          "disableCheck": true,
+          "container": "cel.expr.conformance.proto2",
+          "evalError": {
+            "errors": [
+              {
+                "message": "unsupported field type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "list_value",
+          "expr": "TestAllTypes{list_value: null} == TestAllTypes{}",
+          "disableCheck": true,
+          "container": "cel.expr.conformance.proto2",
+          "evalError": {
+            "errors": [
+              {
+                "message": "unsupported field type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "single_struct",
+          "expr": "TestAllTypes{single_struct: null} == TestAllTypes{}",
+          "disableCheck": true,
+          "container": "cel.expr.conformance.proto2",
+          "evalError": {
+            "errors": [
+              {
+                "message": "unsupported field type"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "quoted_fields",
+      "test": [
+        {
+          "name": "set_field_with_quoted_name",
+          "expr": "TestAllTypes{`in`: true} == TestAllTypes{}",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "get_field_with_quoted_name",
+          "expr": "TestAllTypes{`in`: true}.`in`",
+          "container": "cel.expr.conformance.proto2",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "extensions_has",
+      "description": "Tests for presence checks on proto2 extension fields.",
+      "test": [
+        {
+          "name": "package_scoped_int32",
+          "expr": "has(msg.`cel.expr.conformance.proto2.int32_ext`)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.int32_ext]": 42
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "package_scoped_nested_ext",
+          "expr": "has(msg.`cel.expr.conformance.proto2.nested_ext`)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.nested_ext]": {}
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "package_scoped_test_all_types_ext",
+          "expr": "has(msg.`cel.expr.conformance.proto2.test_all_types_ext`)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.test_all_types_ext]": {}
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "package_scoped_test_all_types_nested_enum_ext",
+          "expr": "has(msg.`cel.expr.conformance.proto2.nested_enum_ext`)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.nested_enum_ext]": "BAR"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "package_scoped_repeated_test_all_types",
+          "expr": "has(msg.`cel.expr.conformance.proto2.repeated_test_all_types`)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.repeated_test_all_types]": [
+                    {
+                      "singleInt64": "1"
+                    },
+                    {
+                      "singleBool": true
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "message_scoped_int64",
+          "expr": "has(msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.int64_ext`)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.int64_ext]": "42"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "message_scoped_nested_ext",
+          "expr": "has(msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_nested_ext`)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_nested_ext]": {}
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "message_scoped_nested_enum_ext",
+          "expr": "has(msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.nested_enum_ext`)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.nested_enum_ext]": "BAR"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "message_scoped_repeated_test_all_types",
+          "expr": "has(msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_repeated_test_all_types`)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_repeated_test_all_types]": [
+                    {
+                      "singleInt64": "1"
+                    },
+                    {
+                      "singleBool": true
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "extensions_get",
+      "description": "Tests for accessing proto2 extension fields.",
+      "test": [
+        {
+          "name": "package_scoped_int32",
+          "expr": "msg.`cel.expr.conformance.proto2.int32_ext` == 42",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.int32_ext]": 42
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "package_scoped_nested_ext",
+          "expr": "msg.`cel.expr.conformance.proto2.nested_ext` == cel.expr.conformance.proto2.TestAllTypes{}",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.nested_ext]": {}
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "package_scoped_test_all_types_ext",
+          "expr": "msg.`cel.expr.conformance.proto2.test_all_types_ext` == cel.expr.conformance.proto2.TestAllTypes{}",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.test_all_types_ext]": {}
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "package_scoped_test_all_types_nested_enum_ext",
+          "expr": "msg.`cel.expr.conformance.proto2.nested_enum_ext` == cel.expr.conformance.proto2.TestAllTypes.NestedEnum.BAR",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.nested_enum_ext]": "BAR"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "package_scoped_repeated_test_all_types",
+          "expr": "msg.`cel.expr.conformance.proto2.repeated_test_all_types` == [cel.expr.conformance.proto2.TestAllTypes{single_int64: 1}, cel.expr.conformance.proto2.TestAllTypes{single_bool: true}]",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.repeated_test_all_types]": [
+                    {
+                      "singleInt64": "1"
+                    },
+                    {
+                      "singleBool": true
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "message_scoped_int64",
+          "expr": "msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.int64_ext` == 42",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.int64_ext]": "42"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "message_scoped_nested_ext",
+          "expr": "msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_nested_ext` == cel.expr.conformance.proto2.TestAllTypes{}",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_nested_ext]": {}
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "message_scoped_nested_enum_ext",
+          "expr": "msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.nested_enum_ext` == cel.expr.conformance.proto2.TestAllTypes.NestedEnum.BAR",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.nested_enum_ext]": "BAR"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "message_scoped_repeated_test_all_types",
+          "expr": "msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_repeated_test_all_types` == [cel.expr.conformance.proto2.TestAllTypes{single_int64: 1}, cel.expr.conformance.proto2.TestAllTypes{single_bool: true}]",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_repeated_test_all_types]": [
+                    {
+                      "singleInt64": "1"
+                    },
+                    {
+                      "singleBool": true
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/proto2_ext.json
+++ b/packages/cel-spec/src/testdata/json/proto2_ext.json
@@ -1,0 +1,476 @@
+{
+  "name": "proto2_ext",
+  "description": "Tests for the proto extension library.",
+  "section": [
+    {
+      "name": "has_ext",
+      "test": [
+        {
+          "name": "package_scoped_int32",
+          "expr": "proto.hasExt(msg, cel.expr.conformance.proto2.int32_ext)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.int32_ext]": 42
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "package_scoped_nested_ext",
+          "expr": "proto.hasExt(msg, cel.expr.conformance.proto2.nested_ext)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.nested_ext]": {}
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "package_scoped_test_all_types_ext",
+          "expr": "proto.hasExt(msg, cel.expr.conformance.proto2.test_all_types_ext)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.test_all_types_ext]": {}
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "package_scoped_test_all_types_nested_enum_ext",
+          "expr": "proto.hasExt(msg, cel.expr.conformance.proto2.nested_enum_ext)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.nested_enum_ext]": "BAR"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "package_scoped_repeated_test_all_types",
+          "expr": "proto.hasExt(msg, cel.expr.conformance.proto2.repeated_test_all_types)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.repeated_test_all_types]": [
+                    {
+                      "singleInt64": "1"
+                    },
+                    {
+                      "singleBool": true
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "message_scoped_int64",
+          "expr": "proto.hasExt(msg, cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.int64_ext)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.int64_ext]": "42"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "message_scoped_nested_ext",
+          "expr": "proto.hasExt(msg, cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_nested_ext)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_nested_ext]": {}
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "message_scoped_nested_enum_ext",
+          "expr": "proto.hasExt(msg, cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.nested_enum_ext)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.nested_enum_ext]": "BAR"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "message_scoped_repeated_test_all_types",
+          "expr": "proto.hasExt(msg, cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_repeated_test_all_types)",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_repeated_test_all_types]": [
+                    {
+                      "singleInt64": "1"
+                    },
+                    {
+                      "singleBool": true
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "get_ext",
+      "test": [
+        {
+          "name": "package_scoped_int32",
+          "expr": "proto.getExt(msg, cel.expr.conformance.proto2.int32_ext) == 42",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.int32_ext]": 42
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "package_scoped_nested_ext",
+          "expr": "proto.getExt(msg, cel.expr.conformance.proto2.nested_ext) == cel.expr.conformance.proto2.TestAllTypes{}",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.nested_ext]": {}
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "package_scoped_test_all_types_ext",
+          "expr": "proto.getExt(msg, cel.expr.conformance.proto2.test_all_types_ext) == cel.expr.conformance.proto2.TestAllTypes{}",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.test_all_types_ext]": {}
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "package_scoped_test_all_types_nested_enum_ext",
+          "expr": "proto.getExt(msg, cel.expr.conformance.proto2.nested_enum_ext) == cel.expr.conformance.proto2.TestAllTypes.NestedEnum.BAR",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.nested_enum_ext]": "BAR"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "package_scoped_repeated_test_all_types",
+          "expr": "proto.getExt(msg, cel.expr.conformance.proto2.repeated_test_all_types) == [cel.expr.conformance.proto2.TestAllTypes{single_int64: 1}, cel.expr.conformance.proto2.TestAllTypes{single_bool: true}]",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.repeated_test_all_types]": [
+                    {
+                      "singleInt64": "1"
+                    },
+                    {
+                      "singleBool": true
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "message_scoped_int64",
+          "expr": "proto.getExt(msg, cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.int64_ext) == 42",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.int64_ext]": "42"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "message_scoped_nested_ext",
+          "expr": "proto.getExt(msg, cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_nested_ext) == cel.expr.conformance.proto2.TestAllTypes{}",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_nested_ext]": {}
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "message_scoped_nested_enum_ext",
+          "expr": "proto.getExt(msg, cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.nested_enum_ext) == cel.expr.conformance.proto2.TestAllTypes.NestedEnum.BAR",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.nested_enum_ext]": "BAR"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "message_scoped_repeated_test_all_types",
+          "expr": "proto.getExt(msg, cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_repeated_test_all_types) == [cel.expr.conformance.proto2.TestAllTypes{single_int64: 1}, cel.expr.conformance.proto2.TestAllTypes{single_bool: true}]",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto2.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes",
+                  "[cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_repeated_test_all_types]": [
+                    {
+                      "singleInt64": "1"
+                    },
+                    {
+                      "singleBool": true
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/proto3.json
+++ b/packages/cel-spec/src/testdata/json/proto3.json
@@ -1,0 +1,811 @@
+{
+  "name": "proto3",
+  "description": "Protocol buffer version 3 tests.  See notes for the available set of protos for tests.",
+  "section": [
+    {
+      "name": "literal_singular",
+      "description": "Literals with singular fields set.",
+      "test": [
+        {
+          "name": "int64_nocontainer",
+          "expr": "cel.expr.conformance.proto3.TestAllTypes{single_int64: 17}",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleInt64": "17"
+            }
+          }
+        },
+        {
+          "name": "int32",
+          "expr": "TestAllTypes{single_int32: -34}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleInt32": -34
+            }
+          }
+        },
+        {
+          "name": "int64",
+          "expr": "TestAllTypes{single_int64: 17}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleInt64": "17"
+            }
+          }
+        },
+        {
+          "name": "uint32",
+          "expr": "TestAllTypes{single_uint32: 1u}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleUint32": 1
+            }
+          }
+        },
+        {
+          "name": "uint64",
+          "expr": "TestAllTypes{single_uint64: 9999u}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleUint64": "9999"
+            }
+          }
+        },
+        {
+          "name": "sint32",
+          "expr": "TestAllTypes{single_sint32: -3}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleSint32": -3
+            }
+          }
+        },
+        {
+          "name": "sint64",
+          "expr": "TestAllTypes{single_sint64: 255}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleSint64": "255"
+            }
+          }
+        },
+        {
+          "name": "fixed32",
+          "expr": "TestAllTypes{single_fixed32: 43u}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleFixed32": 43
+            }
+          }
+        },
+        {
+          "name": "fixed64",
+          "expr": "TestAllTypes{single_fixed64: 1880u}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleFixed64": "1880"
+            }
+          }
+        },
+        {
+          "name": "sfixed32",
+          "expr": "TestAllTypes{single_sfixed32: -404}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleSfixed32": -404
+            }
+          }
+        },
+        {
+          "name": "sfixed64",
+          "expr": "TestAllTypes{single_sfixed64: -1}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleSfixed64": "-1"
+            }
+          }
+        },
+        {
+          "name": "float",
+          "expr": "TestAllTypes{single_float: 3.1416}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleFloat": 3.1416
+            }
+          }
+        },
+        {
+          "name": "double",
+          "expr": "TestAllTypes{single_double: 6.022e23}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleDouble": 6.022e23
+            }
+          }
+        },
+        {
+          "name": "bool",
+          "expr": "TestAllTypes{single_bool: true}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleBool": true
+            }
+          }
+        },
+        {
+          "name": "string",
+          "expr": "TestAllTypes{single_string: 'foo'}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleString": "foo"
+            }
+          }
+        },
+        {
+          "name": "bytes",
+          "expr": "TestAllTypes{single_bytes: b'\\377'}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleBytes": "/w=="
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "literal_wellknown",
+      "description": "Literals with well-known fields set.",
+      "test": [
+        {
+          "name": "any",
+          "expr": "TestAllTypes{single_any: TestAllTypes{single_int32: 1}}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleAny": {
+                "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                "singleInt32": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "duration",
+          "expr": "TestAllTypes{single_duration: duration('123s')}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleDuration": "123s"
+            }
+          }
+        },
+        {
+          "name": "timestamp",
+          "expr": "TestAllTypes{single_timestamp: timestamp('2009-02-13T23:31:30Z')}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleTimestamp": "2009-02-13T23:31:30Z"
+            }
+          }
+        },
+        {
+          "name": "struct",
+          "expr": "TestAllTypes{single_struct: {'one': 1, 'two': 2}}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleStruct": {
+                "one": 1,
+                "two": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "value",
+          "expr": "TestAllTypes{single_value: 'foo'}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleValue": "foo"
+            }
+          }
+        },
+        {
+          "name": "int64_wrapper",
+          "expr": "TestAllTypes{single_int64_wrapper: -321}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleInt64Wrapper": "-321"
+            }
+          }
+        },
+        {
+          "name": "int32_wrapper",
+          "expr": "TestAllTypes{single_int32_wrapper: -456}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleInt32Wrapper": -456
+            }
+          }
+        },
+        {
+          "name": "double_wrapper",
+          "expr": "TestAllTypes{single_double_wrapper: 2.71828}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleDoubleWrapper": 2.71828
+            }
+          }
+        },
+        {
+          "name": "float_wrapper",
+          "expr": "TestAllTypes{single_float_wrapper: 2.99792e8}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleFloatWrapper": 299792000
+            }
+          }
+        },
+        {
+          "name": "uint64_wrapper",
+          "expr": "TestAllTypes{single_uint64_wrapper: 8675309u}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleUint64Wrapper": "8675309"
+            }
+          }
+        },
+        {
+          "name": "uint32_wrapper",
+          "expr": "TestAllTypes{single_uint32_wrapper: 987u}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleUint32Wrapper": 987
+            }
+          }
+        },
+        {
+          "name": "string_wrapper",
+          "expr": "TestAllTypes{single_string_wrapper: 'hubba'}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleStringWrapper": "hubba"
+            }
+          }
+        },
+        {
+          "name": "bool_wrapper",
+          "expr": "TestAllTypes{single_bool_wrapper: true}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleBoolWrapper": true
+            }
+          }
+        },
+        {
+          "name": "bytes_wrapper",
+          "expr": "TestAllTypes{single_bytes_wrapper: b'\\301\\103'}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+              "singleBytesWrapper": "wUM="
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "singular_bind",
+      "description": "Binding the singular fields.",
+      "test": [
+        {
+          "name": "int32",
+          "expr": "x.single_int32",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "singleInt32": 17
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "17"
+          }
+        },
+        {
+          "name": "int64",
+          "expr": "x.single_int64",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                  "singleInt64": "-99"
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "-99"
+          }
+        }
+      ]
+    },
+    {
+      "name": "empty_field",
+      "description": "Tests on empty fields.",
+      "test": [
+        {
+          "name": "scalar",
+          "expr": "TestAllTypes{}.single_fixed32",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "uint64Value": "0"
+          }
+        },
+        {
+          "name": "nested_message",
+          "expr": "TestAllTypes{}.single_nested_message",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "objectValue": {
+              "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes.NestedMessage"
+            }
+          }
+        },
+        {
+          "name": "nested_message_subfield",
+          "expr": "TestAllTypes{}.single_nested_message.bb",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "wkt",
+          "expr": "TestAllTypes{}.single_int64_wrapper",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "nullValue": null
+          }
+        },
+        {
+          "name": "repeated_scalar",
+          "expr": "TestAllTypes{}.repeated_int64",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "repeated_enum",
+          "expr": "TestAllTypes{}.repeated_nested_enum",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "repeated_nested",
+          "expr": "TestAllTypes{}.repeated_nested_message",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "listValue": {}
+          }
+        },
+        {
+          "name": "map",
+          "expr": "TestAllTypes{}.map_string_string",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "mapValue": {}
+          }
+        }
+      ]
+    },
+    {
+      "name": "has",
+      "description": "Tests for the has() macro on proto3 messages.",
+      "test": [
+        {
+          "name": "undefined",
+          "expr": "has(TestAllTypes{}.no_such_field)",
+          "disableCheck": true,
+          "container": "cel.expr.conformance.proto3",
+          "evalError": {
+            "errors": [
+              {
+                "message": "no_such_field"
+              }
+            ]
+          }
+        },
+        {
+          "name": "repeated_none_implicit",
+          "expr": "has(TestAllTypes{}.repeated_int32)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "repeated_none_explicit",
+          "expr": "has(TestAllTypes{repeated_int32: []}.repeated_int32)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "repeated_one",
+          "expr": "has(TestAllTypes{repeated_int32: [1]}.repeated_int32)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "repeated_many",
+          "expr": "has(TestAllTypes{repeated_int32: [1, 2, 3]}.repeated_int32)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_none_implicit",
+          "expr": "has(TestAllTypes{}.map_string_string)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_none_explicit",
+          "expr": "has(TestAllTypes{map_string_string: {}}.map_string_string)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "map_one_default",
+          "expr": "has(TestAllTypes{map_string_string: {'MT': ''}}.map_string_string)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_one",
+          "expr": "has(TestAllTypes{map_string_string: {'one': 'uno'}}.map_string_string)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "map_many",
+          "expr": "has(TestAllTypes{map_string_string: {'one': 'uno', 'two': 'dos'}}.map_string_string)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "single_unset",
+          "expr": "has(TestAllTypes{}.single_int32)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "single_set",
+          "expr": "has(TestAllTypes{single_int32: 16}.single_int32)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "single_set_to_default",
+          "expr": "has(TestAllTypes{single_int32: 0}.single_int32)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "single_message_unset",
+          "expr": "has(TestAllTypes{}.standalone_message)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "single_message_set",
+          "expr": "has(TestAllTypes{standalone_message: TestAllTypes.NestedMessage{bb: 123}}.standalone_message)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "single_message_set_to_default",
+          "expr": "has(TestAllTypes{standalone_message: TestAllTypes.NestedMessage{}}.standalone_message)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "single_enum_unset",
+          "expr": "has(TestAllTypes{}.standalone_enum)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "single_enum_set",
+          "expr": "has(TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.BAR}.standalone_enum)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "single_enum_set_zero",
+          "expr": "has(TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.FOO}.standalone_enum)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "oneof_unset",
+          "expr": "has(TestAllTypes{}.single_nested_message)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "oneof_other_set",
+          "expr": "has(TestAllTypes{single_nested_enum: TestAllTypes.NestedEnum.BAZ}.single_nested_message)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "oneof_set",
+          "expr": "has(TestAllTypes{single_nested_message: TestAllTypes.NestedMessage{}}.single_nested_message)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "oneof_set_default",
+          "expr": "has(TestAllTypes{single_nested_enum: TestAllTypes.NestedEnum.FOO}.single_nested_enum)",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "set_null",
+      "test": [
+        {
+          "name": "single_message",
+          "expr": "TestAllTypes{single_nested_message: null} == TestAllTypes{}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "single_any",
+          "expr": "TestAllTypes{single_any: null}.single_any",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "nullValue": null
+          }
+        },
+        {
+          "name": "single_value",
+          "expr": "TestAllTypes{single_value: null}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "nullValue": null
+          }
+        },
+        {
+          "name": "single_duration",
+          "expr": "TestAllTypes{single_duration: null} == TestAllTypes{}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "single_timestamp",
+          "expr": "TestAllTypes{single_timestamp: null} == TestAllTypes{}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "single_scalar",
+          "expr": "TestAllTypes{single_bool: null} == TestAllTypes{}",
+          "disableCheck": true,
+          "container": "cel.expr.conformance.proto3",
+          "evalError": {
+            "errors": [
+              {
+                "message": "unsupported field type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "repeated",
+          "expr": "TestAllTypes{repeated_int32: null} == TestAllTypes{}",
+          "disableCheck": true,
+          "container": "cel.expr.conformance.proto3",
+          "evalError": {
+            "errors": [
+              {
+                "message": "unsupported field type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "map",
+          "expr": "TestAllTypes{map_string_string: null} == TestAllTypes{}",
+          "disableCheck": true,
+          "container": "cel.expr.conformance.proto3",
+          "evalError": {
+            "errors": [
+              {
+                "message": "unsupported field type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "list_value",
+          "expr": "TestAllTypes{list_value: null} == TestAllTypes{}",
+          "disableCheck": true,
+          "container": "cel.expr.conformance.proto3",
+          "evalError": {
+            "errors": [
+              {
+                "message": "unsupported field type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "single_struct",
+          "expr": "TestAllTypes{single_struct: null} == TestAllTypes{}",
+          "disableCheck": true,
+          "container": "cel.expr.conformance.proto3",
+          "evalError": {
+            "errors": [
+              {
+                "message": "unsupported field type"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "quoted_fields",
+      "test": [
+        {
+          "name": "set_field",
+          "expr": "TestAllTypes{`in`: true} == TestAllTypes{}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "get_field",
+          "expr": "TestAllTypes{`in`: true}.`in`",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/string.json
+++ b/packages/cel-spec/src/testdata/json/string.json
@@ -1,0 +1,405 @@
+{
+  "name": "string",
+  "description": "Tests for string and bytes operations.",
+  "section": [
+    {
+      "name": "size",
+      "description": "Tests for the size() function.",
+      "test": [
+        {
+          "name": "empty",
+          "expr": "size('')",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "one_ascii",
+          "expr": "size('A')",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "one_unicode",
+          "expr": "size('ÿ')",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "ascii",
+          "expr": "size('four')",
+          "value": {
+            "int64Value": "4"
+          }
+        },
+        {
+          "name": "unicode",
+          "expr": "size('πέντε')",
+          "value": {
+            "int64Value": "5"
+          }
+        },
+        {
+          "name": "bytes_empty",
+          "expr": "size(b'')",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "bytes",
+          "expr": "size(b'abc')",
+          "value": {
+            "int64Value": "3"
+          }
+        }
+      ]
+    },
+    {
+      "name": "starts_with",
+      "description": "Tests for the startsWith() function.",
+      "test": [
+        {
+          "name": "basic_true",
+          "expr": "'foobar'.startsWith('foo')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "basic_false",
+          "expr": "'foobar'.startsWith('bar')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "empty_target",
+          "expr": "''.startsWith('foo')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "empty_arg",
+          "expr": "'foobar'.startsWith('')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "empty_empty",
+          "expr": "''.startsWith('')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "unicode",
+          "expr": "'завтра'.startsWith('за')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "unicode_smp",
+          "expr": "'🐱😀😛'.startsWith('🐱')",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "ends_with",
+      "description": "Tests for the endsWith() function.",
+      "test": [
+        {
+          "name": "basic_true",
+          "expr": "'foobar'.endsWith('bar')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "basic_false",
+          "expr": "'foobar'.endsWith('foo')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "empty_target",
+          "expr": "''.endsWith('foo')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "empty_arg",
+          "expr": "'foobar'.endsWith('')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "empty_empty",
+          "expr": "''.endsWith('')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "unicode",
+          "expr": "'forté'.endsWith('té')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "unicode_smp",
+          "expr": "'🐱😀😛'.endsWith('😛')",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "matches",
+      "description": "Tests for regexp matching.  For now, we will only test the subset of regular languages.",
+      "test": [
+        {
+          "name": "basic",
+          "expr": "'hubba'.matches('ubb')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "empty_target",
+          "expr": "''.matches('foo|bar')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "empty_arg",
+          "expr": "'cows'.matches('')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "empty_empty",
+          "expr": "''.matches('')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "re_concat",
+          "expr": "'abcd'.matches('bc')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "re_alt",
+          "expr": "'grey'.matches('gr(a|e)y')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "re_rep",
+          "expr": "'banana'.matches('ba(na)*')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "unicode",
+          "expr": "'mañana'.matches('a+ñ+a+')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "unicode_smp",
+          "expr": "'🐱😀😀'.matches('(a|😀){2}')",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "concatenation",
+      "description": "Tests for string concatenation.",
+      "test": [
+        {
+          "name": "concat_true",
+          "expr": "'he' + 'llo'",
+          "value": {
+            "stringValue": "hello"
+          }
+        },
+        {
+          "name": "concat_with_spaces",
+          "expr": "'hello' + ' ' == 'hello'",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "concat_empty_string_beginning",
+          "expr": "'' + 'abc'",
+          "value": {
+            "stringValue": "abc"
+          }
+        },
+        {
+          "name": "concat_empty_string_end",
+          "expr": "'abc' + ''",
+          "value": {
+            "stringValue": "abc"
+          }
+        },
+        {
+          "name": "concat_empty_with_empty",
+          "expr": "'' + ''",
+          "value": {
+            "stringValue": ""
+          }
+        },
+        {
+          "name": "unicode_unicode",
+          "expr": "'¢' + 'ÿ' + 'Ȁ'",
+          "value": {
+            "stringValue": "¢ÿȀ"
+          }
+        },
+        {
+          "name": "ascii_unicode",
+          "expr": "'r' + 'ô' + 'le'",
+          "value": {
+            "stringValue": "rôle"
+          }
+        },
+        {
+          "name": "ascii_unicode_unicode_smp",
+          "expr": "'a' + 'ÿ' + '🐱'",
+          "value": {
+            "stringValue": "aÿ🐱"
+          }
+        },
+        {
+          "name": "empty_unicode",
+          "expr": "'' + 'Ω' + ''",
+          "value": {
+            "stringValue": "Ω"
+          }
+        }
+      ]
+    },
+    {
+      "name": "contains",
+      "description": "Tests for contains.",
+      "test": [
+        {
+          "name": "contains_true",
+          "expr": "'hello'.contains('he')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "contains_empty",
+          "expr": "'hello'.contains('')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "contains_false",
+          "expr": "'hello'.contains('ol')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "contains_multiple",
+          "expr": "'abababc'.contains('ababc')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "contains_unicode",
+          "expr": "'Straße'.contains('aß')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "contains_unicode_smp",
+          "expr": "'🐱😀😁'.contains('😀')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "empty_contains",
+          "expr": "''.contains('something')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "empty_empty",
+          "expr": "''.contains('')",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "bytes_concat",
+      "description": "Tests for bytes concatenation.",
+      "test": [
+        {
+          "name": "concat",
+          "expr": "b'abc' + b'def'",
+          "value": {
+            "bytesValue": "YWJjZGVm"
+          }
+        },
+        {
+          "name": "left_unit",
+          "expr": "b'' + b'\\xffoo'",
+          "value": {
+            "bytesValue": "/29v"
+          }
+        },
+        {
+          "name": "right_unit",
+          "expr": "b'zxy' + b''",
+          "value": {
+            "bytesValue": "enh5"
+          }
+        },
+        {
+          "name": "empty_empty",
+          "expr": "b'' + b''",
+          "value": {
+            "bytesValue": ""
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/string_ext.json
+++ b/packages/cel-spec/src/testdata/json/string_ext.json
@@ -1,0 +1,1615 @@
+{
+  "name": "string_ext",
+  "description": "Tests for the strings extension library.",
+  "section": [
+    {
+      "name": "char_at",
+      "test": [
+        {
+          "name": "middle_index",
+          "expr": "'tacocat'.charAt(3)",
+          "value": {
+            "stringValue": "o"
+          }
+        },
+        {
+          "name": "end_index",
+          "expr": "'tacocat'.charAt(7)",
+          "value": {
+            "stringValue": ""
+          }
+        },
+        {
+          "name": "multiple",
+          "expr": "'©αT'.charAt(0) == '©' && '©αT'.charAt(1) == 'α' && '©αT'.charAt(2) == 'T'"
+        }
+      ]
+    },
+    {
+      "name": "index_of",
+      "test": [
+        {
+          "name": "empty_index",
+          "expr": "'tacocat'.indexOf('')",
+          "value": {
+            "int64Value": "0"
+          }
+        },
+        {
+          "name": "string_index",
+          "expr": "'tacocat'.indexOf('ac')",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "nomatch",
+          "expr": "'tacocat'.indexOf('none') == -1"
+        },
+        {
+          "name": "empty_index",
+          "expr": "'tacocat'.indexOf('', 3) == 3"
+        },
+        {
+          "name": "char_index",
+          "expr": "'tacocat'.indexOf('a', 3) == 5"
+        },
+        {
+          "name": "string_index",
+          "expr": "'tacocat'.indexOf('at', 3) == 5"
+        },
+        {
+          "name": "unicode_char",
+          "expr": "'ta©o©αT'.indexOf('©') == 2"
+        },
+        {
+          "name": "unicode_char_index",
+          "expr": "'ta©o©αT'.indexOf('©', 3) == 4"
+        },
+        {
+          "name": "unicode_string_index",
+          "expr": "'ta©o©αT'.indexOf('©αT', 3) == 4"
+        },
+        {
+          "name": "unicode_string_nomatch_index",
+          "expr": "'ta©o©αT'.indexOf('©α', 5) == -1"
+        },
+        {
+          "name": "char_index",
+          "expr": "'ijk'.indexOf('k') == 2"
+        },
+        {
+          "name": "string_with_space_fullmatch",
+          "expr": "'hello wello'.indexOf('hello wello') == 0"
+        },
+        {
+          "name": "string_with_space_index",
+          "expr": "'hello wello'.indexOf('ello', 6) == 7"
+        },
+        {
+          "name": "string_nomatch_index",
+          "expr": "'hello wello'.indexOf('elbo room!!') == -1"
+        }
+      ]
+    },
+    {
+      "name": "last_index_of",
+      "test": [
+        {
+          "name": "empty",
+          "expr": "'tacocat'.lastIndexOf('') == 7"
+        },
+        {
+          "name": "string",
+          "expr": "'tacocat'.lastIndexOf('at') == 5"
+        },
+        {
+          "name": "string_nomatch",
+          "expr": "'tacocat'.lastIndexOf('none') == -1"
+        },
+        {
+          "name": "empty_index",
+          "expr": "'tacocat'.lastIndexOf('', 3) == 3"
+        },
+        {
+          "name": "char_index",
+          "expr": "'tacocat'.lastIndexOf('a', 3) == 1"
+        },
+        {
+          "name": "unicode_char",
+          "expr": "'ta©o©αT'.lastIndexOf('©') == 4"
+        },
+        {
+          "name": "unicode_char_index",
+          "expr": "'ta©o©αT'.lastIndexOf('©', 3) == 2"
+        },
+        {
+          "name": "unicode_string_index",
+          "expr": "'ta©o©αT'.lastIndexOf('©α', 4) == 4"
+        },
+        {
+          "name": "string_with_space_string_index",
+          "expr": "'hello wello'.lastIndexOf('ello', 6) == 1"
+        },
+        {
+          "name": "string_with_space_string_nomatch",
+          "expr": "'hello wello'.lastIndexOf('low') == -1"
+        },
+        {
+          "name": "string_with_space_string_with_space_nomatch",
+          "expr": "'hello wello'.lastIndexOf('elbo room!!') == -1"
+        },
+        {
+          "name": "string_with_space_fullmatch",
+          "expr": "'hello wello'.lastIndexOf('hello wello') == 0"
+        },
+        {
+          "name": "repeated_string",
+          "expr": "'bananananana'.lastIndexOf('nana', 7) == 6"
+        }
+      ]
+    },
+    {
+      "name": "ascii_casing",
+      "test": [
+        {
+          "name": "lowerascii",
+          "expr": "'TacoCat'.lowerAscii() == 'tacocat'"
+        },
+        {
+          "name": "lowerascii_unicode",
+          "expr": "'TacoCÆt'.lowerAscii() == 'tacocÆt'"
+        },
+        {
+          "name": "lowerascii_unicode_with_space",
+          "expr": "'TacoCÆt Xii'.lowerAscii() == 'tacocÆt xii'"
+        },
+        {
+          "name": "upperascii",
+          "expr": "'tacoCat'.upperAscii() == 'TACOCAT'"
+        },
+        {
+          "name": "upperascii_unicode",
+          "expr": "'tacoCαt'.upperAscii() == 'TACOCαT'"
+        },
+        {
+          "name": "upperascii_unicode_with_space",
+          "expr": "'TacoCÆt Xii'.upperAscii() == 'TACOCÆT XII'"
+        }
+      ]
+    },
+    {
+      "name": "replace",
+      "test": [
+        {
+          "name": "no_placeholder",
+          "expr": "'12 days 12 hours'.replace('{0}', '2') == '12 days 12 hours'"
+        },
+        {
+          "name": "basic",
+          "expr": "'{0} days {0} hours'.replace('{0}', '2') == '2 days 2 hours'"
+        },
+        {
+          "name": "chained",
+          "expr": "'{0} days {0} hours'.replace('{0}', '2', 1).replace('{0}', '23') == '2 days 23 hours'"
+        },
+        {
+          "name": "unicode",
+          "expr": "'1 ©αT taco'.replace('αT', 'o©α') == '1 ©o©α taco'"
+        }
+      ]
+    },
+    {
+      "name": "split",
+      "test": [
+        {
+          "name": "empty",
+          "expr": "'hello world'.split(' ') == ['hello', 'world']"
+        },
+        {
+          "name": "zero_limit",
+          "expr": "'hello world events!'.split(' ', 0) == []"
+        },
+        {
+          "name": "one_limit",
+          "expr": "'hello world events!'.split(' ', 1) == ['hello world events!']"
+        },
+        {
+          "name": "unicode_negative_limit",
+          "expr": "'o©o©o©o'.split('©', -1) == ['o', 'o', 'o', 'o']"
+        }
+      ]
+    },
+    {
+      "name": "substring",
+      "test": [
+        {
+          "name": "start",
+          "expr": "'tacocat'.substring(4) == 'cat'"
+        },
+        {
+          "name": "start_with_max_length",
+          "expr": "'tacocat'.substring(7) == ''"
+        },
+        {
+          "name": "start_and_end",
+          "expr": "'tacocat'.substring(0, 4) == 'taco'"
+        },
+        {
+          "name": "start_and_end_equal_value",
+          "expr": "'tacocat'.substring(4, 4) == ''"
+        },
+        {
+          "name": "unicode_start_and_end",
+          "expr": "'ta©o©αT'.substring(2, 6) == '©o©α'"
+        },
+        {
+          "name": "unicode_start_and_end_equal_value",
+          "expr": "'ta©o©αT'.substring(7, 7) == ''"
+        }
+      ]
+    },
+    {
+      "name": "trim",
+      "test": [
+        {
+          "name": "blank_spaces_escaped_chars",
+          "expr": "' \\f\\n\\r\\t\\vtext  '.trim() == 'text'"
+        },
+        {
+          "name": "unicode_space_chars_1",
+          "expr": "'\\u0085\\u00a0\\u1680text'.trim() == 'text'"
+        },
+        {
+          "name": "unicode_space_chars_2",
+          "expr": "'text\\u2000\\u2001\\u2002\\u2003\\u2004\\u2004\\u2006\\u2007\\u2008\\u2009'.trim() == 'text'"
+        },
+        {
+          "name": "unicode_space_chars_3",
+          "expr": "'\\u200atext\\u2028\\u2029\\u202F\\u205F\\u3000'.trim() == 'text'"
+        },
+        {
+          "name": "unicode_no_trim",
+          "expr": "'\\u180etext\\u200b\\u200c\\u200d\\u2060\\ufeff'.trim() == '\\u180etext\\u200b\\u200c\\u200d\\u2060\\ufeff'"
+        }
+      ]
+    },
+    {
+      "name": "join",
+      "test": [
+        {
+          "name": "empty_separator",
+          "expr": "['x', 'y'].join() == 'xy'"
+        },
+        {
+          "name": "dash_separator",
+          "expr": "['x', 'y'].join('-') == 'x-y'"
+        },
+        {
+          "name": "empty_string_empty_separator",
+          "expr": "[].join() == ''"
+        },
+        {
+          "name": "empty_string_dash_separator",
+          "expr": "[].join('-') == ''"
+        }
+      ]
+    },
+    {
+      "name": "quote",
+      "test": [
+        {
+          "name": "multiline",
+          "expr": "strings.quote(\"first\\nsecond\") == \"\\\"first\\\\nsecond\\\"\""
+        },
+        {
+          "name": "escaped",
+          "expr": "strings.quote(\"bell\\a\") == \"\\\"bell\\\\a\\\"\""
+        },
+        {
+          "name": "backspace",
+          "expr": "strings.quote(\"\\bbackspace\") == \"\\\"\\\\bbackspace\\\"\""
+        },
+        {
+          "name": "form_feed",
+          "expr": "strings.quote(\"\\fform feed\") == \"\\\"\\\\fform feed\\\"\""
+        },
+        {
+          "name": "carriage_return",
+          "expr": "strings.quote(\"carriage \\r return\") == \"\\\"carriage \\\\r return\\\"\""
+        },
+        {
+          "name": "horizontal_tab",
+          "expr": "strings.quote(\"horizontal tab\\t\") == \"\\\"horizontal tab\\\\t\\\"\""
+        },
+        {
+          "name": "vertical_tab",
+          "expr": "strings.quote(\"vertical \\v tab\") == \"\\\"vertical \\\\v tab\\\"\""
+        },
+        {
+          "name": "double_slash",
+          "expr": "strings.quote(\"double \\\\\\\\ slash\") == \"\\\"double \\\\\\\\\\\\\\\\ slash\\\"\""
+        },
+        {
+          "name": "two_escape_sequences",
+          "expr": "strings.quote(\"two escape sequences \\\\a\\\\n\") == \"\\\"two escape sequences \\\\\\\\a\\\\\\\\n\\\"\""
+        },
+        {
+          "name": "verbatim",
+          "expr": "strings.quote(\"verbatim\") == \"\\\"verbatim\\\"\""
+        },
+        {
+          "name": "ends_with",
+          "expr": "strings.quote(\"ends with \\\\\") == \"\\\"ends with \\\\\\\\\\\"\""
+        },
+        {
+          "name": "starts_with",
+          "expr": "strings.quote(\"\\\\ starts with\") == \"\\\"\\\\\\\\ starts with\\\"\""
+        },
+        {
+          "name": "printable_unicode",
+          "expr": "strings.quote(\"printable unicode😀\") == \"\\\"printable unicode😀\\\"\""
+        },
+        {
+          "name": "mid_string_quote",
+          "expr": "strings.quote(\"mid string \\\" quote\") == \"\\\"mid string \\\\\\\" quote\\\"\""
+        },
+        {
+          "name": "single_quote_with_double_quote",
+          "expr": "strings.quote('single-quote with \"double quote\"') == \"\\\"single-quote with \\\\\\\"double quote\\\\\\\"\\\"\""
+        },
+        {
+          "name": "size_unicode_char",
+          "expr": "strings.quote(\"size('ÿ')\") == \"\\\"size('ÿ')\\\"\""
+        },
+        {
+          "name": "size_unicode_string",
+          "expr": "strings.quote(\"size('πέντε')\") == \"\\\"size('πέντε')\\\"\""
+        },
+        {
+          "name": "unicode",
+          "expr": "strings.quote(\"завтра\") == \"\\\"завтра\\\"\""
+        },
+        {
+          "name": "unicode_code_points",
+          "expr": "strings.quote(\"\\U0001F431\\U0001F600\\U0001F61B\")",
+          "value": {
+            "stringValue": "\"🐱😀😛\""
+          }
+        },
+        {
+          "name": "unicode_2",
+          "expr": "strings.quote(\"ta©o©αT\") == \"\\\"ta©o©αT\\\"\""
+        },
+        {
+          "name": "empty_quote",
+          "expr": "strings.quote(\"\")",
+          "value": {
+            "stringValue": "\"\""
+          }
+        }
+      ]
+    },
+    {
+      "name": "format",
+      "test": [
+        {
+          "name": "no-op",
+          "expr": "\"no substitution\".format([])",
+          "value": {
+            "stringValue": "no substitution"
+          }
+        },
+        {
+          "name": "mid-string substitution",
+          "expr": "\"str is %s and some more\".format([\"filler\"])",
+          "value": {
+            "stringValue": "str is filler and some more"
+          }
+        },
+        {
+          "name": "percent escaping",
+          "expr": "\"%% and also %%\".format([])",
+          "value": {
+            "stringValue": "% and also %"
+          }
+        },
+        {
+          "name": "substitution inside escaped percent signs",
+          "expr": "\"%%%s%%\".format([\"text\"])",
+          "value": {
+            "stringValue": "%text%"
+          }
+        },
+        {
+          "name": "substitution with one escaped percent sign on the right",
+          "expr": "\"%s%%\".format([\"percent on the right\"])",
+          "value": {
+            "stringValue": "percent on the right%"
+          }
+        },
+        {
+          "name": "substitution with one escaped percent sign on the left",
+          "expr": "\"%%%s\".format([\"percent on the left\"])",
+          "value": {
+            "stringValue": "%percent on the left"
+          }
+        },
+        {
+          "name": "multiple substitutions",
+          "expr": "\"%d %d %d, %s %s %s, %d %d %d, %s %s %s\".format([1, 2, 3, \"A\", \"B\", \"C\", 4, 5, 6, \"D\", \"E\", \"F\"])",
+          "value": {
+            "stringValue": "1 2 3, A B C, 4 5 6, D E F"
+          }
+        },
+        {
+          "name": "percent sign escape sequence support",
+          "expr": "\"%%escaped %s%%\".format([\"percent\"])",
+          "value": {
+            "stringValue": "%escaped percent%"
+          }
+        },
+        {
+          "name": "fixed point formatting clause",
+          "expr": "\"%.3f\".format([1.2345])",
+          "value": {
+            "stringValue": "1.234"
+          }
+        },
+        {
+          "name": "binary formatting clause",
+          "expr": "\"this is 5 in binary: %b\".format([5])",
+          "value": {
+            "stringValue": "this is 5 in binary: 101"
+          }
+        },
+        {
+          "name": "uint support for binary formatting",
+          "expr": "\"unsigned 64 in binary: %b\".format([uint(64)])",
+          "value": {
+            "stringValue": "unsigned 64 in binary: 1000000"
+          }
+        },
+        {
+          "name": "bool support for binary formatting",
+          "expr": "\"bit set from bool: %b\".format([true])",
+          "value": {
+            "stringValue": "bit set from bool: 1"
+          }
+        },
+        {
+          "name": "octal formatting clause",
+          "expr": "\"%o\".format([11])",
+          "value": {
+            "stringValue": "13"
+          }
+        },
+        {
+          "name": "uint support for octal formatting clause",
+          "expr": "\"this is an unsigned octal: %o\".format([uint(65535)])",
+          "value": {
+            "stringValue": "this is an unsigned octal: 177777"
+          }
+        },
+        {
+          "name": "lowercase hexadecimal formatting clause",
+          "expr": "\"%x is 20 in hexadecimal\".format([30])",
+          "value": {
+            "stringValue": "1e is 20 in hexadecimal"
+          }
+        },
+        {
+          "name": "uppercase hexadecimal formatting clause",
+          "expr": "\"%X is 20 in hexadecimal\".format([30])",
+          "value": {
+            "stringValue": "1E is 20 in hexadecimal"
+          }
+        },
+        {
+          "name": "unsigned support for hexadecimal formatting clause",
+          "expr": "\"%X is 6000 in hexadecimal\".format([uint(6000)])",
+          "value": {
+            "stringValue": "1770 is 6000 in hexadecimal"
+          }
+        },
+        {
+          "name": "string support with hexadecimal formatting clause",
+          "expr": "\"%x\".format([\"Hello world!\"])",
+          "value": {
+            "stringValue": "48656c6c6f20776f726c6421"
+          }
+        },
+        {
+          "name": "string support with uppercase hexadecimal formatting clause",
+          "expr": "\"%X\".format([\"Hello world!\"])",
+          "value": {
+            "stringValue": "48656C6C6F20776F726C6421"
+          }
+        },
+        {
+          "name": "byte support with hexadecimal formatting clause",
+          "expr": "\"%x\".format([b\"byte string\"])",
+          "value": {
+            "stringValue": "6279746520737472696e67"
+          }
+        },
+        {
+          "name": "byte support with uppercase hexadecimal formatting clause",
+          "expr": "\"%X\".format([b\"byte string\"])",
+          "value": {
+            "stringValue": "6279746520737472696E67"
+          }
+        },
+        {
+          "name": "scientific notation formatting clause",
+          "expr": "\"%.6e\".format([1052.032911275])",
+          "value": {
+            "stringValue": "1.052033e+03"
+          }
+        },
+        {
+          "name": "default precision for fixed-point clause",
+          "expr": "\"%f\".format([2.71828])",
+          "value": {
+            "stringValue": "2.718280"
+          }
+        },
+        {
+          "name": "default precision for scientific notation",
+          "expr": "\"%e\".format([2.71828])",
+          "value": {
+            "stringValue": "2.718280e+00"
+          }
+        },
+        {
+          "name": "NaN support for scientific notation",
+          "expr": "\"%e\".format([double(\"NaN\")])",
+          "value": {
+            "stringValue": "NaN"
+          }
+        },
+        {
+          "name": "positive infinity support for scientific notation",
+          "expr": "\"%e\".format([double(\"Infinity\")])",
+          "value": {
+            "stringValue": "Infinity"
+          }
+        },
+        {
+          "name": "negative infinity support for scientific notation",
+          "expr": "\"%e\".format([double(\"-Infinity\")])",
+          "value": {
+            "stringValue": "-Infinity"
+          }
+        },
+        {
+          "name": "NaN support for decimal",
+          "expr": "\"%d\".format([double(\"NaN\")])",
+          "value": {
+            "stringValue": "NaN"
+          }
+        },
+        {
+          "name": "positive infinity support for decimal",
+          "expr": "\"%d\".format([double(\"Infinity\")])",
+          "value": {
+            "stringValue": "Infinity"
+          }
+        },
+        {
+          "name": "negative infinity support for decimal",
+          "expr": "\"%d\".format([double(\"-Infinity\")])",
+          "value": {
+            "stringValue": "-Infinity"
+          }
+        },
+        {
+          "name": "NaN support for fixed-point",
+          "expr": "\"%f\".format([double(\"NaN\")])",
+          "value": {
+            "stringValue": "NaN"
+          }
+        },
+        {
+          "name": "positive infinity support for fixed-point",
+          "expr": "\"%f\".format([double(\"Infinity\")])",
+          "value": {
+            "stringValue": "Infinity"
+          }
+        },
+        {
+          "name": "negative infinity support for fixed-point",
+          "expr": "\"%f\".format([double(\"-Infinity\")])",
+          "value": {
+            "stringValue": "-Infinity"
+          }
+        },
+        {
+          "name": "uint support for decimal clause",
+          "expr": "\"%d\".format([uint(64)])",
+          "value": {
+            "stringValue": "64"
+          }
+        },
+        {
+          "name": "null support for string",
+          "expr": "\"%s\".format([null])",
+          "value": {
+            "stringValue": "null"
+          }
+        },
+        {
+          "name": "int support for string",
+          "expr": "\"%s\".format([999999999999])",
+          "value": {
+            "stringValue": "999999999999"
+          }
+        },
+        {
+          "name": "bytes support for string",
+          "expr": "\"%s\".format([b\"xyz\"])",
+          "value": {
+            "stringValue": "xyz"
+          }
+        },
+        {
+          "name": "type() support for string",
+          "expr": "\"%s\".format([type(\"test string\")])",
+          "value": {
+            "stringValue": "string"
+          }
+        },
+        {
+          "name": "timestamp support for string",
+          "expr": "\"%s\".format([timestamp(\"2023-02-03T23:31:20+00:00\")])",
+          "value": {
+            "stringValue": "2023-02-03T23:31:20Z"
+          }
+        },
+        {
+          "name": "duration support for string",
+          "expr": "\"%s\".format([duration(\"1h45m47s\")])",
+          "value": {
+            "stringValue": "6347s"
+          }
+        },
+        {
+          "name": "list support for string",
+          "expr": "\"%s\".format([[\"abc\", 3.14, null, [9, 8, 7, 6], timestamp(\"2023-02-03T23:31:20Z\")]])",
+          "value": {
+            "stringValue": "[abc, 3.14, null, [9, 8, 7, 6], 2023-02-03T23:31:20Z]"
+          }
+        },
+        {
+          "name": "map support for string",
+          "expr": "\"%s\".format([{\"key1\": b\"xyz\", \"key5\": null, \"key2\": duration(\"2h\"), \"key4\": true, \"key3\": 2.71828}])",
+          "value": {
+            "stringValue": "{key1: xyz, key2: 7200s, key3: 2.71828, key4: true, key5: null}"
+          }
+        },
+        {
+          "name": "map support (all key types)",
+          "expr": "\"%s\".format([{1: \"value1\", uint(2): \"value2\", true: double(\"NaN\")}])",
+          "value": {
+            "stringValue": "{1: value1, 2: value2, true: NaN}"
+          }
+        },
+        {
+          "name": "boolean support for %s",
+          "expr": "\"%s, %s\".format([true, false])",
+          "value": {
+            "stringValue": "true, false"
+          }
+        },
+        {
+          "name": "dyntype support for string formatting clause",
+          "expr": "\"%s\".format([dyn(\"a string\")])",
+          "value": {
+            "stringValue": "a string"
+          }
+        },
+        {
+          "name": "dyntype support for numbers with string formatting clause",
+          "expr": "\"%s, %s\".format([dyn(32), dyn(56.8)])",
+          "value": {
+            "stringValue": "32, 56.8"
+          }
+        },
+        {
+          "name": "dyntype support for integer formatting clause",
+          "expr": "\"%d\".format([dyn(128)])",
+          "value": {
+            "stringValue": "128"
+          }
+        },
+        {
+          "name": "dyntype support for integer formatting clause (unsigned)",
+          "expr": "\"%d\".format([dyn(256u)])",
+          "value": {
+            "stringValue": "256"
+          }
+        },
+        {
+          "name": "dyntype support for hex formatting clause",
+          "expr": "\"%x\".format([dyn(22)])",
+          "value": {
+            "stringValue": "16"
+          }
+        },
+        {
+          "name": "dyntype support for hex formatting clause (uppercase)",
+          "expr": "\"%X\".format([dyn(26)])",
+          "value": {
+            "stringValue": "1A"
+          }
+        },
+        {
+          "name": "dyntype support for unsigned hex formatting clause",
+          "expr": "\"%x\".format([dyn(500u)])",
+          "value": {
+            "stringValue": "1f4"
+          }
+        },
+        {
+          "name": "dyntype support for fixed-point formatting clause",
+          "expr": "\"%.3f\".format([dyn(4.5)])",
+          "value": {
+            "stringValue": "4.500"
+          }
+        },
+        {
+          "name": "dyntype support for scientific notation",
+          "expr": "\"%e\".format([dyn(2.71828)])",
+          "value": {
+            "stringValue": "2.718280e+00"
+          }
+        },
+        {
+          "name": "dyntype NaN/infinity support",
+          "expr": "\"%s\".format([[double(\"NaN\"), double(\"Infinity\"), double(\"-Infinity\")]])",
+          "value": {
+            "stringValue": "[NaN, Infinity, -Infinity]"
+          }
+        },
+        {
+          "name": "dyntype support for timestamp",
+          "expr": "\"%s\".format([dyn(timestamp(\"2009-11-10T23:00:00Z\"))])",
+          "value": {
+            "stringValue": "2009-11-10T23:00:00Z"
+          }
+        },
+        {
+          "name": "dyntype support for duration",
+          "expr": "\"%s\".format([dyn(duration(\"8747s\"))])",
+          "value": {
+            "stringValue": "8747s"
+          }
+        },
+        {
+          "name": "dyntype support for lists",
+          "expr": "\"%s\".format([dyn([6, 4.2, \"a string\"])])",
+          "value": {
+            "stringValue": "[6, 4.2, a string]"
+          }
+        },
+        {
+          "name": "dyntype support for maps",
+          "expr": "\"%s\".format([{\"strKey\":\"x\", 6:duration(\"422s\"), true:42}])",
+          "value": {
+            "stringValue": "{6: 422s, strKey: x, true: 42}"
+          }
+        },
+        {
+          "name": "string substitution in a string variable",
+          "expr": "str_var.format([\"filler\"])",
+          "typeEnv": [
+            {
+              "name": "str_var",
+              "ident": {
+                "type": {
+                  "primitive": "STRING"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "str_var": {
+              "value": {
+                "stringValue": "%s"
+              }
+            }
+          },
+          "value": {
+            "stringValue": "filler"
+          }
+        },
+        {
+          "name": "multiple substitutions in a string variable",
+          "expr": "str_var.format([1, 2, 3, \"A\", \"B\", \"C\", 4, 5, 6, \"D\", \"E\", \"F\"])",
+          "typeEnv": [
+            {
+              "name": "str_var",
+              "ident": {
+                "type": {
+                  "primitive": "STRING"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "str_var": {
+              "value": {
+                "stringValue": "%d %d %d, %s %s %s, %d %d %d, %s %s %s"
+              }
+            }
+          },
+          "value": {
+            "stringValue": "1 2 3, A B C, 4 5 6, D E F"
+          }
+        },
+        {
+          "name": "substitution inside escaped percent signs in a string variable",
+          "expr": "str_var.format([\"text\"])",
+          "typeEnv": [
+            {
+              "name": "str_var",
+              "ident": {
+                "type": {
+                  "primitive": "STRING"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "str_var": {
+              "value": {
+                "stringValue": "%%%s%%"
+              }
+            }
+          },
+          "value": {
+            "stringValue": "%text%"
+          }
+        },
+        {
+          "name": "fixed point formatting clause in a string variable",
+          "expr": "str_var.format([1.2345])",
+          "typeEnv": [
+            {
+              "name": "str_var",
+              "ident": {
+                "type": {
+                  "primitive": "STRING"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "str_var": {
+              "value": {
+                "stringValue": "%.3f"
+              }
+            }
+          },
+          "value": {
+            "stringValue": "1.234"
+          }
+        },
+        {
+          "name": "binary formatting clause in a string variable",
+          "expr": "str_var.format([5])",
+          "typeEnv": [
+            {
+              "name": "str_var",
+              "ident": {
+                "type": {
+                  "primitive": "STRING"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "str_var": {
+              "value": {
+                "stringValue": "%b"
+              }
+            }
+          },
+          "value": {
+            "stringValue": "101"
+          }
+        },
+        {
+          "name": "scientific notation formatting clause in a string variable",
+          "expr": "str_var.format([1052.032911275])",
+          "typeEnv": [
+            {
+              "name": "str_var",
+              "ident": {
+                "type": {
+                  "primitive": "STRING"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "str_var": {
+              "value": {
+                "stringValue": "%.6e"
+              }
+            }
+          },
+          "value": {
+            "stringValue": "1.052033e+03"
+          }
+        },
+        {
+          "name": "default precision for fixed-point clause in a string variable",
+          "expr": "str_var.format([2.71828])",
+          "typeEnv": [
+            {
+              "name": "str_var",
+              "ident": {
+                "type": {
+                  "primitive": "STRING"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "str_var": {
+              "value": {
+                "stringValue": "%f"
+              }
+            }
+          },
+          "value": {
+            "stringValue": "2.718280"
+          }
+        }
+      ]
+    },
+    {
+      "name": "format_errors",
+      "test": [
+        {
+          "name": "unrecognized formatting clause",
+          "expr": "\"%a\".format([1])",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "could not parse formatting clause: unrecognized formatting clause \"a\""
+              }
+            ]
+          }
+        },
+        {
+          "name": "out of bounds arg index",
+          "expr": "\"%d %d %d\".format([0, 1])",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "index 2 out of range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "string substitution is not allowed with binary clause",
+          "expr": "\"string is %b\".format([\"abc\"])",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "error during formatting: only integers and bools can be formatted as binary, was given string"
+              }
+            ]
+          }
+        },
+        {
+          "name": "duration substitution not allowed with decimal clause",
+          "expr": "\"%d\".format([duration(\"30m2s\")])",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "error during formatting: decimal clause can only be used on integers, was given google.protobuf.Duration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "string substitution not allowed with octal clause",
+          "expr": "\"octal: %o\".format([\"a string\"])",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "error during formatting: octal clause can only be used on integers, was given string"
+              }
+            ]
+          }
+        },
+        {
+          "name": "double substitution not allowed with hex clause",
+          "expr": "\"double is %x\".format([0.5])",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "error during formatting: only integers, byte buffers, and strings can be formatted as hex, was given double"
+              }
+            ]
+          }
+        },
+        {
+          "name": "uppercase not allowed for scientific clause",
+          "expr": "\"double is %E\".format([0.5])",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "could not parse formatting clause: unrecognized formatting clause \"E\""
+              }
+            ]
+          }
+        },
+        {
+          "name": "object not allowed",
+          "expr": "\"object is %s\".format([cel.expr.conformance.proto3.TestAllTypes{}])",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "error during formatting: string clause can only be used on strings, bools, bytes, ints, doubles, maps, lists, types, durations, and timestamps, was given cel.expr.conformance.proto3.TestAllTypes"
+              }
+            ]
+          }
+        },
+        {
+          "name": "object inside list",
+          "expr": "\"%s\".format([[1, 2, cel.expr.conformance.proto3.TestAllTypes{}]])",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "error during formatting: string clause can only be used on strings, bools, bytes, ints, doubles, maps, lists, types, durations, and timestamps, was given cel.expr.conformance.proto3.TestAllTypes"
+              }
+            ]
+          }
+        },
+        {
+          "name": "object inside map",
+          "expr": "\"%s\".format([{1: \"a\", 2: cel.expr.conformance.proto3.TestAllTypes{}}])",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "error during formatting: string clause can only be used on strings, bools, bytes, ints, doubles, maps, lists, types, durations, and timestamps, was given cel.expr.conformance.proto3.TestAllTypes"
+              }
+            ]
+          }
+        },
+        {
+          "name": "null not allowed for %d",
+          "expr": "\"null: %d\".format([null])",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "error during formatting: decimal clause can only be used on integers, was given null_type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "null not allowed for %e",
+          "expr": "\"null: %e\".format([null])",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "error during formatting: scientific clause can only be used on doubles, was given null_type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "null not allowed for %f",
+          "expr": "\"null: %f\".format([null])",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "error during formatting: fixed-point clause can only be used on doubles, was given null_type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "null not allowed for %x",
+          "expr": "\"null: %x\".format([null])",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "error during formatting: only integers, byte buffers, and strings can be formatted as hex, was given null_type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "null not allowed for %X",
+          "expr": "\"null: %X\".format([null])",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "error during formatting: only integers, byte buffers, and strings can be formatted as hex, was given null_type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "null not allowed for %b",
+          "expr": "\"null: %b\".format([null])",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "error during formatting: only integers and bools can be formatted as binary, was given null_type"
+              }
+            ]
+          }
+        },
+        {
+          "name": "null not allowed for %o",
+          "expr": "\"null: %o\".format([null])",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "error during formatting: octal clause can only be used on integers, was given null_type"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "value_errors",
+      "test": [
+        {
+          "name": "charat_out_of_range",
+          "expr": "'tacocat'.charAt(30) == ''",
+          "evalError": {
+            "errors": [
+              {
+                "message": "index out of range: 30"
+              }
+            ]
+          }
+        },
+        {
+          "name": "indexof_out_of_range",
+          "expr": "'tacocat'.indexOf('a', 30) == -1",
+          "evalError": {
+            "errors": [
+              {
+                "message": "index out of range: 30"
+              }
+            ]
+          }
+        },
+        {
+          "name": "lastindexof_negative_index",
+          "expr": "'tacocat'.lastIndexOf('a', -1) == -1",
+          "evalError": {
+            "errors": [
+              {
+                "message": "index out of range: -1"
+              }
+            ]
+          }
+        },
+        {
+          "name": "lastindexof_out_of_range",
+          "expr": "'tacocat'.lastIndexOf('a', 30) == -1",
+          "evalError": {
+            "errors": [
+              {
+                "message": "index out of range: 30"
+              }
+            ]
+          }
+        },
+        {
+          "name": "substring_out_of_range",
+          "expr": "'tacocat'.substring(40) == 'cat'",
+          "evalError": {
+            "errors": [
+              {
+                "message": "index out of range: 40"
+              }
+            ]
+          }
+        },
+        {
+          "name": "substring_negative_index",
+          "expr": "'tacocat'.substring(-1) == 'cat'",
+          "evalError": {
+            "errors": [
+              {
+                "message": "index out of range: -1"
+              }
+            ]
+          }
+        },
+        {
+          "name": "substring_end_index_out_of_range",
+          "expr": "'tacocat'.substring(1, 50) == 'cat'",
+          "evalError": {
+            "errors": [
+              {
+                "message": "index out of range: 50"
+              }
+            ]
+          }
+        },
+        {
+          "name": "substring_begin_index_out_of_range",
+          "expr": "'tacocat'.substring(49, 50) == 'cat'",
+          "evalError": {
+            "errors": [
+              {
+                "message": "index out of range: 49"
+              }
+            ]
+          }
+        },
+        {
+          "name": "substring_end_index_greater_than_begin_index",
+          "expr": "'tacocat'.substring(4, 3) == ''",
+          "evalError": {
+            "errors": [
+              {
+                "message": "invalid substring range. start: 4, end: 3"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "type_errors",
+      "test": [
+        {
+          "name": "charat_invalid_type",
+          "expr": "42.charAt(2) == ''",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "charat_invalid_argument",
+          "expr": "'hello'.charAt(true) == ''",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "indexof_unary_invalid_type",
+          "expr": "24.indexOf('2') == 0",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "indexof_unary_invalid_argument",
+          "expr": "'hello'.indexOf(true) == 1",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "indexof_binary_invalid_argument",
+          "expr": "42.indexOf('4', 0) == 0",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "indexof_binary_invalid_argument_2",
+          "expr": "'42'.indexOf(4, 0) == 0",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "indexof_binary_both_invalid_arguments",
+          "expr": "'42'.indexOf('4', '0') == 0",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "indexof_ternary_invalid_arguments",
+          "expr": "'42'.indexOf('4', 0, 1) == 0",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "split_invalid_type",
+          "expr": "42.split('2') == ['4']",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "replace_invalid_type",
+          "expr": "42.replace(2, 1) == '41'",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "replace_binary_invalid_argument",
+          "expr": "'42'.replace(2, 1) == '41'",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "replace_binary_invalid_argument_2",
+          "expr": "'42'.replace('2', 1) == '41'",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "replace_ternary_invalid_argument",
+          "expr": "42.replace('2', '1', 1) == '41'",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "replace_ternary_invalid_argument_2",
+          "expr": "'42'.replace(2, '1', 1) == '41'",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "replace_ternary_invalid_argument_3",
+          "expr": "'42'.replace('2', 1, 1) == '41'",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "replace_ternary_invalid_argument_4",
+          "expr": "'42'.replace('2', '1', '1') == '41'",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "replace_quaternary_invalid_argument",
+          "expr": "'42'.replace('2', '1', 1, false) == '41'",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "split_invalid_type_empty_arg",
+          "expr": "42.split('') == ['4', '2']",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "split_invalid_argument",
+          "expr": "'42'.split(2) == ['4']",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "split_binary_invalid_type",
+          "expr": "42.split('2', '1') == ['4']",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "split_binary_invalid_argument",
+          "expr": "'42'.split(2, 1) == ['4']",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "split_binary_invalid_argument_2",
+          "expr": "'42'.split('2', '1') == ['4']",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "split_ternary_invalid_argument",
+          "expr": "'42'.split('2', 1, 1) == ['4']",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "substring_ternary_invalid_argument",
+          "expr": "'hello'.substring(1, 2, 3) == ''",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "substring_binary_invalid_type",
+          "expr": "30.substring(true, 3) == ''",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "substring_binary_invalid_argument",
+          "expr": "'tacocat'.substring(true, 3) == ''",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        },
+        {
+          "name": "substring_binary_invalid_argument_2",
+          "expr": "'tacocat'.substring(0, false) == ''",
+          "disableCheck": true,
+          "evalError": {
+            "errors": [
+              {
+                "message": "no such overload"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/timestamps.json
+++ b/packages/cel-spec/src/testdata/json/timestamps.json
@@ -1,0 +1,681 @@
+{
+  "name": "timestamps",
+  "description": "Timestamp and duration tests.",
+  "section": [
+    {
+      "name": "timestamp_conversions",
+      "description": "Conversions of timestamps to other types.",
+      "test": [
+        {
+          "name": "toInt_timestamp",
+          "expr": "int(timestamp('2009-02-13T23:31:30Z'))",
+          "value": {
+            "int64Value": "1234567890"
+          }
+        },
+        {
+          "name": "toString_timestamp",
+          "expr": "string(timestamp('2009-02-13T23:31:30Z'))",
+          "value": {
+            "stringValue": "2009-02-13T23:31:30Z"
+          }
+        },
+        {
+          "name": "toString_timestamp_nanos",
+          "expr": "string(timestamp('9999-12-31T23:59:59.999999999Z'))",
+          "value": {
+            "stringValue": "9999-12-31T23:59:59.999999999Z"
+          }
+        },
+        {
+          "name": "toType_timestamp",
+          "expr": "type(timestamp('2009-02-13T23:31:30Z'))",
+          "value": {
+            "typeValue": "google.protobuf.Timestamp"
+          }
+        },
+        {
+          "name": "type_comparison",
+          "expr": "google.protobuf.Timestamp == type(timestamp('2009-02-13T23:31:30Z'))",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "duration_conversions",
+      "description": "Conversions of durations to other types.",
+      "test": [
+        {
+          "name": "toString_duration",
+          "expr": "string(duration('1000000s'))",
+          "value": {
+            "stringValue": "1000000s"
+          }
+        },
+        {
+          "name": "toType_duration",
+          "expr": "type(duration('1000000s'))",
+          "value": {
+            "typeValue": "google.protobuf.Duration"
+          }
+        },
+        {
+          "name": "type_comparison",
+          "expr": "google.protobuf.Duration == type(duration('1000000s'))",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "timestamp_selectors",
+      "description": "Timestamp selection operators without timezones",
+      "test": [
+        {
+          "name": "getDate",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getDate()",
+          "value": {
+            "int64Value": "13"
+          }
+        },
+        {
+          "name": "getDayOfMonth",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getDayOfMonth()",
+          "value": {
+            "int64Value": "12"
+          }
+        },
+        {
+          "name": "getDayOfWeek",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getDayOfWeek()",
+          "value": {
+            "int64Value": "5"
+          }
+        },
+        {
+          "name": "getDayOfYear",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getDayOfYear()",
+          "value": {
+            "int64Value": "43"
+          }
+        },
+        {
+          "name": "getFullYear",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getFullYear()",
+          "value": {
+            "int64Value": "2009"
+          }
+        },
+        {
+          "name": "getHours",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getHours()",
+          "value": {
+            "int64Value": "23"
+          }
+        },
+        {
+          "name": "getMilliseconds",
+          "expr": "timestamp('2009-02-13T23:31:20.123456789Z').getMilliseconds()",
+          "value": {
+            "int64Value": "123"
+          }
+        },
+        {
+          "name": "getMinutes",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getMinutes()",
+          "value": {
+            "int64Value": "31"
+          }
+        },
+        {
+          "name": "getMonth",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getMonth()",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "getSeconds",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getSeconds()",
+          "value": {
+            "int64Value": "30"
+          }
+        }
+      ]
+    },
+    {
+      "name": "timestamp_selectors_tz",
+      "description": "Timestamp selection operators with timezones",
+      "test": [
+        {
+          "name": "getDate",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getDate('Australia/Sydney')",
+          "value": {
+            "int64Value": "14"
+          }
+        },
+        {
+          "name": "getDayOfMonth_name_pos",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getDayOfMonth('US/Central')",
+          "value": {
+            "int64Value": "12"
+          }
+        },
+        {
+          "name": "getDayOfMonth_numerical_pos",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getDayOfMonth('+11:00')",
+          "value": {
+            "int64Value": "13"
+          }
+        },
+        {
+          "name": "getDayOfMonth_numerical_neg",
+          "expr": "timestamp('2009-02-13T02:00:00Z').getDayOfMonth('-02:30')",
+          "value": {
+            "int64Value": "11"
+          }
+        },
+        {
+          "name": "getDayOfMonth_name_neg",
+          "expr": "timestamp('2009-02-13T02:00:00Z').getDayOfMonth('America/St_Johns')",
+          "value": {
+            "int64Value": "11"
+          }
+        },
+        {
+          "name": "getDayOfWeek",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getDayOfWeek('UTC')",
+          "value": {
+            "int64Value": "5"
+          }
+        },
+        {
+          "name": "getDayOfYear",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getDayOfYear('US/Central')",
+          "value": {
+            "int64Value": "43"
+          }
+        },
+        {
+          "name": "getFullYear",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getFullYear('-09:30')",
+          "value": {
+            "int64Value": "2009"
+          }
+        },
+        {
+          "name": "getHours",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getHours('02:00')",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "getMinutes",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getMinutes('Asia/Kathmandu')",
+          "value": {
+            "int64Value": "16"
+          }
+        },
+        {
+          "name": "getMonth",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getMonth('UTC')",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "getSeconds",
+          "expr": "timestamp('2009-02-13T23:31:30Z').getSeconds('-00:00')",
+          "value": {
+            "int64Value": "30"
+          }
+        }
+      ]
+    },
+    {
+      "name": "timestamp_equality",
+      "description": "Equality operations on timestamps.",
+      "test": [
+        {
+          "name": "eq_same",
+          "expr": "timestamp('2009-02-13T23:31:30Z') == timestamp('2009-02-13T23:31:30Z')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_diff",
+          "expr": "timestamp('2009-02-13T23:31:29Z') == timestamp('2009-02-13T23:31:30Z')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "neq_same",
+          "expr": "timestamp('1945-05-07T02:41:00Z') != timestamp('1945-05-07T02:41:00Z')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "neq_diff",
+          "expr": "timestamp('2000-01-01T00:00:00Z') != timestamp('2001-01-01T00:00:00Z')",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "duration_equality",
+      "description": "Equality tests for durations.",
+      "test": [
+        {
+          "name": "eq_same",
+          "expr": "duration('123s') == duration('123s')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "eq_diff",
+          "expr": "duration('60s') == duration('3600s')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "neq_same",
+          "expr": "duration('604800s') != duration('604800s')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "neq_diff",
+          "expr": "duration('86400s') != duration('86164s')",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "timestamp_arithmetic",
+      "description": "Arithmetic operations on timestamps and/or durations.",
+      "test": [
+        {
+          "name": "add_duration_to_time",
+          "expr": "timestamp('2009-02-13T23:00:00Z') + duration('240s') == timestamp('2009-02-13T23:04:00Z')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "add_time_to_duration",
+          "expr": "duration('120s') + timestamp('2009-02-13T23:01:00Z') == timestamp('2009-02-13T23:03:00Z')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "add_duration_to_duration",
+          "expr": "duration('600s') + duration('50s') == duration('650s')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "add_time_to_duration_nanos_negative",
+          "expr": "timestamp('0001-01-01T00:00:01.000000001Z') + duration('-999999999ns') == timestamp('0001-01-01T00:00:00.000000002Z')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "add_time_to_duration_nanos_positive",
+          "expr": "timestamp('0001-01-01T00:00:01.999999999Z') + duration('999999999ns') == timestamp('0001-01-01T00:00:02.999999998Z')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "subtract_duration_from_time",
+          "expr": "timestamp('2009-02-13T23:10:00Z') - duration('600s') == timestamp('2009-02-13T23:00:00Z')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "subtract_time_from_time",
+          "expr": "timestamp('2009-02-13T23:31:00Z') - timestamp('2009-02-13T23:29:00Z') == duration('120s')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "subtract_duration_from_duration",
+          "expr": "duration('900s') - duration('42s') == duration('858s')",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "comparisons",
+      "description": "Comparisons on timestamps and/or durations.",
+      "test": [
+        {
+          "name": "leq_timestamp_true",
+          "expr": "timestamp('2009-02-13T23:00:00Z') <= timestamp('2009-02-13T23:00:00Z')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "leq_timestamp_false",
+          "expr": "timestamp('2009-02-13T23:00:00Z') <= timestamp('2009-02-13T22:59:59Z')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "leq_duration_true",
+          "expr": "duration('200s') <= duration('200s')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "leq_duration_false",
+          "expr": "duration('300s') <= duration('200s')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "less_timestamp_true",
+          "expr": "timestamp('2009-02-13T23:00:00Z') < timestamp('2009-03-13T23:00:00Z')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "less_duration_true",
+          "expr": "duration('200s') < duration('300s')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "geq_timestamp_true",
+          "expr": "timestamp('2009-02-13T23:00:00Z') >= timestamp('2009-02-13T23:00:00Z')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "geq_timestamp_false",
+          "expr": "timestamp('2009-02-13T22:58:00Z') >= timestamp('2009-02-13T23:00:00Z')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "geq_duration_true",
+          "expr": "duration('200s') >= duration('200s')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "geq_duration_false",
+          "expr": "duration('120s') >= duration('200s')",
+          "value": {
+            "boolValue": false
+          }
+        },
+        {
+          "name": "greater_timestamp_true",
+          "expr": "timestamp('2009-02-13T23:59:00Z') > timestamp('2009-02-13T23:00:00Z')",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "greater_duration_true",
+          "expr": "duration('300s') > duration('200s')",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "duration_converters",
+      "description": "Conversion functions on durations. Unlike timestamps, we don't, e.g. select the 'minutes' field - we convert the duration to integer minutes.",
+      "test": [
+        {
+          "name": "get_hours",
+          "expr": "duration('10000s').getHours()",
+          "value": {
+            "int64Value": "2"
+          }
+        },
+        {
+          "name": "get_milliseconds",
+          "description": "Obtain the milliseconds component of the duration. Note, this is not the same as converting the duration to milliseconds. This behavior will be deprecated.",
+          "expr": "x.getMilliseconds()",
+          "typeEnv": [
+            {
+              "name": "x",
+              "ident": {
+                "type": {
+                  "messageType": "google.protobuf.Duration"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "x": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/google.protobuf.Duration",
+                  "value": "123.321456789s"
+                }
+              }
+            }
+          },
+          "value": {
+            "int64Value": "321"
+          }
+        },
+        {
+          "name": "get_minutes",
+          "expr": "duration('3730s').getMinutes()",
+          "value": {
+            "int64Value": "62"
+          }
+        },
+        {
+          "name": "get_seconds",
+          "expr": "duration('3730s').getSeconds()",
+          "value": {
+            "int64Value": "3730"
+          }
+        }
+      ]
+    },
+    {
+      "name": "timestamp_range",
+      "description": "Tests for out-of-range operations on timestamps.",
+      "test": [
+        {
+          "name": "from_string_under",
+          "expr": "timestamp('0000-01-01T00:00:00Z')",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "from_string_over",
+          "expr": "timestamp('10000-01-01T00:00:00Z')",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "add_duration_under",
+          "expr": "timestamp('0001-01-01T00:00:00Z') + duration('-1s')",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "add_duration_over",
+          "expr": "timestamp('9999-12-31T23:59:59Z') + duration('1s')",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "add_duration_nanos_over",
+          "expr": "timestamp('9999-12-31T23:59:59.999999999Z') + duration('1ns')",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "add_duration_nanos_under",
+          "expr": "timestamp('0001-01-01T00:00:00Z') + duration('-1ns')",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "sub_time_duration_over",
+          "expr": "timestamp('9999-12-31T23:59:59Z') - timestamp('0001-01-01T00:00:00Z')",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "sub_time_duration_under",
+          "expr": "timestamp('0001-01-01T00:00:00Z') - timestamp('9999-12-31T23:59:59Z')",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "duration_range",
+      "description": "Tests for out-of-range operations on durations.",
+      "test": [
+        {
+          "name": "from_string_under",
+          "expr": "duration('-320000000000s')",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "from_string_over",
+          "expr": "duration('320000000000s')",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "add_under",
+          "expr": "duration('-200000000000s') + duration('-200000000000s')",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "add_over",
+          "expr": "duration('200000000000s') + duration('200000000000s')",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "sub_under",
+          "expr": "duration('-200000000000s') - duration('200000000000s')",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        },
+        {
+          "name": "sub_over",
+          "expr": "duration('200000000000s') - duration('-200000000000s')",
+          "evalError": {
+            "errors": [
+              {
+                "message": "range"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/type_deductions.json
+++ b/packages/cel-spec/src/testdata/json/type_deductions.json
@@ -1,0 +1,1171 @@
+{
+  "name": "type_deductions",
+  "description": "Tests for type checker deduced types",
+  "section": [
+    {
+      "name": "constant_literals",
+      "test": [
+        {
+          "name": "bool",
+          "expr": "true",
+          "typedResult": {
+            "result": {
+              "boolValue": true
+            },
+            "deducedType": {
+              "primitive": "BOOL"
+            }
+          }
+        },
+        {
+          "name": "int",
+          "expr": "42",
+          "typedResult": {
+            "result": {
+              "int64Value": "42"
+            },
+            "deducedType": {
+              "primitive": "INT64"
+            }
+          }
+        },
+        {
+          "name": "uint",
+          "expr": "42u",
+          "typedResult": {
+            "result": {
+              "uint64Value": "42"
+            },
+            "deducedType": {
+              "primitive": "UINT64"
+            }
+          }
+        },
+        {
+          "name": "double",
+          "expr": "0.1",
+          "typedResult": {
+            "result": {
+              "doubleValue": 0.1
+            },
+            "deducedType": {
+              "primitive": "DOUBLE"
+            }
+          }
+        },
+        {
+          "name": "string",
+          "expr": "\"test\"",
+          "typedResult": {
+            "result": {
+              "stringValue": "test"
+            },
+            "deducedType": {
+              "primitive": "STRING"
+            }
+          }
+        },
+        {
+          "name": "bytes",
+          "expr": "b\"test\"",
+          "typedResult": {
+            "result": {
+              "bytesValue": "dGVzdA=="
+            },
+            "deducedType": {
+              "primitive": "BYTES"
+            }
+          }
+        },
+        {
+          "name": "null",
+          "expr": "null",
+          "typedResult": {
+            "result": {
+              "nullValue": null
+            },
+            "deducedType": {
+              "null": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "complex_initializers",
+      "test": [
+        {
+          "name": "list",
+          "expr": "[1]",
+          "typedResult": {
+            "result": {
+              "listValue": {
+                "values": [
+                  {
+                    "int64Value": "1"
+                  }
+                ]
+              }
+            },
+            "deducedType": {
+              "listType": {
+                "elemType": {
+                  "primitive": "INT64"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "map",
+          "expr": "{'abc': 123}",
+          "typedResult": {
+            "result": {
+              "mapValue": {
+                "entries": [
+                  {
+                    "key": {
+                      "stringValue": "abc"
+                    },
+                    "value": {
+                      "int64Value": "123"
+                    }
+                  }
+                ]
+              }
+            },
+            "deducedType": {
+              "mapType": {
+                "keyType": {
+                  "primitive": "STRING"
+                },
+                "valueType": {
+                  "primitive": "INT64"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "struct",
+          "expr": "TestAllTypes{single_int64: 1}",
+          "container": "cel.expr.conformance.proto3",
+          "typedResult": {
+            "result": {
+              "objectValue": {
+                "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes",
+                "singleInt64": "1"
+              }
+            },
+            "deducedType": {
+              "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "field_access",
+      "test": [
+        {
+          "name": "int_field",
+          "expr": "TestAllTypes{single_int64: 1}.single_int64",
+          "container": "cel.expr.conformance.proto3",
+          "typedResult": {
+            "result": {
+              "int64Value": "1"
+            },
+            "deducedType": {
+              "primitive": "INT64"
+            }
+          }
+        },
+        {
+          "name": "repeated_int_field",
+          "expr": "TestAllTypes{}.repeated_int64",
+          "container": "cel.expr.conformance.proto3",
+          "typedResult": {
+            "result": {
+              "listValue": {}
+            },
+            "deducedType": {
+              "listType": {
+                "elemType": {
+                  "primitive": "INT64"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "map_bool_int",
+          "expr": "TestAllTypes{}.map_bool_int64",
+          "container": "cel.expr.conformance.proto3",
+          "typedResult": {
+            "result": {
+              "mapValue": {}
+            },
+            "deducedType": {
+              "mapType": {
+                "keyType": {
+                  "primitive": "BOOL"
+                },
+                "valueType": {
+                  "primitive": "INT64"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "enum_field",
+          "expr": "TestAllTypes{}.standalone_enum",
+          "container": "cel.expr.conformance.proto3",
+          "typedResult": {
+            "result": {
+              "int64Value": "0"
+            },
+            "deducedType": {
+              "primitive": "INT64"
+            }
+          }
+        },
+        {
+          "name": "repeated_enum_field",
+          "expr": "TestAllTypes{}.repeated_nested_enum",
+          "container": "cel.expr.conformance.proto3",
+          "typedResult": {
+            "result": {
+              "listValue": {}
+            },
+            "deducedType": {
+              "listType": {
+                "elemType": {
+                  "primitive": "INT64"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "enum_map_field",
+          "expr": "TestAllTypes{}.map_int32_enum",
+          "container": "cel.expr.conformance.proto3",
+          "typedResult": {
+            "result": {
+              "mapValue": {}
+            },
+            "deducedType": {
+              "mapType": {
+                "keyType": {
+                  "primitive": "INT64"
+                },
+                "valueType": {
+                  "primitive": "INT64"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "indexing",
+      "test": [
+        {
+          "name": "list",
+          "expr": "['foo'][0]",
+          "typedResult": {
+            "result": {
+              "stringValue": "foo"
+            },
+            "deducedType": {
+              "primitive": "STRING"
+            }
+          }
+        },
+        {
+          "name": "map",
+          "expr": "{'abc': 123}['abc']",
+          "typedResult": {
+            "result": {
+              "int64Value": "123"
+            },
+            "deducedType": {
+              "primitive": "INT64"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "functions",
+      "test": [
+        {
+          "name": "nested_calls",
+          "expr": "('foo' + 'bar').startsWith('foo')",
+          "typedResult": {
+            "result": {
+              "boolValue": true
+            },
+            "deducedType": {
+              "primitive": "BOOL"
+            }
+          }
+        },
+        {
+          "name": "function_result_type",
+          "expr": "fn('abc', 123)",
+          "checkOnly": true,
+          "typeEnv": [
+            {
+              "name": "fn",
+              "function": {
+                "overloads": [
+                  {
+                    "overloadId": "fn_string_int",
+                    "params": [
+                      {
+                        "primitive": "STRING"
+                      },
+                      {
+                        "primitive": "INT64"
+                      }
+                    ],
+                    "resultType": {
+                      "primitive": "STRING"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "typedResult": {
+            "deducedType": {
+              "primitive": "STRING"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "flexible_type_parameter_assignment",
+      "test": [
+        {
+          "name": "list_parameter",
+          "expr": "[[], [[]], [[[]]], [[[[]]]]]",
+          "checkOnly": true,
+          "typedResult": {
+            "deducedType": {
+              "listType": {
+                "elemType": {
+                  "listType": {
+                    "elemType": {
+                      "listType": {
+                        "elemType": {
+                          "listType": {
+                            "elemType": {
+                              "listType": {
+                                "elemType": {
+                                  "dyn": {}
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "list_parameter_order_independent",
+          "expr": "[[[[[]]]], [], [[[]]]]",
+          "checkOnly": true,
+          "typedResult": {
+            "deducedType": {
+              "listType": {
+                "elemType": {
+                  "listType": {
+                    "elemType": {
+                      "listType": {
+                        "elemType": {
+                          "listType": {
+                            "elemType": {
+                              "listType": {
+                                "elemType": {
+                                  "dyn": {}
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "comprehension_type_var_aliasing",
+          "expr": "msg.repeated_nested_message.map(x, x).map(y, y.bb)",
+          "checkOnly": true,
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "typedResult": {
+            "deducedType": {
+              "listType": {
+                "elemType": {
+                  "primitive": "INT64"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "overload_type_var_aliasing",
+          "expr": "([] + msg.repeated_nested_message + [])[0].bb",
+          "checkOnly": true,
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "typedResult": {
+            "deducedType": {
+              "primitive": "INT64"
+            }
+          }
+        },
+        {
+          "name": "unconstrained_type_var_as_dyn",
+          "expr": "([].map(x,x))[0].foo",
+          "checkOnly": true,
+          "typedResult": {
+            "deducedType": {
+              "dyn": {}
+            }
+          }
+        },
+        {
+          "name": "list_parameters_do_not_unify",
+          "expr": "[msg.single_int64_wrapper, msg.single_string_wrapper]",
+          "checkOnly": true,
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "typedResult": {
+            "deducedType": {
+              "listType": {
+                "elemType": {
+                  "dyn": {}
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "optional_none",
+          "expr": "[optional.none(), optional.of(1)]",
+          "checkOnly": true,
+          "typedResult": {
+            "deducedType": {
+              "listType": {
+                "elemType": {
+                  "abstractType": {
+                    "name": "optional_type",
+                    "parameterTypes": [
+                      {
+                        "primitive": "INT64"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "optional_none_2",
+          "expr": "[optional.of(1), optional.none()]",
+          "checkOnly": true,
+          "typedResult": {
+            "deducedType": {
+              "listType": {
+                "elemType": {
+                  "abstractType": {
+                    "name": "optional_type",
+                    "parameterTypes": [
+                      {
+                        "primitive": "INT64"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "optional_dyn_promotion",
+          "expr": "[optional.of(1), optional.of(dyn(1))]",
+          "checkOnly": true,
+          "typedResult": {
+            "deducedType": {
+              "listType": {
+                "elemType": {
+                  "abstractType": {
+                    "name": "optional_type",
+                    "parameterTypes": [
+                      {
+                        "dyn": {}
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "optional_dyn_promotion_2",
+          "expr": "[optional.of(dyn(1)), optional.of(1)]",
+          "checkOnly": true,
+          "typedResult": {
+            "deducedType": {
+              "listType": {
+                "elemType": {
+                  "abstractType": {
+                    "name": "optional_type",
+                    "parameterTypes": [
+                      {
+                        "dyn": {}
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "optional_in_ternary",
+          "expr": "true ? optional.of(dyn(1)) : optional.of(1)",
+          "checkOnly": true,
+          "typedResult": {
+            "deducedType": {
+              "abstractType": {
+                "name": "optional_type",
+                "parameterTypes": [
+                  {
+                    "dyn": {}
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "wrappers",
+      "test": [
+        {
+          "name": "wrapper_promotion",
+          "expr": "[msg.single_int64_wrapper, msg.single_int64]",
+          "checkOnly": true,
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "typedResult": {
+            "deducedType": {
+              "listType": {
+                "elemType": {
+                  "wrapper": "INT64"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "wrapper_promotion_2",
+          "expr": "[msg.single_int64, msg.single_int64_wrapper]",
+          "checkOnly": true,
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "typedResult": {
+            "deducedType": {
+              "listType": {
+                "elemType": {
+                  "wrapper": "INT64"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "wrapper_dyn_promotion",
+          "expr": "[msg.single_int64_wrapper, msg.single_int64, dyn(1)]",
+          "checkOnly": true,
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "typedResult": {
+            "deducedType": {
+              "listType": {
+                "elemType": {
+                  "dyn": {}
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "wrapper_dyn_promotion_2",
+          "expr": "[dyn(1), msg.single_int64_wrapper, msg.single_int64]",
+          "checkOnly": true,
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "typedResult": {
+            "deducedType": {
+              "listType": {
+                "elemType": {
+                  "dyn": {}
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "wrapper_primitive_assignable",
+          "expr": "msg.single_int64_wrapper + 1",
+          "checkOnly": true,
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "typedResult": {
+            "deducedType": {
+              "primitive": "INT64"
+            }
+          }
+        },
+        {
+          "name": "wrapper_null_assignable",
+          "expr": "msg.single_int64_wrapper == null",
+          "checkOnly": true,
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "typedResult": {
+            "deducedType": {
+              "primitive": "BOOL"
+            }
+          }
+        },
+        {
+          "name": "wrapper_ternary_parameter_assignment",
+          "expr": "false ? msg.single_int64_wrapper : null",
+          "checkOnly": true,
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "typedResult": {
+            "deducedType": {
+              "wrapper": "INT64"
+            }
+          }
+        },
+        {
+          "name": "wrapper_ternary_parameter_assignment_2",
+          "expr": "true ? msg.single_int64_wrapper : 42",
+          "checkOnly": true,
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "typedResult": {
+            "deducedType": {
+              "wrapper": "INT64"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "type_parameters",
+      "test": [
+        {
+          "name": "multiple_parameters_generality",
+          "expr": "[tuple(1, 2u, 3.0), tuple(dyn(1), dyn(2u), dyn(3.0))][0]",
+          "checkOnly": true,
+          "typeEnv": [
+            {
+              "name": "tuple",
+              "function": {
+                "overloads": [
+                  {
+                    "overloadId": "tuple_T_U_V",
+                    "params": [
+                      {
+                        "typeParam": "T"
+                      },
+                      {
+                        "typeParam": "U"
+                      },
+                      {
+                        "typeParam": "V"
+                      }
+                    ],
+                    "resultType": {
+                      "abstractType": {
+                        "name": "tuple",
+                        "parameterTypes": [
+                          {
+                            "typeParam": "T"
+                          },
+                          {
+                            "typeParam": "U"
+                          },
+                          {
+                            "typeParam": "V"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "typedResult": {
+            "deducedType": {
+              "abstractType": {
+                "name": "tuple",
+                "parameterTypes": [
+                  {
+                    "dyn": {}
+                  },
+                  {
+                    "dyn": {}
+                  },
+                  {
+                    "dyn": {}
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "name": "multiple_parameters_generality_2",
+          "expr": "sort(tuple(dyn(1), 2u, 3.0))",
+          "checkOnly": true,
+          "typeEnv": [
+            {
+              "name": "tuple",
+              "function": {
+                "overloads": [
+                  {
+                    "overloadId": "tuple_T_U_V",
+                    "params": [
+                      {
+                        "typeParam": "T"
+                      },
+                      {
+                        "typeParam": "U"
+                      },
+                      {
+                        "typeParam": "V"
+                      }
+                    ],
+                    "resultType": {
+                      "abstractType": {
+                        "name": "tuple",
+                        "parameterTypes": [
+                          {
+                            "typeParam": "T"
+                          },
+                          {
+                            "typeParam": "U"
+                          },
+                          {
+                            "typeParam": "V"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "name": "sort",
+              "function": {
+                "overloads": [
+                  {
+                    "overloadId": "sort_tuple_T_T_T",
+                    "params": [
+                      {
+                        "abstractType": {
+                          "name": "tuple",
+                          "parameterTypes": [
+                            {
+                              "typeParam": "T"
+                            },
+                            {
+                              "typeParam": "T"
+                            },
+                            {
+                              "typeParam": "T"
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "resultType": {
+                      "abstractType": {
+                        "name": "tuple",
+                        "parameterTypes": [
+                          {
+                            "typeParam": "T"
+                          },
+                          {
+                            "typeParam": "T"
+                          },
+                          {
+                            "typeParam": "T"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "typedResult": {
+            "deducedType": {
+              "abstractType": {
+                "name": "tuple",
+                "parameterTypes": [
+                  {
+                    "dyn": {}
+                  },
+                  {
+                    "dyn": {}
+                  },
+                  {
+                    "dyn": {}
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "name": "multiple_parameters_parameterized_ovl",
+          "expr": "tuple(1, 2u, 3.0) == tuple(1, dyn(2u), dyn(3.0))",
+          "checkOnly": true,
+          "typeEnv": [
+            {
+              "name": "tuple",
+              "function": {
+                "overloads": [
+                  {
+                    "overloadId": "tuple_T_U_V",
+                    "params": [
+                      {
+                        "typeParam": "T"
+                      },
+                      {
+                        "typeParam": "U"
+                      },
+                      {
+                        "typeParam": "V"
+                      }
+                    ],
+                    "resultType": {
+                      "abstractType": {
+                        "name": "tuple",
+                        "parameterTypes": [
+                          {
+                            "typeParam": "T"
+                          },
+                          {
+                            "typeParam": "U"
+                          },
+                          {
+                            "typeParam": "V"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "typedResult": {
+            "deducedType": {
+              "primitive": "BOOL"
+            }
+          }
+        },
+        {
+          "name": "multiple_parameters_parameterized_ovl_2",
+          "expr": "tuple(dyn(1), dyn(2u), 3.0) == tuple(1, 2u, 3.0)",
+          "checkOnly": true,
+          "typeEnv": [
+            {
+              "name": "tuple",
+              "function": {
+                "overloads": [
+                  {
+                    "overloadId": "tuple_T_U_V",
+                    "params": [
+                      {
+                        "typeParam": "T"
+                      },
+                      {
+                        "typeParam": "U"
+                      },
+                      {
+                        "typeParam": "V"
+                      }
+                    ],
+                    "resultType": {
+                      "abstractType": {
+                        "name": "tuple",
+                        "parameterTypes": [
+                          {
+                            "typeParam": "T"
+                          },
+                          {
+                            "typeParam": "U"
+                          },
+                          {
+                            "typeParam": "V"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "typedResult": {
+            "deducedType": {
+              "primitive": "BOOL"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "legacy_nullable_types",
+      "test": [
+        {
+          "name": "null_assignable_to_message_parameter_candidate",
+          "expr": "[msg, null][0]",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          },
+          "typedResult": {
+            "result": {
+              "objectValue": {
+                "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes"
+              }
+            },
+            "deducedType": {
+              "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+            }
+          }
+        },
+        {
+          "name": "null_assignable_to_duration_parameter_candidate",
+          "expr": "[msg.single_duration, null][0]",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          },
+          "typedResult": {
+            "result": {
+              "objectValue": {
+                "@type": "type.googleapis.com/google.protobuf.Duration",
+                "value": "0s"
+              }
+            },
+            "deducedType": {
+              "wellKnown": "DURATION"
+            }
+          }
+        },
+        {
+          "name": "null_assignable_to_timestamp_parameter_candidate",
+          "expr": "[msg.single_timestamp, null][0]",
+          "typeEnv": [
+            {
+              "name": "msg",
+              "ident": {
+                "type": {
+                  "messageType": "cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          ],
+          "bindings": {
+            "msg": {
+              "value": {
+                "objectValue": {
+                  "@type": "type.googleapis.com/cel.expr.conformance.proto3.TestAllTypes"
+                }
+              }
+            }
+          },
+          "typedResult": {
+            "result": {
+              "objectValue": {
+                "@type": "type.googleapis.com/google.protobuf.Timestamp",
+                "value": "1970-01-01T00:00:00Z"
+              }
+            },
+            "deducedType": {
+              "wellKnown": "TIMESTAMP"
+            }
+          }
+        },
+        {
+          "name": "null_assignable_to_abstract_parameter_candidate",
+          "expr": "[optional.of(1), null][0]",
+          "checkOnly": true,
+          "typedResult": {
+            "deducedType": {
+              "abstractType": {
+                "name": "optional_type",
+                "parameterTypes": [
+                  {
+                    "primitive": "INT64"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/json/unknowns.json
+++ b/packages/cel-spec/src/testdata/json/unknowns.json
@@ -1,0 +1,4 @@
+{
+  "name": "unknowns",
+  "description": "Tests for evaluation with unknown inputs."
+}

--- a/packages/cel-spec/src/testdata/json/wrappers.json
+++ b/packages/cel-spec/src/testdata/json/wrappers.json
@@ -1,0 +1,374 @@
+{
+  "name": "wrappers",
+  "description": "Conformance tests related to wrapper types.",
+  "section": [
+    {
+      "name": "bool",
+      "test": [
+        {
+          "name": "to_any",
+          "expr": "TestAllTypes{single_any: google.protobuf.BoolValue{value: true}}.single_any",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "to_json",
+          "expr": "TestAllTypes{single_value: google.protobuf.BoolValue{value: true}}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        },
+        {
+          "name": "to_null",
+          "expr": "TestAllTypes{single_bool_wrapper: null} == TestAllTypes{}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "int32",
+      "test": [
+        {
+          "name": "to_any",
+          "expr": "TestAllTypes{single_any: google.protobuf.Int32Value{value: 1}}.single_any",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "to_json",
+          "expr": "TestAllTypes{single_value: google.protobuf.Int32Value{value: 1}}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "doubleValue": 1
+          }
+        },
+        {
+          "name": "to_null",
+          "expr": "TestAllTypes{single_int32_wrapper: null} == TestAllTypes{}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "int64",
+      "test": [
+        {
+          "name": "to_any",
+          "expr": "TestAllTypes{single_any: google.protobuf.Int64Value{value: 1}}.single_any",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "int64Value": "1"
+          }
+        },
+        {
+          "name": "to_json_number",
+          "expr": "TestAllTypes{single_value: google.protobuf.Int64Value{value: 1}}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "doubleValue": 1
+          }
+        },
+        {
+          "name": "to_json_string",
+          "expr": "TestAllTypes{single_value: google.protobuf.Int64Value{value: 9223372036854775807}}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "stringValue": "9223372036854775807"
+          }
+        },
+        {
+          "name": "to_null",
+          "expr": "TestAllTypes{single_int64_wrapper: null} == TestAllTypes{}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "uint32",
+      "test": [
+        {
+          "name": "to_any",
+          "expr": "TestAllTypes{single_any: google.protobuf.UInt32Value{value: 1u}}.single_any",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "uint64Value": "1"
+          }
+        },
+        {
+          "name": "to_json",
+          "expr": "TestAllTypes{single_value: google.protobuf.UInt32Value{value: 1u}}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "doubleValue": 1
+          }
+        },
+        {
+          "name": "to_null",
+          "expr": "TestAllTypes{single_uint32_wrapper: null} == TestAllTypes{}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "uint64",
+      "test": [
+        {
+          "name": "to_any",
+          "expr": "TestAllTypes{single_any: google.protobuf.UInt64Value{value: 1u}}.single_any",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "uint64Value": "1"
+          }
+        },
+        {
+          "name": "to_json_number",
+          "expr": "TestAllTypes{single_value: google.protobuf.UInt64Value{value: 1u}}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "doubleValue": 1
+          }
+        },
+        {
+          "name": "to_json_string",
+          "expr": "TestAllTypes{single_value: google.protobuf.UInt64Value{value: 18446744073709551615u}}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "stringValue": "18446744073709551615"
+          }
+        },
+        {
+          "name": "to_null",
+          "expr": "TestAllTypes{single_uint64_wrapper: null} == TestAllTypes{}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "float",
+      "test": [
+        {
+          "name": "to_any",
+          "expr": "TestAllTypes{single_any: google.protobuf.FloatValue{value: 1.0}}.single_any",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "doubleValue": 1
+          }
+        },
+        {
+          "name": "to_json",
+          "expr": "TestAllTypes{single_value: google.protobuf.FloatValue{value: 1.0}}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "doubleValue": 1
+          }
+        },
+        {
+          "name": "to_null",
+          "expr": "TestAllTypes{single_float_wrapper: null} == TestAllTypes{}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "double",
+      "test": [
+        {
+          "name": "to_any",
+          "expr": "TestAllTypes{single_any: google.protobuf.DoubleValue{value: 1.0}}.single_any",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "doubleValue": 1
+          }
+        },
+        {
+          "name": "to_json",
+          "expr": "TestAllTypes{single_value: google.protobuf.DoubleValue{value: 1.0}}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "doubleValue": 1
+          }
+        },
+        {
+          "name": "to_null",
+          "expr": "TestAllTypes{single_double_wrapper: null} == TestAllTypes{}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "bytes",
+      "test": [
+        {
+          "name": "to_any",
+          "expr": "TestAllTypes{single_any: google.protobuf.BytesValue{value: b'foo'}}.single_any",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "bytesValue": "Zm9v"
+          }
+        },
+        {
+          "name": "to_json",
+          "expr": "TestAllTypes{single_value: google.protobuf.BytesValue{value: b'foo'}}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "stringValue": "Zm9v"
+          }
+        },
+        {
+          "name": "to_null",
+          "expr": "TestAllTypes{single_bytes_wrapper: null} == TestAllTypes{}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "string",
+      "test": [
+        {
+          "name": "to_any",
+          "expr": "TestAllTypes{single_any: google.protobuf.StringValue{value: 'foo'}}.single_any",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "stringValue": "foo"
+          }
+        },
+        {
+          "name": "to_json",
+          "expr": "TestAllTypes{single_value: google.protobuf.StringValue{value: 'foo'}}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "stringValue": "foo"
+          }
+        },
+        {
+          "name": "to_null",
+          "expr": "TestAllTypes{single_string_wrapper: null} == TestAllTypes{}",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "boolValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "value",
+      "test": [
+        {
+          "name": "default_to_json",
+          "expr": "TestAllTypes{single_any: TestAllTypes{}.single_value}.single_any",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "nullValue": null
+          }
+        }
+      ]
+    },
+    {
+      "name": "list_value",
+      "test": [
+        {
+          "name": "literal_to_any",
+          "expr": "TestAllTypes{single_any: []}.single_any",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "listValue": {}
+          }
+        }
+      ]
+    },
+    {
+      "name": "struct",
+      "test": [
+        {
+          "name": "literal_to_any",
+          "expr": "TestAllTypes{single_any: {}}.single_any",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "mapValue": {}
+          }
+        }
+      ]
+    },
+    {
+      "name": "field_mask",
+      "test": [
+        {
+          "name": "to_json",
+          "expr": "TestAllTypes{single_value: google.protobuf.FieldMask{paths: ['foo', 'bar']}}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "stringValue": "foo,bar"
+          }
+        }
+      ]
+    },
+    {
+      "name": "duration",
+      "test": [
+        {
+          "name": "to_json",
+          "expr": "TestAllTypes{single_value: duration('1000000s')}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "stringValue": "1000000s"
+          }
+        }
+      ]
+    },
+    {
+      "name": "timestamp",
+      "test": [
+        {
+          "name": "to_json",
+          "expr": "TestAllTypes{single_value: timestamp('9999-12-31T23:59:59.999999999Z')}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "stringValue": "9999-12-31T23:59:59.999999999Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "empty",
+      "test": [
+        {
+          "name": "to_json",
+          "expr": "TestAllTypes{single_value: google.protobuf.Empty{}}.single_value",
+          "container": "cel.expr.conformance.proto3",
+          "value": {
+            "mapValue": {}
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cel-spec/src/testdata/parser-conformance.ts
+++ b/packages/cel-spec/src/testdata/parser-conformance.ts
@@ -1,0 +1,8426 @@
+// Copyright 2024-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated from cel-go ../src/testdata/json
+export const parserTests = [
+  { expr: "0", ast: "0^#*expr.Constant_Int64Value#" },
+  { expr: "0u", ast: "0u^#*expr.Constant_Uint64Value#" },
+  { expr: "0U", ast: "0u^#*expr.Constant_Uint64Value#" },
+  { expr: "0.0", ast: "0^#*expr.Constant_DoubleValue#" },
+  { expr: "0e+0", ast: "0^#*expr.Constant_DoubleValue#" },
+  { expr: "''", ast: '""^#*expr.Constant_StringValue#' },
+  { expr: '""', ast: '""^#*expr.Constant_StringValue#' },
+  { expr: 'r""', ast: '""^#*expr.Constant_StringValue#' },
+  { expr: 'b""', ast: 'b""^#*expr.Constant_BytesValue#' },
+  { expr: "false", ast: "false^#*expr.Constant_BoolValue#" },
+  { expr: "null", ast: "null^#*expr.Constant_NullValue#" },
+  { expr: "[]", ast: "[]^#*expr.Expr_ListExpr#" },
+  { expr: "{}", ast: "{}^#*expr.Expr_StructExpr#" },
+  { expr: 'r""""""', ast: '""^#*expr.Constant_StringValue#' },
+  { expr: "r''''''", ast: '""^#*expr.Constant_StringValue#' },
+  { expr: "42", ast: "42^#*expr.Constant_Int64Value#" },
+  { expr: "123456789u", ast: "123456789u^#*expr.Constant_Uint64Value#" },
+  { expr: "123456789U", ast: "123456789u^#*expr.Constant_Uint64Value#" },
+  {
+    expr: "-9223372036854775808",
+    ast: "-9223372036854775808^#*expr.Constant_Int64Value#",
+  },
+  { expr: "-2.3e+1", ast: "-23^#*expr.Constant_DoubleValue#" },
+  { expr: '"!"', ast: '"!"^#*expr.Constant_StringValue#' },
+  { expr: "'\\''", ast: '"\'"^#*expr.Constant_StringValue#' },
+  { expr: "b'ÿ'", ast: 'b"ÿ"^#*expr.Constant_BytesValue#' },
+  { expr: "b'\\000\\xff'", ast: 'b"\\x00\\xff"^#*expr.Constant_BytesValue#' },
+  {
+    expr: "[-1]",
+    ast: "[\n  -1^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#",
+  },
+  {
+    expr: '{"k":"v"}',
+    ast: '{\n  "k"^#*expr.Constant_StringValue#:"v"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  { expr: "true", ast: "true^#*expr.Constant_BoolValue#" },
+  { expr: "0x55555555", ast: "1431655765^#*expr.Constant_Int64Value#" },
+  { expr: "-0x55555555", ast: "-1431655765^#*expr.Constant_Int64Value#" },
+  { expr: "0x55555555u", ast: "1431655765u^#*expr.Constant_Uint64Value#" },
+  { expr: "0x55555555U", ast: "1431655765u^#*expr.Constant_Uint64Value#" },
+  { expr: '"\\u270c"', ast: '"✌"^#*expr.Constant_StringValue#' },
+  { expr: '"\\U0001f431"', ast: '"🐱"^#*expr.Constant_StringValue#' },
+  {
+    expr: '"\\a\\b\\f\\n\\r\\t\\v\\"\\\'\\\\"',
+    ast: '"\\a\\b\\f\\n\\r\\t\\v\\"\'\\\\"^#*expr.Constant_StringValue#',
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "x || true",
+    ast: "_||_(\n  x^#*expr.Expr_IdentExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1 + 1",
+    ast: "_+_(\n  1^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "f_unknown(17)",
+    ast: "f_unknown(\n  17^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "f_unknown(17) || true",
+    ast: "_||_(\n  f_unknown(\n    17^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  { expr: "false", ast: "false^#*expr.Constant_BoolValue#" },
+  { expr: "true", ast: "true^#*expr.Constant_BoolValue#" },
+  { expr: "null", ast: "null^#*expr.Constant_NullValue#" },
+  {
+    expr: "cel.bind(t, true, t)",
+    ast: "cel^#*expr.Expr_IdentExpr#.bind(\n  t^#*expr.Expr_IdentExpr#,\n  true^#*expr.Constant_BoolValue#,\n  t^#*expr.Expr_IdentExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: 'cel.bind(msg, "hello", msg + msg + msg)',
+    ast: 'cel^#*expr.Expr_IdentExpr#.bind(\n  msg^#*expr.Expr_IdentExpr#,\n  "hello"^#*expr.Constant_StringValue#,\n  _+_(\n    _+_(\n      msg^#*expr.Expr_IdentExpr#,\n      msg^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#,\n    msg^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "cel.bind(t1, true, cel.bind(t2, true, t1 \u0026\u0026 t2))",
+    ast: "cel^#*expr.Expr_IdentExpr#.bind(\n  t1^#*expr.Expr_IdentExpr#,\n  true^#*expr.Constant_BoolValue#,\n  cel^#*expr.Expr_IdentExpr#.bind(\n    t2^#*expr.Expr_IdentExpr#,\n    true^#*expr.Constant_BoolValue#,\n    _\u0026\u0026_(\n      t1^#*expr.Expr_IdentExpr#,\n      t2^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.bind(valid_elems, [1, 2, 3], [3, 4, 5].exists(e, e in valid_elems))",
+    ast: "cel^#*expr.Expr_IdentExpr#.bind(\n  valid_elems^#*expr.Expr_IdentExpr#,\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  __comprehension__(\n    // Variable\n    e,\n    // Target\n    [\n      3^#*expr.Constant_Int64Value#,\n      4^#*expr.Constant_Int64Value#,\n      5^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#,\n    // Accumulator\n    __result__,\n    // Init\n    false^#*expr.Constant_BoolValue#,\n    // LoopCondition\n    @not_strictly_false(\n      !_(\n        __result__^#*expr.Expr_IdentExpr#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    // LoopStep\n    _||_(\n      __result__^#*expr.Expr_IdentExpr#,\n      @in(\n        e^#*expr.Expr_IdentExpr#,\n        valid_elems^#*expr.Expr_IdentExpr#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    // Result\n    __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.bind(valid_elems, [1, 2, 3], ![4, 5].exists(e, e in valid_elems))",
+    ast: "cel^#*expr.Expr_IdentExpr#.bind(\n  valid_elems^#*expr.Expr_IdentExpr#,\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  !_(\n    __comprehension__(\n      // Variable\n      e,\n      // Target\n      [\n        4^#*expr.Constant_Int64Value#,\n        5^#*expr.Constant_Int64Value#\n      ]^#*expr.Expr_ListExpr#,\n      // Accumulator\n      __result__,\n      // Init\n      false^#*expr.Constant_BoolValue#,\n      // LoopCondition\n      @not_strictly_false(\n        !_(\n          __result__^#*expr.Expr_IdentExpr#\n        )^#*expr.Expr_CallExpr#\n      )^#*expr.Expr_CallExpr#,\n      // LoopStep\n      _||_(\n        __result__^#*expr.Expr_IdentExpr#,\n        @in(\n          e^#*expr.Expr_IdentExpr#,\n          valid_elems^#*expr.Expr_IdentExpr#\n        )^#*expr.Expr_CallExpr#\n      )^#*expr.Expr_CallExpr#,\n      // Result\n      __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.block([1, cel.index(0) + 1, cel.index(1) + 1, cel.index(2) + 1], cel.index(3))",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    1^#*expr.Constant_Int64Value#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  cel^#*expr.Expr_IdentExpr#.index(\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.block([[1, 2], size(cel.index(0)), cel.index(1) + cel.index(1), cel.index(2) + 1], cel.index(3))",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    [\n      1^#*expr.Constant_Int64Value#,\n      2^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#,\n    size(\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  cel^#*expr.Expr_IdentExpr#.index(\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.block([[1, 2], size(cel.index(0)), 2 + cel.index(1), cel.index(2) + cel.index(1), cel.index(3) + 1], cel.index(4))",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    [\n      1^#*expr.Constant_Int64Value#,\n      2^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#,\n    size(\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      2^#*expr.Constant_Int64Value#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  cel^#*expr.Expr_IdentExpr#.index(\n    4^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.block([[0], size(cel.index(0)), [1, 2], size(cel.index(2)), cel.index(1) + cel.index(1), cel.index(4) + cel.index(3), cel.index(5) + cel.index(3)], cel.index(6))",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    [\n      0^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#,\n    size(\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    [\n      1^#*expr.Constant_Int64Value#,\n      2^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#,\n    size(\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        4^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        5^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  cel^#*expr.Expr_IdentExpr#.index(\n    6^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.block([[0], size(cel.index(0)), [1, 2], size(cel.index(2)), [1, 2, 3], size(cel.index(4)), 5 + cel.index(1), cel.index(6) + cel.index(1), cel.index(7) + cel.index(3), cel.index(8) + cel.index(3), cel.index(9) + cel.index(5), cel.index(10) + cel.index(5)], cel.index(11))",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    [\n      0^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#,\n    size(\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    [\n      1^#*expr.Constant_Int64Value#,\n      2^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#,\n    size(\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    [\n      1^#*expr.Constant_Int64Value#,\n      2^#*expr.Constant_Int64Value#,\n      3^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#,\n    size(\n      cel^#*expr.Expr_IdentExpr#.index(\n        4^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      5^#*expr.Constant_Int64Value#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        6^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        7^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        8^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        9^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        5^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        10^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        5^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  cel^#*expr.Expr_IdentExpr#.index(\n    11^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.block([timestamp(1000000000), int(cel.index(0)), timestamp(cel.index(1)), cel.index(2).getFullYear(), timestamp(50), int(cel.index(4)), timestamp(cel.index(5)), timestamp(200), int(cel.index(7)), timestamp(cel.index(8)), cel.index(9).getFullYear(), timestamp(75), int(cel.index(11)), timestamp(cel.index(12)), cel.index(13).getFullYear(), cel.index(3) + cel.index(14), cel.index(6).getFullYear(), cel.index(15) + cel.index(16), cel.index(17) + cel.index(3), cel.index(6).getSeconds(), cel.index(18) + cel.index(19), cel.index(20) + cel.index(10), cel.index(21) + cel.index(10), cel.index(13).getMinutes(), cel.index(22) + cel.index(23), cel.index(24) + cel.index(3)], cel.index(25))",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    timestamp(\n      1000000000^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    int(\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    timestamp(\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.getFullYear()^#*expr.Expr_CallExpr#,\n    timestamp(\n      50^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    int(\n      cel^#*expr.Expr_IdentExpr#.index(\n        4^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    timestamp(\n      cel^#*expr.Expr_IdentExpr#.index(\n        5^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    timestamp(\n      200^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    int(\n      cel^#*expr.Expr_IdentExpr#.index(\n        7^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    timestamp(\n      cel^#*expr.Expr_IdentExpr#.index(\n        8^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      9^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.getFullYear()^#*expr.Expr_CallExpr#,\n    timestamp(\n      75^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    int(\n      cel^#*expr.Expr_IdentExpr#.index(\n        11^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    timestamp(\n      cel^#*expr.Expr_IdentExpr#.index(\n        12^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      13^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.getFullYear()^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        14^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      6^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.getFullYear()^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        15^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        16^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        17^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      6^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.getSeconds()^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        18^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        19^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        20^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        10^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        21^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        10^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      13^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.getMinutes()^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        22^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        23^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        24^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  cel^#*expr.Expr_IdentExpr#.index(\n    25^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: 'cel.block([{"a": 2}, cel.index(0)["a"], cel.index(1) * cel.index(1), cel.index(1) + cel.index(2)], cel.index(3))',
+    ast: 'cel^#*expr.Expr_IdentExpr#.block(\n  [\n    {\n      "a"^#*expr.Constant_StringValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#,\n    _[_](\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      "a"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    _*_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  cel^#*expr.Expr_IdentExpr#.index(\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'cel.block([{"b": 1}, {"e": cel.index(0)}], {"a": cel.index(0), "c": cel.index(0), "d": cel.index(1), "e": cel.index(1)})',
+    ast: 'cel^#*expr.Expr_IdentExpr#.block(\n  [\n    {\n      "b"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#,\n    {\n      "e"^#*expr.Constant_StringValue#:cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  ]^#*expr.Expr_ListExpr#,\n  {\n    "a"^#*expr.Constant_StringValue#:cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#,\n    "c"^#*expr.Constant_StringValue#:cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#,\n    "d"^#*expr.Constant_StringValue#:cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#,\n    "e"^#*expr.Constant_StringValue#:cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "cel.block([[1, 2, 3, 4], [1, 2], [cel.index(1), cel.index(0)]], [1, cel.index(0), 2, cel.index(0), 5, cel.index(0), 7, cel.index(2), cel.index(1)])",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    [\n      1^#*expr.Constant_Int64Value#,\n      2^#*expr.Constant_Int64Value#,\n      3^#*expr.Constant_Int64Value#,\n      4^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#,\n    [\n      1^#*expr.Constant_Int64Value#,\n      2^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#,\n    [\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    ]^#*expr.Expr_ListExpr#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    1^#*expr.Constant_Int64Value#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    2^#*expr.Constant_Int64Value#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    5^#*expr.Constant_Int64Value#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    7^#*expr.Constant_Int64Value#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.block([msg.single_int64, cel.index(0) + cel.index(0)], cel.index(1))",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    msg^#*expr.Expr_IdentExpr#.single_int64^#*expr.Expr_SelectExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  cel^#*expr.Expr_IdentExpr#.index(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.block([msg.oneof_type, cel.index(0).payload, cel.index(1).single_int64, cel.index(1).single_int32, cel.index(2) + cel.index(3), cel.index(4) + cel.index(2), msg.single_int64, cel.index(5) + cel.index(6), cel.index(1).oneof_type, cel.index(8).payload, cel.index(9).single_int64, cel.index(7) + cel.index(10)], cel.index(11))",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    msg^#*expr.Expr_IdentExpr#.oneof_type^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.payload^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.single_int64^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.single_int32^#*expr.Expr_SelectExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        4^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    msg^#*expr.Expr_IdentExpr#.single_int64^#*expr.Expr_SelectExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        5^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        6^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.oneof_type^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      8^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.payload^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      9^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.single_int64^#*expr.Expr_SelectExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        7^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        10^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  cel^#*expr.Expr_IdentExpr#.index(\n    11^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.block([msg.oneof_type, cel.index(0).payload, cel.index(1).oneof_type, cel.index(2).payload, cel.index(3).oneof_type, cel.index(4).payload, cel.index(5).oneof_type, cel.index(6).payload, cel.index(7).single_bool, true || cel.index(8), cel.index(4).child, cel.index(10).child, cel.index(11).payload, cel.index(12).single_bool], cel.index(9) || cel.index(13))",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    msg^#*expr.Expr_IdentExpr#.oneof_type^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.payload^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.oneof_type^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.payload^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.oneof_type^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      4^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.payload^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      5^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.oneof_type^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      6^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.payload^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      7^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.single_bool^#*expr.Expr_SelectExpr#,\n    _||_(\n      true^#*expr.Constant_BoolValue#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        8^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      4^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.child^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      10^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.child^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      11^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.payload^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      12^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.single_bool^#*expr.Expr_SelectExpr#\n  ]^#*expr.Expr_ListExpr#,\n  _||_(\n    cel^#*expr.Expr_IdentExpr#.index(\n      9^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      13^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.block([msg.oneof_type, cel.index(0).payload, cel.index(1).map_int32_int64, cel.index(2)[1], cel.index(3) + cel.index(3), cel.index(4) + cel.index(3)], cel.index(5))",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    msg^#*expr.Expr_IdentExpr#.oneof_type^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.payload^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.map_int32_int64^#*expr.Expr_SelectExpr#,\n    _[_](\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        4^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  cel^#*expr.Expr_IdentExpr#.index(\n    5^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.block([msg.oneof_type, cel.index(0).payload, cel.index(1).map_int32_int64, cel.index(2)[0], cel.index(2)[1], cel.index(3) + cel.index(4), cel.index(2)[2], cel.index(5) + cel.index(6)], cel.index(7))",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    msg^#*expr.Expr_IdentExpr#.oneof_type^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.payload^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.map_int32_int64^#*expr.Expr_SelectExpr#,\n    _[_](\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _[_](\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        4^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _[_](\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        5^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        6^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  cel^#*expr.Expr_IdentExpr#.index(\n    7^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.block([msg.single_int64, cel.index(0) \u003e 0, cel.index(1) ? cel.index(0) : 0], cel.index(2))",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    msg^#*expr.Expr_IdentExpr#.single_int64^#*expr.Expr_SelectExpr#,\n    _\u003e_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _?_:_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  cel^#*expr.Expr_IdentExpr#.index(\n    2^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.block([msg.single_int64, msg.single_int32, cel.index(0) \u003e 0, cel.index(1) \u003e 0, cel.index(0) + cel.index(1), cel.index(3) ? cel.index(4) : 0, cel.index(2) ? cel.index(5) : 0], cel.index(6))",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    msg^#*expr.Expr_IdentExpr#.single_int64^#*expr.Expr_SelectExpr#,\n    msg^#*expr.Expr_IdentExpr#.single_int32^#*expr.Expr_SelectExpr#,\n    _\u003e_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _\u003e_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _?_:_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        4^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _?_:_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        5^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  cel^#*expr.Expr_IdentExpr#.index(\n    6^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.block([[1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 0), size([cel.index(0)]), [2].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 1), size([cel.index(2)])], cel.index(1) + cel.index(1) + cel.index(3) + cel.index(3))",
+    error:
+      "ERROR: \u003cinput\u003e:1:34: argument must be a simple name\n | cel.block([[1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 0), size([cel.index(0)]), [2].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 1), size([cel.index(2)])], cel.index(1) + cel.index(1) + cel.index(3) + cel.index(3))\n | .................................^\nERROR: \u003cinput\u003e:1:110: argument must be a simple name\n | cel.block([[1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 0), size([cel.index(0)]), [2].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 1), size([cel.index(2)])], cel.index(1) + cel.index(1) + cel.index(3) + cel.index(3))\n | .............................................................................................................^",
+  },
+  {
+    expr: "cel.block([[1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 0), [cel.index(0)], ['a'].exists(cel.iterVar(0, 1), cel.iterVar(0, 1) == 'a'), [cel.index(2)]], cel.index(1) + cel.index(1) + cel.index(3) + cel.index(3))",
+    error:
+      "ERROR: \u003cinput\u003e:1:34: argument must be a simple name\n | cel.block([[1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 0), [cel.index(0)], ['a'].exists(cel.iterVar(0, 1), cel.iterVar(0, 1) == 'a'), [cel.index(2)]], cel.index(1) + cel.index(1) + cel.index(3) + cel.index(3))\n | .................................^\nERROR: \u003cinput\u003e:1:106: argument must be a simple name\n | cel.block([[1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 0), [cel.index(0)], ['a'].exists(cel.iterVar(0, 1), cel.iterVar(0, 1) == 'a'), [cel.index(2)]], cel.index(1) + cel.index(1) + cel.index(3) + cel.index(3))\n | .........................................................................................................^",
+  },
+  {
+    expr: "cel.block([[1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 0)], cel.index(0) \u0026\u0026 cel.index(0) \u0026\u0026 [1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 1) \u0026\u0026 [2].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 1))",
+    error:
+      "ERROR: \u003cinput\u003e:1:34: argument must be a simple name\n | cel.block([[1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 0)], cel.index(0) \u0026\u0026 cel.index(0) \u0026\u0026 [1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 1) \u0026\u0026 [2].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 1))\n | .................................^\nERROR: \u003cinput\u003e:1:121: argument must be a simple name\n | cel.block([[1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 0)], cel.index(0) \u0026\u0026 cel.index(0) \u0026\u0026 [1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 1) \u0026\u0026 [2].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 1))\n | ........................................................................................................................^\nERROR: \u003cinput\u003e:1:177: argument must be a simple name\n | cel.block([[1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 0)], cel.index(0) \u0026\u0026 cel.index(0) \u0026\u0026 [1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 1) \u0026\u0026 [2].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) \u003e 1))\n | ................................................................................................................................................................................^",
+  },
+  {
+    expr: "cel.block([[1, 2, 3]], cel.index(0).map(cel.iterVar(0, 0), cel.index(0).map(cel.iterVar(1, 0), cel.iterVar(1, 0) + 1)))",
+    error:
+      "ERROR: \u003cinput\u003e:1:52: argument is not an identifier\n | cel.block([[1, 2, 3]], cel.index(0).map(cel.iterVar(0, 0), cel.index(0).map(cel.iterVar(1, 0), cel.iterVar(1, 0) + 1)))\n | ...................................................^\nERROR: \u003cinput\u003e:1:88: argument is not an identifier\n | cel.block([[1, 2, 3]], cel.index(0).map(cel.iterVar(0, 0), cel.index(0).map(cel.iterVar(1, 0), cel.iterVar(1, 0) + 1)))\n | .......................................................................................^",
+  },
+  {
+    expr: "[1, 2].map(cel.iterVar(0, 0), [1, 2, 3].filter(cel.iterVar(1, 0), cel.iterVar(1, 0) == cel.iterVar(0, 0)))",
+    error:
+      "ERROR: \u003cinput\u003e:1:23: argument is not an identifier\n | [1, 2].map(cel.iterVar(0, 0), [1, 2, 3].filter(cel.iterVar(1, 0), cel.iterVar(1, 0) == cel.iterVar(0, 0)))\n | ......................^\nERROR: \u003cinput\u003e:1:59: argument is not an identifier\n | [1, 2].map(cel.iterVar(0, 0), [1, 2, 3].filter(cel.iterVar(1, 0), cel.iterVar(1, 0) == cel.iterVar(0, 0)))\n | ..........................................................^",
+  },
+  {
+    expr: "cel.block([[1, 2, 3], cel.index(0).map(cel.iterVar(0, 0), cel.index(0).map(cel.iterVar(1, 0), cel.iterVar(1, 0) + 1))], cel.index(1) == cel.index(1))",
+    error:
+      "ERROR: \u003cinput\u003e:1:51: argument is not an identifier\n | cel.block([[1, 2, 3], cel.index(0).map(cel.iterVar(0, 0), cel.index(0).map(cel.iterVar(1, 0), cel.iterVar(1, 0) + 1))], cel.index(1) == cel.index(1))\n | ..................................................^\nERROR: \u003cinput\u003e:1:87: argument is not an identifier\n | cel.block([[1, 2, 3], cel.index(0).map(cel.iterVar(0, 0), cel.index(0).map(cel.iterVar(1, 0), cel.iterVar(1, 0) + 1))], cel.index(1) == cel.index(1))\n | ......................................................................................^",
+  },
+  {
+    expr: "cel.block([x - 1, cel.index(0) \u003e 3], [cel.index(1) ? cel.index(0) : 5].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) - 1 \u003e 3) || cel.index(1))",
+    error:
+      "ERROR: \u003cinput\u003e:1:90: argument must be a simple name\n | cel.block([x - 1, cel.index(0) \u003e 3], [cel.index(1) ? cel.index(0) : 5].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) - 1 \u003e 3) || cel.index(1))\n | .........................................................................................^",
+  },
+  {
+    expr: "['foo', 'bar'].map(cel.iterVar(1, 0), [cel.iterVar(1, 0) + cel.iterVar(1, 0), cel.iterVar(1, 0) + cel.iterVar(1, 0)]).map(cel.iterVar(0, 0), [cel.iterVar(0, 0) + cel.iterVar(0, 0), cel.iterVar(0, 0) + cel.iterVar(0, 0)])",
+    error:
+      "ERROR: \u003cinput\u003e:1:31: argument is not an identifier\n | ['foo', 'bar'].map(cel.iterVar(1, 0), [cel.iterVar(1, 0) + cel.iterVar(1, 0), cel.iterVar(1, 0) + cel.iterVar(1, 0)]).map(cel.iterVar(0, 0), [cel.iterVar(0, 0) + cel.iterVar(0, 0), cel.iterVar(0, 0) + cel.iterVar(0, 0)])\n | ..............................^\nERROR: \u003cinput\u003e:1:134: argument is not an identifier\n | ['foo', 'bar'].map(cel.iterVar(1, 0), [cel.iterVar(1, 0) + cel.iterVar(1, 0), cel.iterVar(1, 0) + cel.iterVar(1, 0)]).map(cel.iterVar(0, 0), [cel.iterVar(0, 0) + cel.iterVar(0, 0), cel.iterVar(0, 0) + cel.iterVar(0, 0)])\n | .....................................................................................................................................^",
+  },
+  {
+    expr: "cel.block([[1, 2, 3], 1 in cel.index(0), 2 in cel.index(0), cel.index(1) \u0026\u0026 cel.index(2), [3, cel.index(0)], 3 in cel.index(4), cel.index(5) \u0026\u0026 cel.index(1)], cel.index(3) \u0026\u0026 cel.index(6))",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    [\n      1^#*expr.Constant_Int64Value#,\n      2^#*expr.Constant_Int64Value#,\n      3^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#,\n    @in(\n      1^#*expr.Constant_Int64Value#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    @in(\n      2^#*expr.Constant_Int64Value#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _\u0026\u0026_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    [\n      3^#*expr.Constant_Int64Value#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    ]^#*expr.Expr_ListExpr#,\n    @in(\n      3^#*expr.Constant_Int64Value#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        4^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    _\u0026\u0026_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        5^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  _\u0026\u0026_(\n    cel^#*expr.Expr_IdentExpr#.index(\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      6^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: 'cel.block([{true: false}, {"a": 1, 2: cel.index(0), 3: cel.index(0)}], 2 in cel.index(1))',
+    ast: 'cel^#*expr.Expr_IdentExpr#.block(\n  [\n    {\n      true^#*expr.Constant_BoolValue#:false^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#,\n    {\n      "a"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n      2^#*expr.Constant_Int64Value#:cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#,\n      3^#*expr.Constant_Int64Value#:cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  ]^#*expr.Expr_ListExpr#,\n  @in(\n    2^#*expr.Constant_Int64Value#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'cel.block([{"a": true}, has(cel.index(0).a), cel.index(0)["a"]], cel.index(1) \u0026\u0026 cel.index(2))',
+    ast: 'cel^#*expr.Expr_IdentExpr#.block(\n  [\n    {\n      "a"^#*expr.Constant_StringValue#:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.a~test-only~^#*expr.Expr_SelectExpr#,\n    _[_](\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      "a"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  _\u0026\u0026_(\n    cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'cel.block([{"a": true}, has(cel.index(0).a)], cel.index(1) \u0026\u0026 cel.index(1))',
+    ast: 'cel^#*expr.Expr_IdentExpr#.block(\n  [\n    {\n      "a"^#*expr.Constant_StringValue#:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.a~test-only~^#*expr.Expr_SelectExpr#\n  ]^#*expr.Expr_ListExpr#,\n  _\u0026\u0026_(\n    cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "cel.block([msg.oneof_type, has(cel.index(0).payload), cel.index(0).payload, cel.index(2).single_int64, cel.index(1) ? cel.index(3) : 0], cel.index(4))",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    msg^#*expr.Expr_IdentExpr#.oneof_type^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.payload~test-only~^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.payload^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.single_int64^#*expr.Expr_SelectExpr#,\n    _?_:_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  cel^#*expr.Expr_IdentExpr#.index(\n    4^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.block([msg.oneof_type, cel.index(0).payload, cel.index(1).single_int64, has(cel.index(0).payload), cel.index(2) * 0, cel.index(3) ? cel.index(2) : cel.index(4)], cel.index(5))",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    msg^#*expr.Expr_IdentExpr#.oneof_type^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.payload^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.single_int64^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.payload~test-only~^#*expr.Expr_SelectExpr#,\n    _*_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _?_:_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        4^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  cel^#*expr.Expr_IdentExpr#.index(\n    5^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.block([msg.oneof_type, cel.index(0).payload, cel.index(1).single_int64, has(cel.index(1).single_int64), cel.index(2) * 0, cel.index(3) ? cel.index(2) : cel.index(4)], cel.index(5))",
+    ast: "cel^#*expr.Expr_IdentExpr#.block(\n  [\n    msg^#*expr.Expr_IdentExpr#.oneof_type^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.payload^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.single_int64^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.single_int64~test-only~^#*expr.Expr_SelectExpr#,\n    _*_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _?_:_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        4^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  cel^#*expr.Expr_IdentExpr#.index(\n    5^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: 'cel.block([msg.oneof_type, cel.index(0).payload, cel.index(1).map_string_string, has(msg.oneof_type), has(cel.index(0).payload), cel.index(3) \u0026\u0026 cel.index(4), has(cel.index(1).single_int64), cel.index(5) \u0026\u0026 cel.index(6), has(cel.index(1).map_string_string), has(cel.index(2).key), cel.index(8) \u0026\u0026 cel.index(9), cel.index(2).key, cel.index(11) == "A", cel.index(10) ? cel.index(12) : false], cel.index(7) ? cel.index(13) : false)',
+    ast: 'cel^#*expr.Expr_IdentExpr#.block(\n  [\n    msg^#*expr.Expr_IdentExpr#.oneof_type^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.payload^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.map_string_string^#*expr.Expr_SelectExpr#,\n    msg^#*expr.Expr_IdentExpr#.oneof_type~test-only~^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.payload~test-only~^#*expr.Expr_SelectExpr#,\n    _\u0026\u0026_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        4^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.single_int64~test-only~^#*expr.Expr_SelectExpr#,\n    _\u0026\u0026_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        5^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        6^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.map_string_string~test-only~^#*expr.Expr_SelectExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.key~test-only~^#*expr.Expr_SelectExpr#,\n    _\u0026\u0026_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        8^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        9^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#.key^#*expr.Expr_SelectExpr#,\n    _==_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        11^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      "A"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    _?_:_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        10^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      cel^#*expr.Expr_IdentExpr#.index(\n        12^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      false^#*expr.Constant_BoolValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  _?_:_(\n    cel^#*expr.Expr_IdentExpr#.index(\n      7^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    cel^#*expr.Expr_IdentExpr#.index(\n      13^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    false^#*expr.Constant_BoolValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "cel.block([optional.none(), [?cel.index(0), ?optional.of(opt_x)], [5], [10, ?cel.index(0), cel.index(1), cel.index(1)], [10, cel.index(2), cel.index(2)]], cel.index(3) == cel.index(4))",
+    error:
+      "ERROR: \u003cinput\u003e:1:30: unsupported syntax '?'\n | cel.block([optional.none(), [?cel.index(0), ?optional.of(opt_x)], [5], [10, ?cel.index(0), cel.index(1), cel.index(1)], [10, cel.index(2), cel.index(2)]], cel.index(3) == cel.index(4))\n | .............................^\nERROR: \u003cinput\u003e:1:45: unsupported syntax '?'\n | cel.block([optional.none(), [?cel.index(0), ?optional.of(opt_x)], [5], [10, ?cel.index(0), cel.index(1), cel.index(1)], [10, cel.index(2), cel.index(2)]], cel.index(3) == cel.index(4))\n | ............................................^\nERROR: \u003cinput\u003e:1:77: unsupported syntax '?'\n | cel.block([optional.none(), [?cel.index(0), ?optional.of(opt_x)], [5], [10, ?cel.index(0), cel.index(1), cel.index(1)], [10, cel.index(2), cel.index(2)]], cel.index(3) == cel.index(4))\n | ............................................................................^",
+  },
+  {
+    expr: 'cel.block([optional.of("hello"), {?"hello": cel.index(0)}, cel.index(1)["hello"], cel.index(2) + cel.index(2)], cel.index(3) == "hellohello")',
+    error:
+      'ERROR: \u003cinput\u003e:1:35: unsupported syntax \'?\'\n | cel.block([optional.of("hello"), {?"hello": cel.index(0)}, cel.index(1)["hello"], cel.index(2) + cel.index(2)], cel.index(3) == "hellohello")\n | ..................................^',
+  },
+  {
+    expr: 'cel.block([{"key": "test"}, optional.of("test"), {?"key": cel.index(1)}, cel.index(2)[?"bogus"], cel.index(0)[?"bogus"], cel.index(3).or(cel.index(4)), cel.index(0)["key"], cel.index(5).orValue(cel.index(6))], cel.index(7))',
+    error:
+      'ERROR: \u003cinput\u003e:1:51: unsupported syntax \'?\'\n | cel.block([{"key": "test"}, optional.of("test"), {?"key": cel.index(1)}, cel.index(2)[?"bogus"], cel.index(0)[?"bogus"], cel.index(3).or(cel.index(4)), cel.index(0)["key"], cel.index(5).orValue(cel.index(6))], cel.index(7))\n | ..................................................^\nERROR: \u003cinput\u003e:1:86: unsupported syntax \'[?\'\n | cel.block([{"key": "test"}, optional.of("test"), {?"key": cel.index(1)}, cel.index(2)[?"bogus"], cel.index(0)[?"bogus"], cel.index(3).or(cel.index(4)), cel.index(0)["key"], cel.index(5).orValue(cel.index(6))], cel.index(7))\n | .....................................................................................^\nERROR: \u003cinput\u003e:1:110: unsupported syntax \'[?\'\n | cel.block([{"key": "test"}, optional.of("test"), {?"key": cel.index(1)}, cel.index(2)[?"bogus"], cel.index(0)[?"bogus"], cel.index(3).or(cel.index(4)), cel.index(0)["key"], cel.index(5).orValue(cel.index(6))], cel.index(7))\n | .............................................................................................................^',
+  },
+  {
+    expr: "cel.block([optional.ofNonZeroValue(1), optional.of(4), TestAllTypes{?single_int64: cel.index(0), ?single_int32: cel.index(1)}, cel.index(2).single_int32, cel.index(2).single_int64, cel.index(3) + cel.index(4)], cel.index(5))",
+    error:
+      "ERROR: \u003cinput\u003e:1:69: unsupported syntax '?'\n | cel.block([optional.ofNonZeroValue(1), optional.of(4), TestAllTypes{?single_int64: cel.index(0), ?single_int32: cel.index(1)}, cel.index(2).single_int32, cel.index(2).single_int64, cel.index(3) + cel.index(4)], cel.index(5))\n | ....................................................................^\nERROR: \u003cinput\u003e:1:98: unsupported syntax '?'\n | cel.block([optional.ofNonZeroValue(1), optional.of(4), TestAllTypes{?single_int64: cel.index(0), ?single_int32: cel.index(1)}, cel.index(2).single_int32, cel.index(2).single_int64, cel.index(3) + cel.index(4)], cel.index(5))\n | .................................................................................................^",
+  },
+  {
+    expr: 'cel.block(["h" + "e", cel.index(0) + "l", cel.index(1) + "l", cel.index(2) + "o", cel.index(3) + " world"], cel.index(4).matches(cel.index(3)))',
+    ast: 'cel^#*expr.Expr_IdentExpr#.block(\n  [\n    _+_(\n      "h"^#*expr.Constant_StringValue#,\n      "e"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      "l"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      "l"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      "o"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      cel^#*expr.Expr_IdentExpr#.index(\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      " world"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  cel^#*expr.Expr_IdentExpr#.index(\n    4^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#.matches(\n    cel^#*expr.Expr_IdentExpr#.index(\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "1 == 1",
+    ast: "_==_(\n  1^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-1 == 1",
+    ast: "_==_(\n  -1^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) == 1u",
+    ast: "_==_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2) == 1u",
+    ast: "_==_(\n  dyn(\n    2^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) == 1.0",
+    ast: "_==_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2) == 1.0",
+    ast: "_==_(\n  dyn(\n    2^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "2u == 2u",
+    ast: "_==_(\n  2u^#*expr.Constant_Uint64Value#,\n  2u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1u == 2u",
+    ast: "_==_(\n  1u^#*expr.Constant_Uint64Value#,\n  2u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) == 1",
+    ast: "_==_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2u) == 1",
+    ast: "_==_(\n  dyn(\n    2u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) == 1.0",
+    ast: "_==_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2u) == 1.0",
+    ast: "_==_(\n  dyn(\n    2u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1.0 == 1.0e+0",
+    ast: "_==_(\n  1^#*expr.Constant_DoubleValue#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-1.0 == 1.0",
+    ast: "_==_(\n  -1^#*expr.Constant_DoubleValue#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0.0/0.0 == 0.0/0.0",
+    ast: "_==_(\n  _/_(\n    0^#*expr.Constant_DoubleValue#,\n    0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  _/_(\n    0^#*expr.Constant_DoubleValue#,\n    0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) == 0.0/0.0",
+    ast: "_==_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  _/_(\n    0^#*expr.Constant_DoubleValue#,\n    0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) == 0.0/0.0",
+    ast: "_==_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  _/_(\n    0^#*expr.Constant_DoubleValue#,\n    0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1.0) == 1",
+    ast: "_==_(\n  dyn(\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2.0) == 1",
+    ast: "_==_(\n  dyn(\n    2^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1.0) == 1u",
+    ast: "_==_(\n  dyn(\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2.0) == 1u",
+    ast: "_==_(\n  dyn(\n    2^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "'' == \"\"",
+    ast: '_==_(\n  ""^#*expr.Constant_StringValue#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'a' == 'b'",
+    ast: '_==_(\n  "a"^#*expr.Constant_StringValue#,\n  "b"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'abc' == r'abc'",
+    ast: '_==_(\n  "abc"^#*expr.Constant_StringValue#,\n  "abc"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'abc' == 'ABC'",
+    ast: '_==_(\n  "abc"^#*expr.Constant_StringValue#,\n  "ABC"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'ίσος' == 'ίσος'",
+    ast: '_==_(\n  "ίσος"^#*expr.Constant_StringValue#,\n  "ίσος"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'a' == 'à'",
+    ast: '_==_(\n  "a"^#*expr.Constant_StringValue#,\n  "à"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'Am\\u00E9lie' == 'Ame\\u0301lie'",
+    ast: '_==_(\n  "Amélie"^#*expr.Constant_StringValue#,\n  "Amélie"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "null == null",
+    ast: "_==_(\n  null^#*expr.Constant_NullValue#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "true == true",
+    ast: "_==_(\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "false == true",
+    ast: "_==_(\n  false^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "b'ÿ' == b'\\303\\277'",
+    ast: '_==_(\n  b"ÿ"^#*expr.Constant_BytesValue#,\n  b"ÿ"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'abc' == b'abcd'",
+    ast: '_==_(\n  b"abc"^#*expr.Constant_BytesValue#,\n  b"abcd"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[] == []",
+    ast: "_==_(\n  []^#*expr.Expr_ListExpr#,\n  []^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[null] == [null]",
+    ast: "_==_(\n  [\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "['1', '2', null] == ['1', '2', '3']",
+    ast: '_==_(\n  [\n    "1"^#*expr.Constant_StringValue#,\n    "2"^#*expr.Constant_StringValue#,\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    "1"^#*expr.Constant_StringValue#,\n    "2"^#*expr.Constant_StringValue#,\n    "3"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[1, 2, 3] == [1, 2, 3]",
+    ast: "_==_(\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1.0, 2.0, 3] == [1u, 2, 3u]",
+    ast: "_==_(\n  [\n    1^#*expr.Constant_DoubleValue#,\n    2^#*expr.Constant_DoubleValue#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    1u^#*expr.Constant_Uint64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3u^#*expr.Constant_Uint64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1.0, 2.1] == [1u, 2]",
+    ast: "_==_(\n  [\n    1^#*expr.Constant_DoubleValue#,\n    2.1^#*expr.Constant_DoubleValue#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    1u^#*expr.Constant_Uint64Value#,\n    2^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1, 2, 3] == [1, 3, 2]",
+    ast: "_==_(\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    1^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "['case'] == ['cAse']",
+    ast: '_==_(\n  [\n    "case"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    "cAse"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "['one'] == [2, 3]",
+    ast: '_==_(\n  [\n    "one"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[1, 'dos', 3] == [1, 2, 4]",
+    ast: '_==_(\n  [\n    1^#*expr.Constant_Int64Value#,\n    "dos"^#*expr.Constant_StringValue#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    4^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{} == {}",
+    ast: "_==_(\n  {}^#*expr.Expr_StructExpr#,\n  {}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{'k': null} == {'k': null}",
+    ast: '_==_(\n  {\n    "k"^#*expr.Constant_StringValue#:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    "k"^#*expr.Constant_StringValue#:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'k': 1, 'j': 2} == {'k': 1, 'j': null}",
+    ast: '_==_(\n  {\n    "k"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    "j"^#*expr.Constant_StringValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    "k"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    "j"^#*expr.Constant_StringValue#:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'k':'v'} == {\"k\":\"v\"}",
+    ast: '_==_(\n  {\n    "k"^#*expr.Constant_StringValue#:"v"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    "k"^#*expr.Constant_StringValue#:"v"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'k':1.0} == {'k':1e+0}",
+    ast: '_==_(\n  {\n    "k"^#*expr.Constant_StringValue#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    "k"^#*expr.Constant_StringValue#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{1: 1.0, 2u: 3u} == {1u: 1, 2: 3.0}",
+    ast: "_==_(\n  {\n    1^#*expr.Constant_Int64Value#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    2u^#*expr.Constant_Uint64Value#:3u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    1u^#*expr.Constant_Uint64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    2^#*expr.Constant_Int64Value#:3^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{'k':'v'} == {'k':'v1'}",
+    ast: '_==_(\n  {\n    "k"^#*expr.Constant_StringValue#:"v"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    "k"^#*expr.Constant_StringValue#:"v1"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'k':'v','k1':'v1'} == {'k':'v'}",
+    ast: '_==_(\n  {\n    "k"^#*expr.Constant_StringValue#:"v"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    "k1"^#*expr.Constant_StringValue#:"v1"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    "k"^#*expr.Constant_StringValue#:"v"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'k1':'v1','k2':'v2'} == {'k2':'v2','k1':'v1'}",
+    ast: '_==_(\n  {\n    "k1"^#*expr.Constant_StringValue#:"v1"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    "k2"^#*expr.Constant_StringValue#:"v2"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    "k2"^#*expr.Constant_StringValue#:"v2"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    "k1"^#*expr.Constant_StringValue#:"v1"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'key':'value'} == {'Key':'value'}",
+    ast: '_==_(\n  {\n    "key"^#*expr.Constant_StringValue#:"value"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    "Key"^#*expr.Constant_StringValue#:"value"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'k1': 1, 'k2': 'dos', 'k3': 3} == {'k1': 1, 'k2': 2, 'k3': 4}",
+    ast: '_==_(\n  {\n    "k1"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    "k2"^#*expr.Constant_StringValue#:"dos"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    "k3"^#*expr.Constant_StringValue#:3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    "k1"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    "k2"^#*expr.Constant_StringValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    "k3"^#*expr.Constant_StringValue#:4^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "1.0 == 1",
+    ast: "_==_(\n  1^#*expr.Constant_DoubleValue#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1] == [1.0]",
+    ast: "_==_(\n  [\n    1^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    1^#*expr.Constant_DoubleValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{'k':'v', 1:1} == {'k':'v', 1:'v1'}",
+    ast: '_==_(\n  {\n    "k"^#*expr.Constant_StringValue#:"v"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    1^#*expr.Constant_Int64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    "k"^#*expr.Constant_StringValue#:"v"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    1^#*expr.Constant_Int64Value#:"v1"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn(google.protobuf.Value{}) == null",
+    ast: "_==_(\n  dyn(\n    google.protobuf.Value{}^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(false) == null",
+    ast: "_==_(\n  dyn(\n    false^#*expr.Constant_BoolValue#\n  )^#*expr.Expr_CallExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(b'') == null",
+    ast: '_==_(\n  dyn(\n    b""^#*expr.Constant_BytesValue#\n  )^#*expr.Expr_CallExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn(2.1) == null",
+    ast: "_==_(\n  dyn(\n    2.1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(duration('0s')) == null",
+    ast: '_==_(\n  dyn(\n    duration(\n      "0s"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn(1) == null",
+    ast: "_==_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn([]) == null",
+    ast: "_==_(\n  dyn(\n    []^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn({}) == null",
+    ast: "_==_(\n  dyn(\n    {}^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(TestAllTypes{}) == null",
+    ast: "_==_(\n  dyn(\n    TestAllTypes{}^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(TestAllTypes{}) == null",
+    ast: "_==_(\n  dyn(\n    TestAllTypes{}^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn('') == null",
+    ast: '_==_(\n  dyn(\n    ""^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn(timestamp(0)) == null",
+    ast: "_==_(\n  dyn(\n    timestamp(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1, 2, null] == [1, null, 3]",
+    ast: "_==_(\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    1^#*expr.Constant_Int64Value#,\n    null^#*expr.Constant_NullValue#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{1:'hello', 2:'world'} == {1:'goodbye', 2:null}",
+    ast: '_==_(\n  {\n    1^#*expr.Constant_Int64Value#:"hello"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    2^#*expr.Constant_Int64Value#:"world"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    1^#*expr.Constant_Int64Value#:"goodbye"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    2^#*expr.Constant_Int64Value#:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn(1) == 1u",
+    ast: "_==_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) == 1.0",
+    ast: "_==_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) == 1",
+    ast: "_==_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) == 1.0",
+    ast: "_==_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1.0) == 1",
+    ast: "_==_(\n  dyn(\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1.0) == 1u",
+    ast: "_==_(\n  dyn(\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) == 2u",
+    ast: "_==_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  2u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) == 2.0",
+    ast: "_==_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  2^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) == 2",
+    ast: "_==_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) == 120",
+    ast: "_==_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  120^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1.0) == 2",
+    ast: "_==_(\n  dyn(\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1.0) == 2u",
+    ast: "_==_(\n  dyn(\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  2u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.BoolValue{value: true} == true",
+    ast: "_==_(\n  google.protobuf.BoolValue{\n    value:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.BoolValue{} == false",
+    ast: "_==_(\n  google.protobuf.BoolValue{}^#*expr.Expr_StructExpr#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.BoolValue{} != null",
+    ast: "_!=_(\n  google.protobuf.BoolValue{}^#*expr.Expr_StructExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_bool_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_bool_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_bool_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_bool_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.BytesValue{value: b'set'} == b'set'",
+    ast: '_==_(\n  google.protobuf.BytesValue{\n    value:b"set"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  b"set"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "google.protobuf.BytesValue{} == b''",
+    ast: '_==_(\n  google.protobuf.BytesValue{}^#*expr.Expr_StructExpr#,\n  b""^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "google.protobuf.BytesValue{} != null",
+    ast: "_!=_(\n  google.protobuf.BytesValue{}^#*expr.Expr_StructExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_bytes_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_bytes_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_bytes_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_bytes_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.DoubleValue{value: -1.175494e-40} == -1.175494e-40",
+    ast: "_==_(\n  google.protobuf.DoubleValue{\n    value:-1.175494e-40^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  -1.175494e-40^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.DoubleValue{} == 0.0",
+    ast: "_==_(\n  google.protobuf.DoubleValue{}^#*expr.Expr_StructExpr#,\n  0^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.DoubleValue{} != null",
+    ast: "_!=_(\n  google.protobuf.DoubleValue{}^#*expr.Expr_StructExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_double_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_double_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_double_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_double_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.FloatValue{value: -1.5} == -1.5",
+    ast: "_==_(\n  google.protobuf.FloatValue{\n    value:-1.5^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  -1.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.FloatValue{} == 0.0",
+    ast: "_==_(\n  google.protobuf.FloatValue{}^#*expr.Expr_StructExpr#,\n  0^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.FloatValue{} != null",
+    ast: "_!=_(\n  google.protobuf.FloatValue{}^#*expr.Expr_StructExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_float_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_float_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_float_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_float_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.Int32Value{value: 123} == 123",
+    ast: "_==_(\n  google.protobuf.Int32Value{\n    value:123^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  123^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.Int32Value{} == 0",
+    ast: "_==_(\n  google.protobuf.Int32Value{}^#*expr.Expr_StructExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.Int32Value{} != null",
+    ast: "_!=_(\n  google.protobuf.Int32Value{}^#*expr.Expr_StructExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_int32_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_int32_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_int32_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_int32_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.Int64Value{value: 2147483650} == 2147483650",
+    ast: "_==_(\n  google.protobuf.Int64Value{\n    value:2147483650^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  2147483650^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.Int64Value{} == 0",
+    ast: "_==_(\n  google.protobuf.Int64Value{}^#*expr.Expr_StructExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.Int64Value{} != null",
+    ast: "_!=_(\n  google.protobuf.Int64Value{}^#*expr.Expr_StructExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_int64_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_int64_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_int64_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_int64_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.StringValue{value: 'set'} == 'set'",
+    ast: '_==_(\n  google.protobuf.StringValue{\n    value:"set"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  "set"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "google.protobuf.StringValue{} == ''",
+    ast: '_==_(\n  google.protobuf.StringValue{}^#*expr.Expr_StructExpr#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "google.protobuf.StringValue{} != null",
+    ast: "_!=_(\n  google.protobuf.StringValue{}^#*expr.Expr_StructExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_string_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_string_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_string_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_string_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.UInt32Value{value: 42u} == 42u",
+    ast: "_==_(\n  google.protobuf.UInt32Value{\n    value:42u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  42u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.UInt32Value{} == 0u",
+    ast: "_==_(\n  google.protobuf.UInt32Value{}^#*expr.Expr_StructExpr#,\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.UInt32Value{} != null",
+    ast: "_!=_(\n  google.protobuf.UInt32Value{}^#*expr.Expr_StructExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_uint32_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_uint32_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_uint32_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_uint32_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.UInt64Value{value: 4294967296u} == 4294967296u",
+    ast: "_==_(\n  google.protobuf.UInt64Value{\n    value:4294967296u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  4294967296u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.UInt64Value{} == 0u",
+    ast: "_==_(\n  google.protobuf.UInt64Value{}^#*expr.Expr_StructExpr#,\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.UInt64Value{} != null",
+    ast: "_!=_(\n  google.protobuf.UInt64Value{}^#*expr.Expr_StructExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_uint64_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_uint64_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_uint64_wrapper == null",
+    ast: "_==_(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.single_uint64_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int64: 1234, single_string: '1234'} == TestAllTypes{single_int64: 1234, single_string: '1234'}",
+    ast: '_==_(\n  TestAllTypes{\n    single_int64:1234^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    single_string:"1234"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_int64:1234^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    single_string:"1234"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_int64: 1234, single_string: '1234'} == TestAllTypes{single_int64: 1234, single_string: '1234'}",
+    ast: '_==_(\n  TestAllTypes{\n    single_int64:1234^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    single_string:"1234"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_int64:1234^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    single_string:"1234"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_int64: 1234} == TestAllTypes{single_string: '1234'}",
+    ast: '_==_(\n  TestAllTypes{\n    single_int64:1234^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_string:"1234"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_int64: 1234} == TestAllTypes{single_string: '1234'}",
+    ast: '_==_(\n  TestAllTypes{\n    single_int64:1234^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_string:"1234"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_double: double('NaN')} == TestAllTypes{single_double: double('NaN')}",
+    ast: '_==_(\n  TestAllTypes{\n    single_double:double(\n      "NaN"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_double:double(\n      "NaN"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn(TestAllTypes{}) == dyn(NestedTestAllTypes{})",
+    ast: "_==_(\n  dyn(\n    TestAllTypes{}^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#,\n  dyn(\n    NestedTestAllTypes{}^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} == TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+    ast: '_==_(\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01r\\x041234"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"r\\x041234\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'a\\000\\000\\000\\000\\000H\\223\\300r\\0041234'}} == TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+    ast: '_==_(\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"a\\x00\\x00\\x00\\x00\\x00H\\x93\\xc0r\\x041234"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"r\\x041234\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} == TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+    ast: '_==_(\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"\\xa2\\x06\\x13\\x12\\x11\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01r\\x041234"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"\\xa2\\x06\\x13\\x12\\x11r\\x041234\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} == TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}}",
+    ast: '_==_(\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"\\xa2\\x06\\x13\\x12\\x11\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01r\\x041234"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"\\xa2\\x06\\x13\\x12\\x11\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01r\\x041234"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} == TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+    ast: '_==_(\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01r\\x041234"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"r\\x041234\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'a\\000\\000\\000\\000\\000H\\223\\300r\\0041234'}} == TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+    ast: '_==_(\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"a\\x00\\x00\\x00\\x00\\x00H\\x93\\xc0r\\x041234"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"r\\x041234\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} == TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+    ast: '_==_(\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"\\xa2\\x06\\x13\\x12\\x11\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01r\\x041234"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"\\xa2\\x06\\x13\\x12\\x11r\\x041234\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} == TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}}",
+    ast: '_==_(\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"\\xa2\\x06\\x13\\x12\\x11\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01r\\x041234"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"\\xa2\\x06\\x13\\x12\\x11\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01r\\x041234"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "24 != 42",
+    ast: "_!=_(\n  24^#*expr.Constant_Int64Value#,\n  42^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1 != 1",
+    ast: "_!=_(\n  1^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(24) != 24.1",
+    ast: "_!=_(\n  dyn(\n    24^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  24.1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) != 1.0",
+    ast: "_!=_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(24) != 42u",
+    ast: "_!=_(\n  dyn(\n    24^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  42u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) != 1u",
+    ast: "_!=_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1u != 2u",
+    ast: "_!=_(\n  1u^#*expr.Constant_Uint64Value#,\n  2u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "99u != 99u",
+    ast: "_!=_(\n  99u^#*expr.Constant_Uint64Value#,\n  99u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) != 2.0",
+    ast: "_!=_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  2^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(99u) != 99.0",
+    ast: "_!=_(\n  dyn(\n    99u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  99^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "9.0e+3 != 9001.0",
+    ast: "_!=_(\n  9000^#*expr.Constant_DoubleValue#,\n  9001^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0.0/0.0 != 0.0/0.0",
+    ast: "_!=_(\n  _/_(\n    0^#*expr.Constant_DoubleValue#,\n    0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  _/_(\n    0^#*expr.Constant_DoubleValue#,\n    0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) != 0.0/0.0",
+    ast: "_!=_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  _/_(\n    0^#*expr.Constant_DoubleValue#,\n    0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) != 0.0/0.0",
+    ast: "_!=_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  _/_(\n    0^#*expr.Constant_DoubleValue#,\n    0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1.0 != 1e+0",
+    ast: "_!=_(\n  1^#*expr.Constant_DoubleValue#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9000) != 9001.0",
+    ast: "_!=_(\n  dyn(\n    9000^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  9001^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) != 1e+0",
+    ast: "_!=_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9000u) != 9001.0",
+    ast: "_!=_(\n  dyn(\n    9000u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  9001^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) != 1e+0",
+    ast: "_!=_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0.0/0.0 != 0.0/0.0",
+    ast: "_!=_(\n  _/_(\n    0^#*expr.Constant_DoubleValue#,\n    0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  _/_(\n    0^#*expr.Constant_DoubleValue#,\n    0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "'abc' != ''",
+    ast: '_!=_(\n  "abc"^#*expr.Constant_StringValue#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'abc' != 'abc'",
+    ast: '_!=_(\n  "abc"^#*expr.Constant_StringValue#,\n  "abc"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'résumé' != 'resume'",
+    ast: '_!=_(\n  "résumé"^#*expr.Constant_StringValue#,\n  "resume"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'ίδιο' != 'ίδιο'",
+    ast: '_!=_(\n  "ίδιο"^#*expr.Constant_StringValue#,\n  "ίδιο"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'\\x00\\xFF' != b'ÿ'",
+    ast: '_!=_(\n  b"\\x00\\xff"^#*expr.Constant_BytesValue#,\n  b"ÿ"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'\\303\\277' != b'ÿ'",
+    ast: '_!=_(\n  b"ÿ"^#*expr.Constant_BytesValue#,\n  b"ÿ"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "false != true",
+    ast: "_!=_(\n  false^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "true != true",
+    ast: "_!=_(\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "null != null",
+    ast: "_!=_(\n  null^#*expr.Constant_NullValue#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[] != [1]",
+    ast: "_!=_(\n  []^#*expr.Expr_ListExpr#,\n  [\n    1^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[] != []",
+    ast: "_!=_(\n  []^#*expr.Expr_ListExpr#,\n  []^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[true, false, true] != [true, true, false]",
+    ast: "_!=_(\n  [\n    true^#*expr.Constant_BoolValue#,\n    false^#*expr.Constant_BoolValue#,\n    true^#*expr.Constant_BoolValue#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    true^#*expr.Constant_BoolValue#,\n    true^#*expr.Constant_BoolValue#,\n    false^#*expr.Constant_BoolValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[false, true] != [false, true]",
+    ast: "_!=_(\n  [\n    false^#*expr.Constant_BoolValue#,\n    true^#*expr.Constant_BoolValue#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    false^#*expr.Constant_BoolValue#,\n    true^#*expr.Constant_BoolValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[[]] != [[]]",
+    ast: "_!=_(\n  [\n    []^#*expr.Expr_ListExpr#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    []^#*expr.Expr_ListExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{'k':'v'} != {'k':'v1'}",
+    ast: '_!=_(\n  {\n    "k"^#*expr.Constant_StringValue#:"v"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    "k"^#*expr.Constant_StringValue#:"v1"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'k':true} != {'k1':true}",
+    ast: '_!=_(\n  {\n    "k"^#*expr.Constant_StringValue#:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    "k1"^#*expr.Constant_StringValue#:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{1:1.0} != {1:1.0}",
+    ast: "_!=_(\n  {\n    1^#*expr.Constant_Int64Value#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    1^#*expr.Constant_Int64Value#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{'a':'b','c':'d'} != {'c':'d','a':'b'}",
+    ast: '_!=_(\n  {\n    "a"^#*expr.Constant_StringValue#:"b"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    "c"^#*expr.Constant_StringValue#:"d"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    "c"^#*expr.Constant_StringValue#:"d"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    "a"^#*expr.Constant_StringValue#:"b"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "2u != 2",
+    ast: "_!=_(\n  2u^#*expr.Constant_Uint64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int64: 1234, single_string: '1234'} != TestAllTypes{single_int64: 1234, single_string: '1234'}",
+    ast: '_!=_(\n  TestAllTypes{\n    single_int64:1234^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    single_string:"1234"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_int64:1234^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    single_string:"1234"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_int64: 1234, single_string: '1234'} != TestAllTypes{single_int64: 1234, single_string: '1234'}",
+    ast: '_!=_(\n  TestAllTypes{\n    single_int64:1234^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    single_string:"1234"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_int64:1234^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    single_string:"1234"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_int64: 1234} != TestAllTypes{single_string: '1234'}",
+    ast: '_!=_(\n  TestAllTypes{\n    single_int64:1234^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_string:"1234"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_int64: 1234} != TestAllTypes{single_string: '1234'}",
+    ast: '_!=_(\n  TestAllTypes{\n    single_int64:1234^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_string:"1234"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_double: double('NaN')} != TestAllTypes{single_double: double('NaN')}",
+    ast: '_!=_(\n  TestAllTypes{\n    single_double:double(\n      "NaN"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_double:double(\n      "NaN"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn(TestAllTypes{}) != dyn(NestedTestAllTypes{})",
+    ast: "_!=_(\n  dyn(\n    TestAllTypes{}^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#,\n  dyn(\n    NestedTestAllTypes{}^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} != TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+    ast: '_!=_(\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01r\\x041234"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"r\\x041234\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} != TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+    ast: '_!=_(\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"\\xa2\\x06\\x13\\x12\\x11\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01r\\x041234"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"\\xa2\\x06\\x13\\x12\\x11r\\x041234\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} != TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+    ast: '_!=_(\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01r\\x041234"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"r\\x041234\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001r\\0041234'}} != TestAllTypes{single_any: google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\242\\006\\023\\022\\021r\\0041234\\020\\256\\366\\377\\377\\377\\377\\377\\377\\377\\001'}}",
+    ast: '_!=_(\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"\\xa2\\x06\\x13\\x12\\x11\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01r\\x041234"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{\n    single_any:google.protobuf.Any{\n      type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      value:b"\\xa2\\x06\\x13\\x12\\x11r\\x041234\\x10\\xae\\xf6\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x01"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "-1 \u003c 0",
+    ast: "_\u003c_(\n  -1^#*expr.Constant_Int64Value#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0 \u003c 0",
+    ast: "_\u003c_(\n  0^#*expr.Constant_Int64Value#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0u \u003c 1u",
+    ast: "_\u003c_(\n  0u^#*expr.Constant_Uint64Value#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "2u \u003c 2u",
+    ast: "_\u003c_(\n  2u^#*expr.Constant_Uint64Value#,\n  2u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1.0 \u003c 1.0000001",
+    ast: "_\u003c_(\n  1^#*expr.Constant_DoubleValue#,\n  1.0000001^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-0.0 \u003c 0.0",
+    ast: "_\u003c_(\n  -0^#*expr.Constant_DoubleValue#,\n  0^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "'a' \u003c 'b'",
+    ast: '_\u003c_(\n  "a"^#*expr.Constant_StringValue#,\n  "b"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'' \u003c 'a'",
+    ast: '_\u003c_(\n  ""^#*expr.Constant_StringValue#,\n  "a"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'Abc' \u003c 'aBC'",
+    ast: '_\u003c_(\n  "Abc"^#*expr.Constant_StringValue#,\n  "aBC"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'abc' \u003c 'abcd'",
+    ast: '_\u003c_(\n  "abc"^#*expr.Constant_StringValue#,\n  "abcd"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'a' \u003c '\\u00E1'",
+    ast: '_\u003c_(\n  "a"^#*expr.Constant_StringValue#,\n  "á"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'' \u003c ''",
+    ast: '_\u003c_(\n  ""^#*expr.Constant_StringValue#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'abc' \u003c 'abc'",
+    ast: '_\u003c_(\n  "abc"^#*expr.Constant_StringValue#,\n  "abc"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'a' \u003c 'AB'",
+    ast: '_\u003c_(\n  "a"^#*expr.Constant_StringValue#,\n  "AB"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'f' \u003c '\\u1EBF'",
+    ast: '_\u003c_(\n  "f"^#*expr.Constant_StringValue#,\n  "ế"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'a' \u003c b'b'",
+    ast: '_\u003c_(\n  b"a"^#*expr.Constant_BytesValue#,\n  b"b"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'abc' \u003c b'abc'",
+    ast: '_\u003c_(\n  b"abc"^#*expr.Constant_BytesValue#,\n  b"abc"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'á' \u003c b'b'",
+    ast: '_\u003c_(\n  b"á"^#*expr.Constant_BytesValue#,\n  b"b"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "false \u003c true",
+    ast: "_\u003c_(\n  false^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "true \u003c true",
+    ast: "_\u003c_(\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "true \u003c false",
+    ast: "_\u003c_(\n  true^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[0] \u003c [1]",
+    ast: "_\u003c_(\n  [\n    0^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    1^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{0:'a'} \u003c {1:'b'}",
+    ast: '_\u003c_(\n  {\n    0^#*expr.Constant_Int64Value#:"a"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    1^#*expr.Constant_Int64Value#:"b"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "null \u003c null",
+    ast: "_\u003c_(\n  null^#*expr.Constant_NullValue#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "'foo' \u003c 1024",
+    ast: '_\u003c_(\n  "foo"^#*expr.Constant_StringValue#,\n  1024^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn(1) \u003c 2u",
+    ast: "_\u003c_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  2u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) \u003c 2.0",
+    ast: "_\u003c_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  2^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) \u003c 2",
+    ast: "_\u003c_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) \u003c 2.0",
+    ast: "_\u003c_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  2^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1.0) \u003c 2",
+    ast: "_\u003c_(\n  dyn(\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1.0) \u003c 2u",
+    ast: "_\u003c_(\n  dyn(\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  2u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) \u003c 1u",
+    ast: "_\u003c_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) \u003c 1.0",
+    ast: "_\u003c_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) \u003c 1",
+    ast: "_\u003c_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) \u003c 1.0",
+    ast: "_\u003c_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1.0) \u003c 1",
+    ast: "_\u003c_(\n  dyn(\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1.0) \u003c 1u",
+    ast: "_\u003c_(\n  dyn(\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) \u003c 9223372036854775808u",
+    ast: "_\u003c_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  9223372036854775808u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(-1) \u003c 0u",
+    ast: "_\u003c_(\n  dyn(\n    -1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9223372036854775807) \u003c 9223372036854775808.0",
+    ast: "_\u003c_(\n  dyn(\n    9223372036854775807^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  9.223372036854776e+18^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9223372036854775807) \u003c 9223372036854777857.0",
+    ast: "_\u003c_(\n  dyn(\n    9223372036854775807^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  9.223372036854778e+18^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9223372036854775807) \u003c -9223372036854777857.0",
+    ast: "_\u003c_(\n  dyn(\n    9223372036854775807^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -9.223372036854778e+18^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(-9223372036854775808) \u003c -9223372036854775809.0",
+    ast: "_\u003c_(\n  dyn(\n    -9223372036854775808^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -9.223372036854776e+18^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) \u003c -9223372036854775808",
+    ast: "_\u003c_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  -9223372036854775808^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9223372036854775808u) \u003c 1",
+    ast: "_\u003c_(\n  dyn(\n    9223372036854775808u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(18446744073709551615u) \u003c -1.0",
+    ast: "_\u003c_(\n  dyn(\n    18446744073709551615u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(18446744073709551615u) \u003c 18446744073709590000.0",
+    ast: "_\u003c_(\n  dyn(\n    18446744073709551615u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1.844674407370959e+19^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(18446744073709553665.0) \u003c 18446744073709551615u",
+    ast: "_\u003c_(\n  dyn(\n    1.8446744073709556e+19^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  18446744073709551615u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9223372036854775808.0) \u003c 9223372036854775807",
+    ast: "_\u003c_(\n  dyn(\n    9.223372036854776e+18^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  9223372036854775807^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(-9223372036854775809.0) \u003c -9223372036854775808",
+    ast: "_\u003c_(\n  dyn(\n    -9.223372036854776e+18^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  -9223372036854775808^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "42 \u003e -42",
+    ast: "_\u003e_(\n  42^#*expr.Constant_Int64Value#,\n  -42^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0 \u003e 0",
+    ast: "_\u003e_(\n  0^#*expr.Constant_Int64Value#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "48u \u003e 46u",
+    ast: "_\u003e_(\n  48u^#*expr.Constant_Uint64Value#,\n  46u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0u \u003e 999u",
+    ast: "_\u003e_(\n  0u^#*expr.Constant_Uint64Value#,\n  999u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1e+1 \u003e 1e+0",
+    ast: "_\u003e_(\n  10^#*expr.Constant_DoubleValue#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: ".99 \u003e 9.9e-1",
+    ast: "_\u003e_(\n  0.99^#*expr.Constant_DoubleValue#,\n  0.99^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "'abc' \u003e 'aBc'",
+    ast: '_\u003e_(\n  "abc"^#*expr.Constant_StringValue#,\n  "aBc"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'A' \u003e ''",
+    ast: '_\u003e_(\n  "A"^#*expr.Constant_StringValue#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'' \u003e ''",
+    ast: '_\u003e_(\n  ""^#*expr.Constant_StringValue#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'α' \u003e 'omega'",
+    ast: '_\u003e_(\n  "α"^#*expr.Constant_StringValue#,\n  "omega"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'\u0001' \u003e b'\u0000'",
+    ast: '_\u003e_(\n  b"\\x01"^#*expr.Constant_BytesValue#,\n  b"\\x00"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'\u0000' \u003e b''",
+    ast: '_\u003e_(\n  b"\\x00"^#*expr.Constant_BytesValue#,\n  b""^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'\u0000\u0001' \u003e b'\u0001'",
+    ast: '_\u003e_(\n  b"\\x00\\x01"^#*expr.Constant_BytesValue#,\n  b"\\x01"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "true \u003e false",
+    ast: "_\u003e_(\n  true^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "false \u003e true",
+    ast: "_\u003e_(\n  false^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "true \u003e true",
+    ast: "_\u003e_(\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "null \u003e null",
+    ast: "_\u003e_(\n  null^#*expr.Constant_NullValue#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1] \u003e [0]",
+    ast: "_\u003e_(\n  [\n    1^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    0^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{1:'b'} \u003e {0:'a'}",
+    ast: '_\u003e_(\n  {\n    1^#*expr.Constant_Int64Value#:"b"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    0^#*expr.Constant_Int64Value#:"a"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'foo' \u003e 1024",
+    ast: '_\u003e_(\n  "foo"^#*expr.Constant_StringValue#,\n  1024^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn(2) \u003e 1u",
+    ast: "_\u003e_(\n  dyn(\n    2^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2) \u003e 1.0",
+    ast: "_\u003e_(\n  dyn(\n    2^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2u) \u003e 1",
+    ast: "_\u003e_(\n  dyn(\n    2u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2u) \u003e 1.0",
+    ast: "_\u003e_(\n  dyn(\n    2u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2.0) \u003e 1",
+    ast: "_\u003e_(\n  dyn(\n    2^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2.0) \u003e 1u",
+    ast: "_\u003e_(\n  dyn(\n    2^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) \u003e 1u",
+    ast: "_\u003e_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) \u003e 1.0",
+    ast: "_\u003e_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) \u003e 1",
+    ast: "_\u003e_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) \u003e 1.0",
+    ast: "_\u003e_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1.0) \u003e 1",
+    ast: "_\u003e_(\n  dyn(\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1.0) \u003e 1u",
+    ast: "_\u003e_(\n  dyn(\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) \u003e 9223372036854775808u",
+    ast: "_\u003e_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  9223372036854775808u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(-1) \u003e 0u",
+    ast: "_\u003e_(\n  dyn(\n    -1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9223372036854775807) \u003e 9223372036854775808.0",
+    ast: "_\u003e_(\n  dyn(\n    9223372036854775807^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  9.223372036854776e+18^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(-9223372036854775808) \u003e -9223372036854775809.0",
+    ast: "_\u003e_(\n  dyn(\n    -9223372036854775808^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -9.223372036854776e+18^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(-9223372036854775808) \u003e -9223372036854777857.0",
+    ast: "_\u003e_(\n  dyn(\n    -9223372036854775808^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -9.223372036854778e+18^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) \u003e -1",
+    ast: "_\u003e_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9223372036854775808u) \u003e 1",
+    ast: "_\u003e_(\n  dyn(\n    9223372036854775808u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9223372036854775807u) \u003e -1.0",
+    ast: "_\u003e_(\n  dyn(\n    9223372036854775807u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(18446744073709551615u) \u003e 18446744073709590000.0",
+    ast: "_\u003e_(\n  dyn(\n    18446744073709551615u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1.844674407370959e+19^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(18446744073709553665.0) \u003e 18446744073709551615u",
+    ast: "_\u003e_(\n  dyn(\n    1.8446744073709556e+19^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  18446744073709551615u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9223372036854775808.0) \u003e 9223372036854775807",
+    ast: "_\u003e_(\n  dyn(\n    9.223372036854776e+18^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  9223372036854775807^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(-9223372036854775809.0) \u003e -9223372036854775808",
+    ast: "_\u003e_(\n  dyn(\n    -9.223372036854776e+18^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  -9223372036854775808^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0 \u003c= 1",
+    ast: "_\u003c=_(\n  0^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1 \u003c= 1",
+    ast: "_\u003c=_(\n  1^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1 \u003c= -1",
+    ast: "_\u003c=_(\n  1^#*expr.Constant_Int64Value#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0u \u003c= 1u",
+    ast: "_\u003c=_(\n  0u^#*expr.Constant_Uint64Value#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1u \u003c= 1u",
+    ast: "_\u003c=_(\n  1u^#*expr.Constant_Uint64Value#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1u \u003c= 0u",
+    ast: "_\u003c=_(\n  1u^#*expr.Constant_Uint64Value#,\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0.0 \u003c= 0.1e-31",
+    ast: "_\u003c=_(\n  0^#*expr.Constant_DoubleValue#,\n  1e-32^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0.0 \u003c= 0e-1",
+    ast: "_\u003c=_(\n  0^#*expr.Constant_DoubleValue#,\n  0^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1.0 \u003c= 0.99",
+    ast: "_\u003c=_(\n  1^#*expr.Constant_DoubleValue#,\n  0.99^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "'' \u003c= ''",
+    ast: '_\u003c=_(\n  ""^#*expr.Constant_StringValue#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'' \u003c= 'a'",
+    ast: '_\u003c=_(\n  ""^#*expr.Constant_StringValue#,\n  "a"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'a' \u003c= ''",
+    ast: '_\u003c=_(\n  "a"^#*expr.Constant_StringValue#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'aBc' \u003c= 'abc'",
+    ast: '_\u003c=_(\n  "aBc"^#*expr.Constant_StringValue#,\n  "abc"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'α' \u003c= 'α'",
+    ast: '_\u003c=_(\n  "α"^#*expr.Constant_StringValue#,\n  "α"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'a' \u003c= 'α'",
+    ast: '_\u003c=_(\n  "a"^#*expr.Constant_StringValue#,\n  "α"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'α' \u003c= 'a'",
+    ast: '_\u003c=_(\n  "α"^#*expr.Constant_StringValue#,\n  "a"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'' \u003c= b'\u0000'",
+    ast: '_\u003c=_(\n  b""^#*expr.Constant_BytesValue#,\n  b"\\x00"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'\u0001\u0000' \u003c= b'\u0001'",
+    ast: '_\u003c=_(\n  b"\\x01\\x00"^#*expr.Constant_BytesValue#,\n  b"\\x01"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "false \u003c= true",
+    ast: "_\u003c=_(\n  false^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "false \u003c= false",
+    ast: "_\u003c=_(\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "true \u003c= false",
+    ast: "_\u003c=_(\n  true^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "null \u003c= null",
+    ast: "_\u003c=_(\n  null^#*expr.Constant_NullValue#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[0] \u003c= [0]",
+    ast: "_\u003c=_(\n  [\n    0^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    0^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{0:'a'} \u003c= {1:'b'}",
+    ast: '_\u003c=_(\n  {\n    0^#*expr.Constant_Int64Value#:"a"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    1^#*expr.Constant_Int64Value#:"b"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'foo' \u003c= 1024",
+    ast: '_\u003c=_(\n  "foo"^#*expr.Constant_StringValue#,\n  1024^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn(1) \u003c= 2u",
+    ast: "_\u003c=_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  2u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) \u003c= 2.0",
+    ast: "_\u003c=_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  2^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) \u003c= 2",
+    ast: "_\u003c=_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) \u003c= 2.0",
+    ast: "_\u003c=_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  2^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1.0) \u003c= 2",
+    ast: "_\u003c=_(\n  dyn(\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1.0) \u003c= 2u",
+    ast: "_\u003c=_(\n  dyn(\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  2u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2) \u003c= 1u",
+    ast: "_\u003c=_(\n  dyn(\n    2^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2) \u003c= 1.0",
+    ast: "_\u003c=_(\n  dyn(\n    2^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2u) \u003c= 1",
+    ast: "_\u003c=_(\n  dyn(\n    2u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2u) \u003c= 1.0",
+    ast: "_\u003c=_(\n  dyn(\n    2u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2.0) \u003c= 1",
+    ast: "_\u003c=_(\n  dyn(\n    2^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2.0) \u003c= 1u",
+    ast: "_\u003c=_(\n  dyn(\n    2^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) \u003c= 9223372036854775808u",
+    ast: "_\u003c=_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  9223372036854775808u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(-1) \u003c= 0u",
+    ast: "_\u003c=_(\n  dyn(\n    -1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9223372036854775807) \u003c= 9223372036854775808.0",
+    ast: "_\u003c=_(\n  dyn(\n    9223372036854775807^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  9.223372036854776e+18^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(-9223372036854775808) \u003c= -9223372036854775809.0",
+    ast: "_\u003c=_(\n  dyn(\n    -9223372036854775808^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -9.223372036854776e+18^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(-9223372036854775808) \u003c= -9223372036854777857.0",
+    ast: "_\u003c=_(\n  dyn(\n    -9223372036854775808^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -9.223372036854778e+18^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) \u003c= -9223372036854775808",
+    ast: "_\u003c=_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  -9223372036854775808^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9223372036854775808u) \u003c= 1",
+    ast: "_\u003c=_(\n  dyn(\n    9223372036854775808u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(18446744073709551615u) \u003c= -1.0",
+    ast: "_\u003c=_(\n  dyn(\n    18446744073709551615u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(18446744073709551615u) \u003c= 18446744073709590000.0",
+    ast: "_\u003c=_(\n  dyn(\n    18446744073709551615u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1.844674407370959e+19^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(18446744073709553665.0) \u003c= 18446744073709551615u",
+    ast: "_\u003c=_(\n  dyn(\n    1.8446744073709556e+19^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  18446744073709551615u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9223372036854775808.0) \u003c= 9223372036854775807",
+    ast: "_\u003c=_(\n  dyn(\n    9.223372036854776e+18^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  9223372036854775807^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(-9223372036854775809.0) \u003c= -9223372036854775808",
+    ast: "_\u003c=_(\n  dyn(\n    -9.223372036854776e+18^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  -9223372036854775808^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0 \u003e= -1",
+    ast: "_\u003e=_(\n  0^#*expr.Constant_Int64Value#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "999 \u003e= 999",
+    ast: "_\u003e=_(\n  999^#*expr.Constant_Int64Value#,\n  999^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "999 \u003e= 1000",
+    ast: "_\u003e=_(\n  999^#*expr.Constant_Int64Value#,\n  1000^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1u \u003e= 0u",
+    ast: "_\u003e=_(\n  1u^#*expr.Constant_Uint64Value#,\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0u \u003e= 0u",
+    ast: "_\u003e=_(\n  0u^#*expr.Constant_Uint64Value#,\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1u \u003e= 10u",
+    ast: "_\u003e=_(\n  1u^#*expr.Constant_Uint64Value#,\n  10u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1e+1 \u003e= 1e+0",
+    ast: "_\u003e=_(\n  10^#*expr.Constant_DoubleValue#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "9.80665 \u003e= 9.80665e+0",
+    ast: "_\u003e=_(\n  9.80665^#*expr.Constant_DoubleValue#,\n  9.80665^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0.9999 \u003e= 1.0",
+    ast: "_\u003e=_(\n  0.9999^#*expr.Constant_DoubleValue#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "'' \u003e= ''",
+    ast: '_\u003e=_(\n  ""^#*expr.Constant_StringValue#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'a' \u003e= ''",
+    ast: '_\u003e=_(\n  "a"^#*expr.Constant_StringValue#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'' \u003e= 'a'",
+    ast: '_\u003e=_(\n  ""^#*expr.Constant_StringValue#,\n  "a"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'abcd' \u003e= 'abc'",
+    ast: '_\u003e=_(\n  "abcd"^#*expr.Constant_StringValue#,\n  "abc"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'abc' \u003e= 'abd'",
+    ast: '_\u003e=_(\n  "abc"^#*expr.Constant_StringValue#,\n  "abd"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'τ' \u003e= 'τ'",
+    ast: '_\u003e=_(\n  "τ"^#*expr.Constant_StringValue#,\n  "τ"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'τ' \u003e= 't'",
+    ast: '_\u003e=_(\n  "τ"^#*expr.Constant_StringValue#,\n  "t"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'t' \u003e= 'τ'",
+    ast: '_\u003e=_(\n  "t"^#*expr.Constant_StringValue#,\n  "τ"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'\u0000' \u003e= b''",
+    ast: '_\u003e=_(\n  b"\\x00"^#*expr.Constant_BytesValue#,\n  b""^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'' \u003e= b'\u0000'",
+    ast: '_\u003e=_(\n  b""^#*expr.Constant_BytesValue#,\n  b"\\x00"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'\u0000\u0001' \u003e= b'\u0001\u0000'",
+    ast: '_\u003e=_(\n  b"\\x00\\x01"^#*expr.Constant_BytesValue#,\n  b"\\x01\\x00"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "true \u003e= false",
+    ast: "_\u003e=_(\n  true^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "true \u003e= true",
+    ast: "_\u003e=_(\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "false \u003e= true",
+    ast: "_\u003e=_(\n  false^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "null \u003e= null",
+    ast: "_\u003e=_(\n  null^#*expr.Constant_NullValue#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "['y'] \u003e= ['x']",
+    ast: '_\u003e=_(\n  [\n    "y"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    "x"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{1:'b'} \u003e= {0:'a'}",
+    ast: '_\u003e=_(\n  {\n    1^#*expr.Constant_Int64Value#:"b"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  {\n    0^#*expr.Constant_Int64Value#:"a"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'foo' \u003e= 1.0",
+    ast: '_\u003e=_(\n  "foo"^#*expr.Constant_StringValue#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn(2) \u003e= 1u",
+    ast: "_\u003e=_(\n  dyn(\n    2^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2) \u003e= 1.0",
+    ast: "_\u003e=_(\n  dyn(\n    2^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2u) \u003e= 1",
+    ast: "_\u003e=_(\n  dyn(\n    2u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2u) \u003e= 1.0",
+    ast: "_\u003e=_(\n  dyn(\n    2u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2.0) \u003e= 1",
+    ast: "_\u003e=_(\n  dyn(\n    2^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(2.0) \u003e= 1u",
+    ast: "_\u003e=_(\n  dyn(\n    2^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(0) \u003e= 1u",
+    ast: "_\u003e=_(\n  dyn(\n    0^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(0) \u003e= 1.0",
+    ast: "_\u003e=_(\n  dyn(\n    0^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(0u) \u003e= 1",
+    ast: "_\u003e=_(\n  dyn(\n    0u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(0u) \u003e= 1.0",
+    ast: "_\u003e=_(\n  dyn(\n    0u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(0.0) \u003e= 1",
+    ast: "_\u003e=_(\n  dyn(\n    0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(0.0) \u003e= 1u",
+    ast: "_\u003e=_(\n  dyn(\n    0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1) \u003e= 9223372036854775808u",
+    ast: "_\u003e=_(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  9223372036854775808u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(-1) \u003e= 0u",
+    ast: "_\u003e=_(\n  dyn(\n    -1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9223372036854775807) \u003e= 9223372036854775808.0",
+    ast: "_\u003e=_(\n  dyn(\n    9223372036854775807^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  9.223372036854776e+18^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9223372036854775807) \u003e= 9223372036854777857.0",
+    ast: "_\u003e=_(\n  dyn(\n    9223372036854775807^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  9.223372036854778e+18^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(-9223372036854775808) \u003e= -9223372036854775809.0",
+    ast: "_\u003e=_(\n  dyn(\n    -9223372036854775808^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -9.223372036854776e+18^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(-9223372036854775808) \u003e= -9223372036854777857.0",
+    ast: "_\u003e=_(\n  dyn(\n    -9223372036854775808^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -9.223372036854778e+18^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(1u) \u003e= -1",
+    ast: "_\u003e=_(\n  dyn(\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9223372036854775808u) \u003e= 1",
+    ast: "_\u003e=_(\n  dyn(\n    9223372036854775808u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9223372036854775807u) \u003e= -1.0",
+    ast: "_\u003e=_(\n  dyn(\n    9223372036854775807u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(18446744073709551615u) \u003e= 18446744073709553665.0",
+    ast: "_\u003e=_(\n  dyn(\n    18446744073709551615u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1.8446744073709556e+19^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(18446744073709553665.0) \u003e= 18446744073709551615u",
+    ast: "_\u003e=_(\n  dyn(\n    1.8446744073709556e+19^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  18446744073709551615u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(9223372036854775808.0) \u003e= 9223372036854775807",
+    ast: "_\u003e=_(\n  dyn(\n    9.223372036854776e+18^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  9223372036854775807^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(-9223372036854775809.0) \u003e= -9223372036854775808",
+    ast: "_\u003e=_(\n  dyn(\n    -9.223372036854776e+18^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  -9223372036854775808^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "'empty' in []",
+    ast: '@in(\n  "empty"^#*expr.Constant_StringValue#,\n  []^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'elem' in ['elem', 'elemA', 'elemB']",
+    ast: '@in(\n  "elem"^#*expr.Constant_StringValue#,\n  [\n    "elem"^#*expr.Constant_StringValue#,\n    "elemA"^#*expr.Constant_StringValue#,\n    "elemB"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'not' in ['elem1', 'elem2', 'elem3']",
+    ast: '@in(\n  "not"^#*expr.Constant_StringValue#,\n  [\n    "elem1"^#*expr.Constant_StringValue#,\n    "elem2"^#*expr.Constant_StringValue#,\n    "elem3"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'elem' in [1, 'elem', 2]",
+    ast: '@in(\n  "elem"^#*expr.Constant_StringValue#,\n  [\n    1^#*expr.Constant_Int64Value#,\n    "elem"^#*expr.Constant_StringValue#,\n    2^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'elem' in [1u, 'str', 2, b'bytes']",
+    ast: '@in(\n  "elem"^#*expr.Constant_StringValue#,\n  [\n    1u^#*expr.Constant_Uint64Value#,\n    "str"^#*expr.Constant_StringValue#,\n    2^#*expr.Constant_Int64Value#,\n    b"bytes"^#*expr.Constant_BytesValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'empty' in {}",
+    ast: '@in(\n  "empty"^#*expr.Constant_StringValue#,\n  {}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'key' in {'key':'1', 'other':'2'}",
+    ast: '@in(\n  "key"^#*expr.Constant_StringValue#,\n  {\n    "key"^#*expr.Constant_StringValue#:"1"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    "other"^#*expr.Constant_StringValue#:"2"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'key' in {'lock':1, 'gate':2}",
+    ast: '@in(\n  "key"^#*expr.Constant_StringValue#,\n  {\n    "lock"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    "gate"^#*expr.Constant_StringValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'key' in {3:3.0, 'key':2u}",
+    ast: '@in(\n  "key"^#*expr.Constant_StringValue#,\n  {\n    3^#*expr.Constant_Int64Value#:3^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    "key"^#*expr.Constant_StringValue#:2u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'key' in {1u:'str', 2:b'bytes'}",
+    ast: '@in(\n  "key"^#*expr.Constant_StringValue#,\n  {\n    1u^#*expr.Constant_Uint64Value#:"str"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    2^#*expr.Constant_Int64Value#:b"bytes"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "x \u003e b'\u0000'",
+    ast: '_\u003e_(\n  x^#*expr.Expr_IdentExpr#,\n  b"\\x00"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "123 \u003c= x",
+    ast: "_\u003c=_(\n  123^#*expr.Constant_Int64Value#,\n  x^#*expr.Expr_IdentExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "false \u003c x",
+    ast: "_\u003c_(\n  false^#*expr.Constant_BoolValue#,\n  x^#*expr.Expr_IdentExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "x != 9.8",
+    ast: "_!=_(\n  x^#*expr.Expr_IdentExpr#,\n  9.8^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{'a':'b','c':'d'} != x",
+    ast: '_!=_(\n  {\n    "a"^#*expr.Constant_StringValue#:"b"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    "c"^#*expr.Constant_StringValue#:"d"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  x^#*expr.Expr_IdentExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "x == null",
+    ast: "_==_(\n  x^#*expr.Expr_IdentExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1, 2] == x",
+    ast: "_==_(\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  x^#*expr.Expr_IdentExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "'abcd' \u003e= x",
+    ast: '_\u003e=_(\n  "abcd"^#*expr.Constant_StringValue#,\n  x^#*expr.Expr_IdentExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "999u == x",
+    ast: "_==_(\n  999u^#*expr.Constant_Uint64Value#,\n  x^#*expr.Expr_IdentExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "null \u003c x",
+    ast: "_\u003c_(\n  null^#*expr.Constant_NullValue#,\n  x^#*expr.Expr_IdentExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "bytes('')",
+    ast: 'bytes(\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "bytes('abc')",
+    ast: 'bytes(\n  "abc"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "bytes('ÿ')",
+    ast: 'bytes(\n  "ÿ"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "bytes('\\377') == b'\\377'",
+    ast: '_==_(\n  bytes(\n    "ÿ"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  b"\\xff"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "double(0)",
+    ast: "double(\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "double(1000000000000)",
+    ast: "double(\n  1000000000000^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "double(-1000000000000000)",
+    ast: "double(\n  -1000000000000000^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "double(-9007199254740992)",
+    ast: "double(\n  -9007199254740992^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "double(9007199254740992)",
+    ast: "double(\n  9007199254740992^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "double(9223372036854775807)",
+    ast: "double(\n  9223372036854775807^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "double(0u)",
+    ast: "double(\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "double(123u)",
+    ast: "double(\n  123u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "double(9007199254740992u)",
+    ast: "double(\n  9007199254740992u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "double(18446744073709551615u)",
+    ast: "double(\n  18446744073709551615u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "double('0')",
+    ast: 'double(\n  "0"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "double('0.0')",
+    ast: 'double(\n  "0.0"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "double('-0.0')",
+    ast: 'double(\n  "-0.0"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "double('123')",
+    ast: 'double(\n  "123"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "double('123.456')",
+    ast: 'double(\n  "123.456"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "double('-987.654')",
+    ast: 'double(\n  "-987.654"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "double('6.02214e23')",
+    ast: 'double(\n  "6.02214e23"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "double('1.38e-23')",
+    ast: 'double(\n  "1.38e-23"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "double('-84.32e7')",
+    ast: 'double(\n  "-84.32e7"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "double('-5.43e-21')",
+    ast: 'double(\n  "-5.43e-21"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "type(dyn([1, 'one']))",
+    ast: 'type(\n  dyn(\n    [\n      1^#*expr.Constant_Int64Value#,\n      "one"^#*expr.Constant_StringValue#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "int(42u)",
+    ast: "int(\n  42u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(0u)",
+    ast: "int(\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(9223372036854775807u)",
+    ast: "int(\n  9223372036854775807u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(18446744073709551615u)",
+    ast: "int(\n  18446744073709551615u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(-123.456)",
+    ast: "int(\n  -123.456^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(1.9)",
+    ast: "int(\n  1.9^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(-7.9)",
+    ast: "int(\n  -7.9^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(11.5)",
+    ast: "int(\n  11.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(-3.5)",
+    ast: "int(\n  -3.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(double(36028797018963968))",
+    ast: "int(\n  double(\n    36028797018963968^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(double(36028797018963969))",
+    ast: "int(\n  double(\n    36028797018963969^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(9223372036854775807.0)",
+    ast: "int(\n  9.223372036854776e+18^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(-9223372036854775808.0)",
+    ast: "int(\n  -9.223372036854776e+18^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(1e99)",
+    ast: "int(\n  1e+99^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int('987')",
+    ast: 'int(\n  "987"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "int(timestamp('2004-09-16T23:59:59Z'))",
+    ast: 'int(\n  timestamp(\n    "2004-09-16T23:59:59Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "string(123)",
+    ast: "string(\n  123^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "string(-456)",
+    ast: "string(\n  -456^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "string(9876u)",
+    ast: "string(\n  9876u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "string(123.456)",
+    ast: "string(\n  123.456^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "string(-4.5e-3)",
+    ast: "string(\n  -0.0045^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "string(b'abc')",
+    ast: 'string(\n  b"abc"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "string(b'\\303\\277')",
+    ast: 'string(\n  b"ÿ"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "string(b'\\000\\xff')",
+    ast: 'string(\n  b"\\x00\\xff"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "type(true)",
+    ast: "type(\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  { expr: "bool", ast: "bool^#*expr.Expr_IdentExpr#" },
+  { expr: "dyn", ast: "dyn^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "type(0)",
+    ast: "type(\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  { expr: "int", ast: "int^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "type(true) == type(false)",
+    ast: "_==_(\n  type(\n    true^#*expr.Constant_BoolValue#\n  )^#*expr.Expr_CallExpr#,\n  type(\n    false^#*expr.Constant_BoolValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "type(64u)",
+    ast: "type(\n  64u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  { expr: "uint", ast: "uint^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "type(3.14)",
+    ast: "type(\n  3.14^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  { expr: "double", ast: "double^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "type(null)",
+    ast: "type(\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  { expr: "null_type", ast: "null_type^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "type('foo')",
+    ast: 'type(\n  "foo"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  { expr: "string", ast: "string^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "type(b'\\xff')",
+    ast: 'type(\n  b"\\xff"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  { expr: "bytes", ast: "bytes^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "type([1, 2, 3])",
+    ast: "type(\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  { expr: "list", ast: "list^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "type([1, 2, 3]) == type(['one', 'two', 'three'])",
+    ast: '_==_(\n  type(\n    [\n      1^#*expr.Constant_Int64Value#,\n      2^#*expr.Constant_Int64Value#,\n      3^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  type(\n    [\n      "one"^#*expr.Constant_StringValue#,\n      "two"^#*expr.Constant_StringValue#,\n      "three"^#*expr.Constant_StringValue#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "type({4: 16})",
+    ast: "type(\n  {\n    4^#*expr.Constant_Int64Value#:16^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  { expr: "map", ast: "map^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "type({'one': 1}) == type({1: 'one'})",
+    ast: '_==_(\n  type(\n    {\n      "one"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#,\n  type(\n    {\n      1^#*expr.Constant_Int64Value#:"one"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "type(7) == type(7u)",
+    ast: "_==_(\n  type(\n    7^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  type(\n    7u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "type(0.0) != type(-0.0)",
+    ast: "_!=_(\n  type(\n    0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  type(\n    -0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "type(0.0) != type(0)",
+    ast: "_!=_(\n  type(\n    0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  type(\n    0^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "type(type(7)) == type(type(7u))",
+    ast: "_==_(\n  type(\n    type(\n      7^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  type(\n    type(\n      7u^#*expr.Constant_Uint64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "type(int)",
+    ast: "type(\n  int^#*expr.Expr_IdentExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  { expr: "type", ast: "type^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "type(type)",
+    ast: "type(\n  type^#*expr.Expr_IdentExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "uint(1729)",
+    ast: "uint(\n  1729^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "uint(9223372036854775807)",
+    ast: "uint(\n  9223372036854775807^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "uint(-1)",
+    ast: "uint(\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "uint(3.14159265)",
+    ast: "uint(\n  3.14159265^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "uint(1.9)",
+    ast: "uint(\n  1.9^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "uint(25.5)",
+    ast: "uint(\n  25.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "uint(double(36028797018963968u))",
+    ast: "uint(\n  double(\n    36028797018963968u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "uint(double(36028797018963969u))",
+    ast: "uint(\n  double(\n    36028797018963969u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(18446744073709551615.0)",
+    ast: "int(\n  1.8446744073709552e+19^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "uint(6.022e23)",
+    ast: "uint(\n  6.022e+23^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "uint('300')",
+    ast: 'uint(\n  "300"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "bool('1')",
+    ast: 'bool(\n  "1"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "bool('t')",
+    ast: 'bool(\n  "t"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "bool('true')",
+    ast: 'bool(\n  "true"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "bool('TRUE')",
+    ast: 'bool(\n  "TRUE"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "bool('True')",
+    ast: 'bool(\n  "True"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "bool('0')",
+    ast: 'bool(\n  "0"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "bool('f')",
+    ast: 'bool(\n  "f"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "bool('false')",
+    ast: 'bool(\n  "false"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "bool('FALSE')",
+    ast: 'bool(\n  "FALSE"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "bool('False')",
+    ast: 'bool(\n  "False"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "bool('TrUe')",
+    ast: 'bool(\n  "TrUe"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "bool('FaLsE')",
+    ast: 'bool(\n  "FaLsE"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "bool(true)",
+    ast: "bool(\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(1)",
+    ast: "int(\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "uint(1u)",
+    ast: "uint(\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "double(5.5)",
+    ast: "double(\n  5.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "string('hello')",
+    ast: 'string(\n  "hello"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "bytes(b'abc')",
+    ast: 'bytes(\n  b"abc"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration(duration('100s')) == duration('100s')",
+    ast: '_==_(\n  duration(\n    duration(\n      "100s"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "100s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp(timestamp(1000000000)) == timestamp(1000000000)",
+    ast: "_==_(\n  timestamp(\n    timestamp(\n      1000000000^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    1000000000^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.Int32Value{value: -123}",
+    ast: "google.protobuf.Int32Value{\n  value:-123^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "google.protobuf.Int32Value{value: -123}.value",
+    ast: "google.protobuf.Int32Value{\n  value:-123^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.Int32Value{}",
+    ast: "google.protobuf.Int32Value{}^#*expr.Expr_StructExpr#",
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: 432}",
+    ast: "TestAllTypes{\n  single_int32_wrapper:432^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: 0}",
+    ast: "TestAllTypes{\n  single_int32_wrapper:0^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: 2147483647}",
+    ast: "TestAllTypes{\n  single_int32_wrapper:2147483647^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: -2147483648}",
+    ast: "TestAllTypes{\n  single_int32_wrapper:-2147483648^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: 12345678900}",
+    ast: "TestAllTypes{\n  single_int32_wrapper:12345678900^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: 642}.single_int32_wrapper",
+    ast: "TestAllTypes{\n  single_int32_wrapper:642^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_int32_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: 0}.single_int32_wrapper",
+    ast: "TestAllTypes{\n  single_int32_wrapper:0^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_int32_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_int32_wrapper",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_int32_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: -975}",
+    ast: "TestAllTypes{\n  single_int32_wrapper:-975^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: 0}",
+    ast: "TestAllTypes{\n  single_int32_wrapper:0^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: 2147483647}",
+    ast: "TestAllTypes{\n  single_int32_wrapper:2147483647^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: -2147483648}",
+    ast: "TestAllTypes{\n  single_int32_wrapper:-2147483648^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: -998877665544332211}",
+    ast: "TestAllTypes{\n  single_int32_wrapper:-998877665544332211^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: 642}.single_int32_wrapper",
+    ast: "TestAllTypes{\n  single_int32_wrapper:642^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_int32_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: 0}.single_int32_wrapper",
+    ast: "TestAllTypes{\n  single_int32_wrapper:0^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_int32_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_int32_wrapper",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_int32_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.Int64Value{value: -123}",
+    ast: "google.protobuf.Int64Value{\n  value:-123^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "google.protobuf.Int64Value{value: -123}.value",
+    ast: "google.protobuf.Int64Value{\n  value:-123^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.Int64Value{}",
+    ast: "google.protobuf.Int64Value{}^#*expr.Expr_StructExpr#",
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{single_int64_wrapper: 432}",
+    ast: "TestAllTypes{\n  single_int64_wrapper:432^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int64_wrapper: 0}",
+    ast: "TestAllTypes{\n  single_int64_wrapper:0^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int64_wrapper: -975}",
+    ast: "TestAllTypes{\n  single_int64_wrapper:-975^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int64_wrapper: 0}",
+    ast: "TestAllTypes{\n  single_int64_wrapper:0^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "google.protobuf.UInt32Value{value: 123u}",
+    ast: "google.protobuf.UInt32Value{\n  value:123u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "google.protobuf.UInt32Value{value: 123u}.value",
+    ast: "google.protobuf.UInt32Value{\n  value:123u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.UInt32Value{}",
+    ast: "google.protobuf.UInt32Value{}^#*expr.Expr_StructExpr#",
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{single_uint32_wrapper: 432u}",
+    ast: "TestAllTypes{\n  single_uint32_wrapper:432u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint32_wrapper: 0u}",
+    ast: "TestAllTypes{\n  single_uint32_wrapper:0u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint32_wrapper: 4294967295u}",
+    ast: "TestAllTypes{\n  single_uint32_wrapper:4294967295u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint32_wrapper: 6111222333u}",
+    ast: "TestAllTypes{\n  single_uint32_wrapper:6111222333u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint32_wrapper: 975u}",
+    ast: "TestAllTypes{\n  single_uint32_wrapper:975u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint32_wrapper: 0u}",
+    ast: "TestAllTypes{\n  single_uint32_wrapper:0u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint32_wrapper: 4294967295u}",
+    ast: "TestAllTypes{\n  single_uint32_wrapper:4294967295u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint32_wrapper: 6111222333u}",
+    ast: "TestAllTypes{\n  single_uint32_wrapper:6111222333u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint32_wrapper: 258u}.single_uint32_wrapper",
+    ast: "TestAllTypes{\n  single_uint32_wrapper:258u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_uint32_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint32_wrapper: 0u}.single_uint32_wrapper",
+    ast: "TestAllTypes{\n  single_uint32_wrapper:0u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_uint32_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_uint32_wrapper",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_uint32_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.UInt64Value{value: 123u}",
+    ast: "google.protobuf.UInt64Value{\n  value:123u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "google.protobuf.UInt64Value{value: 123u}.value",
+    ast: "google.protobuf.UInt64Value{\n  value:123u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.UInt64Value{}",
+    ast: "google.protobuf.UInt64Value{}^#*expr.Expr_StructExpr#",
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{single_uint64_wrapper: 432u}",
+    ast: "TestAllTypes{\n  single_uint64_wrapper:432u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint64_wrapper: 0u}",
+    ast: "TestAllTypes{\n  single_uint64_wrapper:0u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint64_wrapper: 975u}",
+    ast: "TestAllTypes{\n  single_uint64_wrapper:975u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint64_wrapper: 0u}",
+    ast: "TestAllTypes{\n  single_uint64_wrapper:0u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint64_wrapper: 5123123123u}.single_uint64_wrapper",
+    ast: "TestAllTypes{\n  single_uint64_wrapper:5123123123u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_uint64_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint64_wrapper: 0u}.single_uint64_wrapper",
+    ast: "TestAllTypes{\n  single_uint64_wrapper:0u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_uint64_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_uint64_wrapper",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_uint64_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.FloatValue{value: -1.5e3}",
+    ast: "google.protobuf.FloatValue{\n  value:-1500^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "google.protobuf.FloatValue{value: 1.333} == 1.333",
+    ast: "_==_(\n  google.protobuf.FloatValue{\n    value:1.333^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  1.333^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "google.protobuf.FloatValue{value: 3.1416}.value",
+    ast: "google.protobuf.FloatValue{\n  value:3.1416^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.FloatValue{}",
+    ast: "google.protobuf.FloatValue{}^#*expr.Expr_StructExpr#",
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{single_float_wrapper: 86.75}",
+    ast: "TestAllTypes{\n  single_float_wrapper:86.75^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float_wrapper: 0.0}",
+    ast: "TestAllTypes{\n  single_float_wrapper:0^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float_wrapper: 1e-40}",
+    ast: "TestAllTypes{\n  single_float_wrapper:1e-40^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float_wrapper: 1e-50}",
+    ast: "TestAllTypes{\n  single_float_wrapper:1e-50^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float_wrapper: 1.4e55}",
+    ast: "TestAllTypes{\n  single_float_wrapper:1.4e+55^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float_wrapper: -12.375}.single_float_wrapper",
+    ast: "TestAllTypes{\n  single_float_wrapper:-12.375^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_float_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float_wrapper: 0.0}.single_float_wrapper",
+    ast: "TestAllTypes{\n  single_float_wrapper:0^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_float_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_float_wrapper",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_float_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float_wrapper: -9.75}",
+    ast: "TestAllTypes{\n  single_float_wrapper:-9.75^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float_wrapper: 0.0}",
+    ast: "TestAllTypes{\n  single_float_wrapper:0^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float_wrapper: 1e-40}",
+    ast: "TestAllTypes{\n  single_float_wrapper:1e-40^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float_wrapper: -9.9e-100}",
+    ast: "TestAllTypes{\n  single_float_wrapper:-9.9e-100^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float_wrapper: -9.9e100}",
+    ast: "TestAllTypes{\n  single_float_wrapper:-9.9e+100^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float_wrapper: 64.25}.single_float_wrapper",
+    ast: "TestAllTypes{\n  single_float_wrapper:64.25^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_float_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float_wrapper: 0.0}.single_float_wrapper",
+    ast: "TestAllTypes{\n  single_float_wrapper:0^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_float_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_float_wrapper",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_float_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.DoubleValue{value: -1.5e3}",
+    ast: "google.protobuf.DoubleValue{\n  value:-1500^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "google.protobuf.DoubleValue{value: 3.1416}.value",
+    ast: "google.protobuf.DoubleValue{\n  value:3.1416^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.DoubleValue{}",
+    ast: "google.protobuf.DoubleValue{}^#*expr.Expr_StructExpr#",
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{single_double_wrapper: 86.75}",
+    ast: "TestAllTypes{\n  single_double_wrapper:86.75^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_double_wrapper: 0.0}",
+    ast: "TestAllTypes{\n  single_double_wrapper:0^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_double_wrapper: 1.4e55}",
+    ast: "TestAllTypes{\n  single_double_wrapper:1.4e+55^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_double_wrapper: -12.375}.single_double_wrapper",
+    ast: "TestAllTypes{\n  single_double_wrapper:-12.375^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_double_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: 0}.single_int32_wrapper",
+    ast: "TestAllTypes{\n  single_int32_wrapper:0^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_int32_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_double_wrapper",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_double_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_double_wrapper: -9.75}",
+    ast: "TestAllTypes{\n  single_double_wrapper:-9.75^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_double_wrapper: 0.0}",
+    ast: "TestAllTypes{\n  single_double_wrapper:0^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_double_wrapper: -9.9e100}",
+    ast: "TestAllTypes{\n  single_double_wrapper:-9.9e+100^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_double_wrapper: 64.25}.single_double_wrapper",
+    ast: "TestAllTypes{\n  single_double_wrapper:64.25^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_double_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_double_wrapper: 0.0}.single_double_wrapper",
+    ast: "TestAllTypes{\n  single_double_wrapper:0^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_double_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_double_wrapper",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_double_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.BoolValue{value: true}",
+    ast: "google.protobuf.BoolValue{\n  value:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "google.protobuf.BoolValue{value: true}.value",
+    ast: "google.protobuf.BoolValue{\n  value:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.BoolValue{}",
+    ast: "google.protobuf.BoolValue{}^#*expr.Expr_StructExpr#",
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{single_bool_wrapper: true}",
+    ast: "TestAllTypes{\n  single_bool_wrapper:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_bool_wrapper: false}",
+    ast: "TestAllTypes{\n  single_bool_wrapper:false^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_bool_wrapper: true}",
+    ast: "TestAllTypes{\n  single_bool_wrapper:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_bool_wrapper: false}",
+    ast: "TestAllTypes{\n  single_bool_wrapper:false^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "google.protobuf.StringValue{value: 'foo'}",
+    ast: 'google.protobuf.StringValue{\n  value:"foo"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "google.protobuf.StringValue{value: 'foo'}.value",
+    ast: 'google.protobuf.StringValue{\n  value:"foo"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "google.protobuf.StringValue{}",
+    ast: "google.protobuf.StringValue{}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "google.protobuf.StringValue{value: 'flambé'}",
+    ast: 'google.protobuf.StringValue{\n  value:"flambé"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{single_string_wrapper: 'baz'}",
+    ast: 'TestAllTypes{\n  single_string_wrapper:"baz"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_string_wrapper: ''}",
+    ast: 'TestAllTypes{\n  single_string_wrapper:""^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_string_wrapper: 'bletch'}",
+    ast: 'TestAllTypes{\n  single_string_wrapper:"bletch"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_string_wrapper: ''}",
+    ast: 'TestAllTypes{\n  single_string_wrapper:""^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "google.protobuf.BytesValue{value: b'foo\\123'}",
+    ast: 'google.protobuf.BytesValue{\n  value:b"fooS"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "google.protobuf.BytesValue{value: b'foo'}.value",
+    ast: 'google.protobuf.BytesValue{\n  value:b"foo"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "google.protobuf.BytesValue{}",
+    ast: "google.protobuf.BytesValue{}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "google.protobuf.BytesValue{value: b'flambé'}",
+    ast: 'google.protobuf.BytesValue{\n  value:b"flambé"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{single_bytes_wrapper: b'baz'}",
+    ast: 'TestAllTypes{\n  single_bytes_wrapper:b"baz"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_bytes_wrapper: b''}",
+    ast: 'TestAllTypes{\n  single_bytes_wrapper:b""^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_bytes_wrapper: b'bletch'}",
+    ast: 'TestAllTypes{\n  single_bytes_wrapper:b"bletch"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_bytes_wrapper: b''}",
+    ast: 'TestAllTypes{\n  single_bytes_wrapper:b""^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "google.protobuf.ListValue{values: [3.0, 'foo', null]}",
+    ast: 'google.protobuf.ListValue{\n  values:[\n    3^#*expr.Constant_DoubleValue#,\n    "foo"^#*expr.Constant_StringValue#,\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "google.protobuf.ListValue{values: [3.0, 'foo', null]}.values",
+    ast: 'google.protobuf.ListValue{\n  values:[\n    3^#*expr.Constant_DoubleValue#,\n    "foo"^#*expr.Constant_StringValue#,\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.values^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "google.protobuf.ListValue{values: []}",
+    ast: "google.protobuf.ListValue{\n  values:[]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{list_value: [1.0, 'one']}",
+    ast: 'TestAllTypes{\n  list_value:[\n    1^#*expr.Constant_DoubleValue#,\n    "one"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{list_value: []}",
+    ast: "TestAllTypes{\n  list_value:[]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{list_value: [1.0, 'one']}.list_value",
+    ast: 'TestAllTypes{\n  list_value:[\n    1^#*expr.Constant_DoubleValue#,\n    "one"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.list_value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{list_value: []}.list_value",
+    ast: "TestAllTypes{\n  list_value:[]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.list_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.list_value",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.list_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{list_value: [1.0, 'one']}",
+    ast: 'TestAllTypes{\n  list_value:[\n    1^#*expr.Constant_DoubleValue#,\n    "one"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{list_value: []}",
+    ast: "TestAllTypes{\n  list_value:[]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{list_value: [1.0, 'one']}.list_value",
+    ast: 'TestAllTypes{\n  list_value:[\n    1^#*expr.Constant_DoubleValue#,\n    "one"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.list_value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{list_value: []}.list_value",
+    ast: "TestAllTypes{\n  list_value:[]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.list_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.list_value",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.list_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.Struct{fields: {'uno': 1.0, 'dos': 2.0}}",
+    ast: 'google.protobuf.Struct{\n  fields:{\n    "uno"^#*expr.Constant_StringValue#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    "dos"^#*expr.Constant_StringValue#:2^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "google.protobuf.Struct{fields: {'uno': 1.0, 'dos': 2.0}}.fields",
+    ast: 'google.protobuf.Struct{\n  fields:{\n    "uno"^#*expr.Constant_StringValue#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    "dos"^#*expr.Constant_StringValue#:2^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.fields^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "google.protobuf.Struct{fields: {}}",
+    ast: "google.protobuf.Struct{\n  fields:{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{single_struct: {'un': 1.0, 'deux': 2.0}}",
+    ast: 'TestAllTypes{\n  single_struct:{\n    "un"^#*expr.Constant_StringValue#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    "deux"^#*expr.Constant_StringValue#:2^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_struct: {}}",
+    ast: "TestAllTypes{\n  single_struct:{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_struct: {1: 'uno'}}",
+    ast: 'TestAllTypes{\n  single_struct:{\n    1^#*expr.Constant_Int64Value#:"uno"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_struct: {'one': 1.0}}.single_struct",
+    ast: 'TestAllTypes{\n  single_struct:{\n    "one"^#*expr.Constant_StringValue#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_struct^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_struct: {}}.single_struct",
+    ast: "TestAllTypes{\n  single_struct:{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_struct^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_struct",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_struct^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_struct: {'un': 1.0, 'deux': 2.0}}",
+    ast: 'TestAllTypes{\n  single_struct:{\n    "un"^#*expr.Constant_StringValue#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    "deux"^#*expr.Constant_StringValue#:2^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_struct: {}}",
+    ast: "TestAllTypes{\n  single_struct:{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_struct: {1: 'uno'}}",
+    ast: 'TestAllTypes{\n  single_struct:{\n    1^#*expr.Constant_Int64Value#:"uno"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_struct: {'one': 1.0}}.single_struct",
+    ast: 'TestAllTypes{\n  single_struct:{\n    "one"^#*expr.Constant_StringValue#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_struct^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_struct: {}}.single_struct",
+    ast: "TestAllTypes{\n  single_struct:{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_struct^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_struct",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_struct^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "Value{null_value: NullValue.NULL_VALUE}",
+    ast: "Value{\n  null_value:NullValue^#*expr.Expr_IdentExpr#.NULL_VALUE^#*expr.Expr_SelectExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "Value{null_value: NullValue.NULL_VALUE}.null_value",
+    ast: "Value{\n  null_value:NullValue^#*expr.Expr_IdentExpr#.NULL_VALUE^#*expr.Expr_SelectExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.null_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.Value{}",
+    ast: "google.protobuf.Value{}^#*expr.Expr_StructExpr#",
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{single_value: null}",
+    ast: "TestAllTypes{\n  single_value:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: null}.single_value",
+    ast: "TestAllTypes{\n  single_value:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_value",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: null}",
+    ast: "TestAllTypes{\n  single_value:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: null}.single_value",
+    ast: "TestAllTypes{\n  single_value:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_value",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.Value{number_value: 12.5}",
+    ast: "google.protobuf.Value{\n  number_value:12.5^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "google.protobuf.Value{number_value: 12.5}.number_value",
+    ast: "google.protobuf.Value{\n  number_value:12.5^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.number_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.Value{number_value: 0.0}",
+    ast: "google.protobuf.Value{\n  number_value:0^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{single_value: 7e23}",
+    ast: "TestAllTypes{\n  single_value:7e+23^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: 0.0}",
+    ast: "TestAllTypes{\n  single_value:0^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: 7e23}.single_value",
+    ast: "TestAllTypes{\n  single_value:7e+23^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: 0.0}.single_value",
+    ast: "TestAllTypes{\n  single_value:0^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: 7e23}",
+    ast: "TestAllTypes{\n  single_value:7e+23^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: 0.0}",
+    ast: "TestAllTypes{\n  single_value:0^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: 7e23}.single_value",
+    ast: "TestAllTypes{\n  single_value:7e+23^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: 0.0}.single_value",
+    ast: "TestAllTypes{\n  single_value:0^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.Value{string_value: 'foo'}",
+    ast: 'google.protobuf.Value{\n  string_value:"foo"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "google.protobuf.Value{string_value: 'foo'}.string_value",
+    ast: 'google.protobuf.Value{\n  string_value:"foo"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.string_value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "google.protobuf.Value{string_value: ''}",
+    ast: 'google.protobuf.Value{\n  string_value:""^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{single_value: 'baz'}",
+    ast: 'TestAllTypes{\n  single_value:"baz"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: ''}",
+    ast: 'TestAllTypes{\n  single_value:""^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: 'bletch'}.single_value",
+    ast: 'TestAllTypes{\n  single_value:"bletch"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: ''}.single_value",
+    ast: 'TestAllTypes{\n  single_value:""^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: 'baz'}",
+    ast: 'TestAllTypes{\n  single_value:"baz"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: ''}",
+    ast: 'TestAllTypes{\n  single_value:""^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: 'bletch'}.single_value",
+    ast: 'TestAllTypes{\n  single_value:"bletch"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: ''}.single_value",
+    ast: 'TestAllTypes{\n  single_value:""^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "google.protobuf.Value{bool_value: true}",
+    ast: "google.protobuf.Value{\n  bool_value:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "google.protobuf.Value{bool_value: true}.bool_value",
+    ast: "google.protobuf.Value{\n  bool_value:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.bool_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.Value{bool_value: false}",
+    ast: "google.protobuf.Value{\n  bool_value:false^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{single_value: true}",
+    ast: "TestAllTypes{\n  single_value:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: false}",
+    ast: "TestAllTypes{\n  single_value:false^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: true}.single_value",
+    ast: "TestAllTypes{\n  single_value:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: false}.single_value",
+    ast: "TestAllTypes{\n  single_value:false^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: true}",
+    ast: "TestAllTypes{\n  single_value:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: false}",
+    ast: "TestAllTypes{\n  single_value:false^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: true}.single_value",
+    ast: "TestAllTypes{\n  single_value:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: false}.single_value",
+    ast: "TestAllTypes{\n  single_value:false^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.Value{struct_value: {'a': 1.0, 'b': 'two'}}",
+    ast: 'google.protobuf.Value{\n  struct_value:{\n    "a"^#*expr.Constant_StringValue#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    "b"^#*expr.Constant_StringValue#:"two"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "google.protobuf.Value{struct_value: {'a': 1.0, 'b': 'two'}}.struct_value",
+    ast: 'google.protobuf.Value{\n  struct_value:{\n    "a"^#*expr.Constant_StringValue#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    "b"^#*expr.Constant_StringValue#:"two"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.struct_value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "google.protobuf.Value{struct_value: {}}",
+    ast: "google.protobuf.Value{\n  struct_value:{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{single_value: {'un': 1.0, 'deux': 2.0}}",
+    ast: 'TestAllTypes{\n  single_value:{\n    "un"^#*expr.Constant_StringValue#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    "deux"^#*expr.Constant_StringValue#:2^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: {}}",
+    ast: "TestAllTypes{\n  single_value:{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: {'i': true}}.single_value",
+    ast: 'TestAllTypes{\n  single_value:{\n    "i"^#*expr.Constant_StringValue#:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: {}}.single_value",
+    ast: "TestAllTypes{\n  single_value:{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: {'un': 1.0, 'deux': 2.0}}",
+    ast: 'TestAllTypes{\n  single_value:{\n    "un"^#*expr.Constant_StringValue#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    "deux"^#*expr.Constant_StringValue#:2^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: {}}",
+    ast: "TestAllTypes{\n  single_value:{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: {'i': true}}.single_value",
+    ast: 'TestAllTypes{\n  single_value:{\n    "i"^#*expr.Constant_StringValue#:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: {}}.single_value",
+    ast: "TestAllTypes{\n  single_value:{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.Value{list_value: ['a', 3.0]}",
+    ast: 'google.protobuf.Value{\n  list_value:[\n    "a"^#*expr.Constant_StringValue#,\n    3^#*expr.Constant_DoubleValue#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "google.protobuf.Value{list_value: []}.list_value",
+    ast: "google.protobuf.Value{\n  list_value:[]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.list_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.Value{list_value: []}",
+    ast: "google.protobuf.Value{\n  list_value:[]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{single_value: ['un', 1.0]}",
+    ast: 'TestAllTypes{\n  single_value:[\n    "un"^#*expr.Constant_StringValue#,\n    1^#*expr.Constant_DoubleValue#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: []}",
+    ast: "TestAllTypes{\n  single_value:[]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: ['i', true]}.single_value",
+    ast: 'TestAllTypes{\n  single_value:[\n    "i"^#*expr.Constant_StringValue#,\n    true^#*expr.Constant_BoolValue#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: []}.single_value",
+    ast: "TestAllTypes{\n  single_value:[]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: ['un', 1.0]}",
+    ast: 'TestAllTypes{\n  single_value:[\n    "un"^#*expr.Constant_StringValue#,\n    1^#*expr.Constant_DoubleValue#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: []}",
+    ast: "TestAllTypes{\n  single_value:[]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: ['i', true]}.single_value",
+    ast: 'TestAllTypes{\n  single_value:[\n    "i"^#*expr.Constant_StringValue#,\n    true^#*expr.Constant_BoolValue#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: []}.single_value",
+    ast: "TestAllTypes{\n  single_value:[]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\x08\\x96\\x01'}",
+    ast: 'google.protobuf.Any{\n  type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n  value:b"\\b\\x96\\x01"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\x08\\x96\\x01'}.type_url",
+    ast: 'google.protobuf.Any{\n  type_url:"type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n  value:b"\\b\\x96\\x01"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.type_url^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "google.protobuf.Any{}",
+    ast: "google.protobuf.Any{}^#*expr.Expr_StructExpr#",
+  },
+  { expr: "x", ast: "x^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "TestAllTypes{single_any: TestAllTypes{single_int32: 150}}",
+    ast: "TestAllTypes{\n  single_any:TestAllTypes{\n    single_int32:150^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: TestAllTypes{single_int32: 150}}.single_any",
+    ast: "TestAllTypes{\n  single_any:TestAllTypes{\n    single_int32:150^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_any^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: TestAllTypes{single_int32: 150}}",
+    ast: "TestAllTypes{\n  single_any:TestAllTypes{\n    single_int32:150^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: TestAllTypes{single_int32: 150}}.single_any",
+    ast: "TestAllTypes{\n  single_any:TestAllTypes{\n    single_int32:150^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_any^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: [{'almost': 'done'}]}.single_any",
+    ast: 'TestAllTypes{\n  single_any:[\n    {\n      "almost"^#*expr.Constant_StringValue#:"done"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_any^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "base64.encode(b'hello')",
+    ast: 'base64^#*expr.Expr_IdentExpr#.encode(\n  b"hello"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "base64.decode('aGVsbG8=')",
+    ast: 'base64^#*expr.Expr_IdentExpr#.decode(\n  "aGVsbG8="^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "base64.decode('aGVsbG8')",
+    ast: 'base64^#*expr.Expr_IdentExpr#.decode(\n  "aGVsbG8"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "base64.decode(base64.encode(b'Hello World!'))",
+    ast: 'base64^#*expr.Expr_IdentExpr#.decode(\n  base64^#*expr.Expr_IdentExpr#.encode(\n    b"Hello World!"^#*expr.Constant_BytesValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "GlobalEnum.GAZ",
+    ast: "GlobalEnum^#*expr.Expr_IdentExpr#.GAZ^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes.NestedEnum.BAR",
+    ast: "TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAR^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "GlobalEnum.GOO",
+    ast: "GlobalEnum^#*expr.Expr_IdentExpr#.GOO^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "GlobalEnum.GAR == 1",
+    ast: "_==_(\n  GlobalEnum^#*expr.Expr_IdentExpr#.GAR^#*expr.Expr_SelectExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes.NestedEnum.BAR + 3",
+    ast: "_+_(\n  TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAR^#*expr.Expr_SelectExpr#,\n  3^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "type(GlobalEnum.GOO)",
+    ast: "type(\n  GlobalEnum^#*expr.Expr_IdentExpr#.GOO^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "type(TestAllTypes.NestedEnum.BAZ)",
+    ast: "type(\n  TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAZ^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.standalone_enum",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.standalone_enum^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "type(TestAllTypes{}.standalone_enum)",
+    ast: "type(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.standalone_enum^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.BAZ}",
+    ast: "TestAllTypes{\n  standalone_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAZ^#*expr.Expr_SelectExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: 1}",
+    ast: "TestAllTypes{\n  standalone_enum:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: 5000000000}",
+    ast: "TestAllTypes{\n  standalone_enum:5000000000^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: -7000000000}",
+    ast: "TestAllTypes{\n  standalone_enum:-7000000000^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.repeated_nested_enum",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.repeated_nested_enum^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{  repeated_nested_enum: [    TestAllTypes.NestedEnum.FOO,    TestAllTypes.NestedEnum.BAR]}",
+    ast: "TestAllTypes{\n  repeated_nested_enum:[\n    TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.FOO^#*expr.Expr_SelectExpr#,\n    TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAR^#*expr.Expr_SelectExpr#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "0 in TestAllTypes{  repeated_nested_enum: [    TestAllTypes.NestedEnum.FOO,    TestAllTypes.NestedEnum.BAR]}.repeated_nested_enum",
+    ast: "@in(\n  0^#*expr.Constant_Int64Value#,\n  TestAllTypes{\n    repeated_nested_enum:[\n      TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.FOO^#*expr.Expr_SelectExpr#,\n      TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAR^#*expr.Expr_SelectExpr#\n    ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#.repeated_nested_enum^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.FOO}.standalone_enum in [0]",
+    ast: "@in(\n  TestAllTypes{\n    standalone_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.FOO^#*expr.Expr_SelectExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#.standalone_enum^#*expr.Expr_SelectExpr#,\n  [\n    0^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "GlobalEnum.GAZ",
+    ast: "GlobalEnum^#*expr.Expr_IdentExpr#.GAZ^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes.NestedEnum.BAR",
+    ast: "TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAR^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "GlobalEnum.GOO",
+    ast: "GlobalEnum^#*expr.Expr_IdentExpr#.GOO^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "GlobalEnum.GAR == 1",
+    ast: "_==_(\n  GlobalEnum^#*expr.Expr_IdentExpr#.GAR^#*expr.Expr_SelectExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes.NestedEnum.BAR + 3",
+    ast: "_+_(\n  TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAR^#*expr.Expr_SelectExpr#,\n  3^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "type(GlobalEnum.GOO)",
+    ast: "type(\n  GlobalEnum^#*expr.Expr_IdentExpr#.GOO^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "type(TestAllTypes.NestedEnum.BAZ)",
+    ast: "type(\n  TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAZ^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.standalone_enum",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.standalone_enum^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "x.standalone_enum",
+    ast: "x^#*expr.Expr_IdentExpr#.standalone_enum^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "x.standalone_enum",
+    ast: "x^#*expr.Expr_IdentExpr#.standalone_enum^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "x.standalone_enum",
+    ast: "x^#*expr.Expr_IdentExpr#.standalone_enum^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "type(TestAllTypes{}.standalone_enum)",
+    ast: "type(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.standalone_enum^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.BAZ}",
+    ast: "TestAllTypes{\n  standalone_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAZ^#*expr.Expr_SelectExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: 1}",
+    ast: "TestAllTypes{\n  standalone_enum:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: 99}",
+    ast: "TestAllTypes{\n  standalone_enum:99^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: -1}",
+    ast: "TestAllTypes{\n  standalone_enum:-1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: 5000000000}",
+    ast: "TestAllTypes{\n  standalone_enum:5000000000^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: -7000000000}",
+    ast: "TestAllTypes{\n  standalone_enum:-7000000000^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.repeated_nested_enum",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.repeated_nested_enum^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{  repeated_nested_enum: [    TestAllTypes.NestedEnum.FOO,    TestAllTypes.NestedEnum.BAR]}",
+    ast: "TestAllTypes{\n  repeated_nested_enum:[\n    TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.FOO^#*expr.Expr_SelectExpr#,\n    TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAR^#*expr.Expr_SelectExpr#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "0 in TestAllTypes{  repeated_nested_enum: [    TestAllTypes.NestedEnum.FOO,    TestAllTypes.NestedEnum.BAR]}.repeated_nested_enum",
+    ast: "@in(\n  0^#*expr.Constant_Int64Value#,\n  TestAllTypes{\n    repeated_nested_enum:[\n      TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.FOO^#*expr.Expr_SelectExpr#,\n      TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAR^#*expr.Expr_SelectExpr#\n    ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#.repeated_nested_enum^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.FOO}.standalone_enum in [0]",
+    ast: "@in(\n  TestAllTypes{\n    standalone_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.FOO^#*expr.Expr_SelectExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#.standalone_enum^#*expr.Expr_SelectExpr#,\n  [\n    0^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "GlobalEnum.GAZ",
+    ast: "GlobalEnum^#*expr.Expr_IdentExpr#.GAZ^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes.NestedEnum.BAR",
+    ast: "TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAR^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "GlobalEnum.GOO",
+    ast: "GlobalEnum^#*expr.Expr_IdentExpr#.GOO^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "GlobalEnum.GAR == GlobalEnum.GAR",
+    ast: "_==_(\n  GlobalEnum^#*expr.Expr_IdentExpr#.GAR^#*expr.Expr_SelectExpr#,\n  GlobalEnum^#*expr.Expr_IdentExpr#.GAR^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "GlobalEnum.GAR == GlobalEnum.GAZ",
+    ast: "_==_(\n  GlobalEnum^#*expr.Expr_IdentExpr#.GAR^#*expr.Expr_SelectExpr#,\n  GlobalEnum^#*expr.Expr_IdentExpr#.GAZ^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "type(GlobalEnum.GOO)",
+    ast: "type(\n  GlobalEnum^#*expr.Expr_IdentExpr#.GOO^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "type(TestAllTypes.NestedEnum.BAZ)",
+    ast: "type(\n  TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAZ^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.standalone_enum",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.standalone_enum^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "type(TestAllTypes{}.standalone_enum)",
+    ast: "type(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.standalone_enum^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.BAZ}",
+    ast: "TestAllTypes{\n  standalone_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAZ^#*expr.Expr_SelectExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum(1)}",
+    ast: "TestAllTypes{\n  standalone_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "int(GlobalEnum.GAZ)",
+    ast: "int(\n  GlobalEnum^#*expr.Expr_IdentExpr#.GAZ^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(x)",
+    ast: "int(\n  x^#*expr.Expr_IdentExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes.NestedEnum(2)",
+    ast: "TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum(\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes.NestedEnum(20000)",
+    ast: "TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum(\n  20000^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "GlobalEnum(-33)",
+    ast: "GlobalEnum(\n  -33^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes.NestedEnum(5000000000)",
+    ast: "TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum(\n  5000000000^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes.NestedEnum(-7000000000)",
+    ast: "TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum(\n  -7000000000^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes.NestedEnum('BAZ')",
+    ast: 'TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum(\n  "BAZ"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes.NestedEnum('BLETCH')",
+    ast: 'TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum(\n  "BLETCH"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "GlobalEnum.GAZ",
+    ast: "GlobalEnum^#*expr.Expr_IdentExpr#.GAZ^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes.NestedEnum.BAR",
+    ast: "TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAR^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "GlobalEnum.GOO",
+    ast: "GlobalEnum^#*expr.Expr_IdentExpr#.GOO^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "GlobalEnum.GAR == GlobalEnum.GAR",
+    ast: "_==_(\n  GlobalEnum^#*expr.Expr_IdentExpr#.GAR^#*expr.Expr_SelectExpr#,\n  GlobalEnum^#*expr.Expr_IdentExpr#.GAR^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "GlobalEnum.GAR == GlobalEnum.GAZ",
+    ast: "_==_(\n  GlobalEnum^#*expr.Expr_IdentExpr#.GAR^#*expr.Expr_SelectExpr#,\n  GlobalEnum^#*expr.Expr_IdentExpr#.GAZ^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "type(GlobalEnum.GOO)",
+    ast: "type(\n  GlobalEnum^#*expr.Expr_IdentExpr#.GOO^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "type(TestAllTypes.NestedEnum.BAZ)",
+    ast: "type(\n  TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAZ^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.standalone_enum",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.standalone_enum^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "x.standalone_enum",
+    ast: "x^#*expr.Expr_IdentExpr#.standalone_enum^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "x.standalone_enum",
+    ast: "x^#*expr.Expr_IdentExpr#.standalone_enum^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "x.standalone_enum",
+    ast: "x^#*expr.Expr_IdentExpr#.standalone_enum^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "type(TestAllTypes{}.standalone_enum)",
+    ast: "type(\n  TestAllTypes{}^#*expr.Expr_StructExpr#.standalone_enum^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.BAZ}",
+    ast: "TestAllTypes{\n  standalone_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAZ^#*expr.Expr_SelectExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum(1)}",
+    ast: "TestAllTypes{\n  standalone_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum(99)}",
+    ast: "TestAllTypes{\n  standalone_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum(\n    99^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{standalone_enum: TestAllTypes.NestedEnum(-1)}",
+    ast: "TestAllTypes{\n  standalone_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum(\n    -1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "int(GlobalEnum.GAZ)",
+    ast: "int(\n  GlobalEnum^#*expr.Expr_IdentExpr#.GAZ^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(x)",
+    ast: "int(\n  x^#*expr.Expr_IdentExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "int(x.standalone_enum)",
+    ast: "int(\n  x^#*expr.Expr_IdentExpr#.standalone_enum^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes.NestedEnum(2)",
+    ast: "TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum(\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes.NestedEnum(20000)",
+    ast: "TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum(\n  20000^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "GlobalEnum(-33)",
+    ast: "GlobalEnum(\n  -33^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes.NestedEnum(5000000000)",
+    ast: "TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum(\n  5000000000^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes.NestedEnum(-7000000000)",
+    ast: "TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum(\n  -7000000000^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes.NestedEnum('BAZ')",
+    ast: 'TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum(\n  "BAZ"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes.NestedEnum('BLETCH')",
+    ast: 'TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum(\n  "BLETCH"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{0:1,2:2,5:true}[5]",
+    ast: "_[_](\n  {\n    0^#*expr.Constant_Int64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    2^#*expr.Constant_Int64Value#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    5^#*expr.Constant_Int64Value#:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  5^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{0u:1u,2u:'happy',5u:3u}[2u]",
+    ast: '_[_](\n  {\n    0u^#*expr.Constant_Uint64Value#:1u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#,\n    2u^#*expr.Constant_Uint64Value#:"happy"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    5u^#*expr.Constant_Uint64Value#:3u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  2u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'name':100u}['name']",
+    ast: '_[_](\n  {\n    "name"^#*expr.Constant_StringValue#:100u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  "name"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{true:5}[true]",
+    ast: "_[_](\n  {\n    true^#*expr.Constant_BoolValue#:5^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{true:1,2:2,5u:3}[true]",
+    ast: "_[_](\n  {\n    true^#*expr.Constant_BoolValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    2^#*expr.Constant_Int64Value#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    5u^#*expr.Constant_Uint64Value#:3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{1u: 1.0, 2: 2.0, 3u: 3.0}[3.0]",
+    ast: "_[_](\n  {\n    1u^#*expr.Constant_Uint64Value#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    2^#*expr.Constant_Int64Value#:2^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    3u^#*expr.Constant_Uint64Value#:3^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  3^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{1u: 1.0, 2: 2.0, 3u: 3.0}[3.1]",
+    ast: "_[_](\n  {\n    1u^#*expr.Constant_Uint64Value#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    2^#*expr.Constant_Int64Value#:2^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    3u^#*expr.Constant_Uint64Value#:3^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  3.1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{1u: 1.0, 2: 2.0, 3u: 3.0}[2u]",
+    ast: "_[_](\n  {\n    1u^#*expr.Constant_Uint64Value#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    2^#*expr.Constant_Int64Value#:2^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    3u^#*expr.Constant_Uint64Value#:3^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  2u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{1u: 1.0, 2: 2.0, 3u: 3.0}[1]",
+    ast: "_[_](\n  {\n    1u^#*expr.Constant_Uint64Value#:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    2^#*expr.Constant_Int64Value#:2^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    3u^#*expr.Constant_Uint64Value#:3^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "x.name",
+    ast: "x^#*expr.Expr_IdentExpr#.name^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "{0:1,2:2,5:3}[1]",
+    ast: "_[_](\n  {\n    0^#*expr.Constant_Int64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    2^#*expr.Constant_Int64Value#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    5^#*expr.Constant_Int64Value#:3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn({0:1,2:2,5:3}[1]) || false",
+    ast: "_||_(\n  dyn(\n    _[_](\n      {\n        0^#*expr.Constant_Int64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n        2^#*expr.Constant_Int64Value#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n        5^#*expr.Constant_Int64Value#:3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n      }^#*expr.Expr_StructExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn({0:1,2:2,5:3}[1]) || true",
+    ast: "_||_(\n  dyn(\n    _[_](\n      {\n        0^#*expr.Constant_Int64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n        2^#*expr.Constant_Int64Value#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n        5^#*expr.Constant_Int64Value#:3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n      }^#*expr.Expr_StructExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn({0:1,2:2,5:3}[1]) \u0026\u0026 false",
+    ast: "_\u0026\u0026_(\n  dyn(\n    _[_](\n      {\n        0^#*expr.Constant_Int64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n        2^#*expr.Constant_Int64Value#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n        5^#*expr.Constant_Int64Value#:3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n      }^#*expr.Expr_StructExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn({0:1,2:2,5:3}[1]) \u0026\u0026 true",
+    ast: "_\u0026\u0026_(\n  dyn(\n    _[_](\n      {\n        0^#*expr.Constant_Int64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n        2^#*expr.Constant_Int64Value#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n        5^#*expr.Constant_Int64Value#:3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n      }^#*expr.Expr_StructExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{0:1,2:2,5:3}[dyn(b'')]",
+    ast: '_[_](\n  {\n    0^#*expr.Constant_Int64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    2^#*expr.Constant_Int64Value#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    5^#*expr.Constant_Int64Value#:3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  dyn(\n    b""^#*expr.Constant_BytesValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn({0:1,2:2,5:3}[dyn(b'')]) || false",
+    ast: '_||_(\n  dyn(\n    _[_](\n      {\n        0^#*expr.Constant_Int64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n        2^#*expr.Constant_Int64Value#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n        5^#*expr.Constant_Int64Value#:3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n      }^#*expr.Expr_StructExpr#,\n      dyn(\n        b""^#*expr.Constant_BytesValue#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn({0:1,2:2,5:3}[dyn(b'')]) || true",
+    ast: '_||_(\n  dyn(\n    _[_](\n      {\n        0^#*expr.Constant_Int64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n        2^#*expr.Constant_Int64Value#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n        5^#*expr.Constant_Int64Value#:3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n      }^#*expr.Expr_StructExpr#,\n      dyn(\n        b""^#*expr.Constant_BytesValue#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn({0:1,2:2,5:3}[dyn(b'')]) \u0026\u0026 false",
+    ast: '_\u0026\u0026_(\n  dyn(\n    _[_](\n      {\n        0^#*expr.Constant_Int64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n        2^#*expr.Constant_Int64Value#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n        5^#*expr.Constant_Int64Value#:3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n      }^#*expr.Expr_StructExpr#,\n      dyn(\n        b""^#*expr.Constant_BytesValue#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn({0:1,2:2,5:3}[dyn(b'')]) \u0026\u0026 true",
+    ast: '_\u0026\u0026_(\n  dyn(\n    _[_](\n      {\n        0^#*expr.Constant_Int64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n        2^#*expr.Constant_Int64Value#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n        5^#*expr.Constant_Int64Value#:3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n      }^#*expr.Expr_StructExpr#,\n      dyn(\n        b""^#*expr.Constant_BytesValue#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "x.name",
+    ast: "x^#*expr.Expr_IdentExpr#.name^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "dyn(x.name) || false",
+    ast: "_||_(\n  dyn(\n    x^#*expr.Expr_IdentExpr#.name^#*expr.Expr_SelectExpr#\n  )^#*expr.Expr_CallExpr#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(x.name) || true",
+    ast: "_||_(\n  dyn(\n    x^#*expr.Expr_IdentExpr#.name^#*expr.Expr_SelectExpr#\n  )^#*expr.Expr_CallExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(x.name) \u0026\u0026 false",
+    ast: "_\u0026\u0026_(\n  dyn(\n    x^#*expr.Expr_IdentExpr#.name^#*expr.Expr_SelectExpr#\n  )^#*expr.Expr_CallExpr#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(x.name) \u0026\u0026 true",
+    ast: "_\u0026\u0026_(\n  dyn(\n    x^#*expr.Expr_IdentExpr#.name^#*expr.Expr_SelectExpr#\n  )^#*expr.Expr_CallExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{true:null}[true]",
+    ast: "_[_](\n  {\n    true^#*expr.Constant_BoolValue#:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{27:false}[27]",
+    ast: "_[_](\n  {\n    27^#*expr.Constant_Int64Value#:false^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  27^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{'n':'x'}['n']",
+    ast: '_[_](\n  {\n    "n"^#*expr.Constant_StringValue#:"x"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  "n"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{3:15.15}[3]",
+    ast: "_[_](\n  {\n    3^#*expr.Constant_Int64Value#:15.15^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  3^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{0u:1u,2u:2u,5u:3u}[0u]",
+    ast: "_[_](\n  {\n    0u^#*expr.Constant_Uint64Value#:1u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#,\n    2u^#*expr.Constant_Uint64Value#:2u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#,\n    5u^#*expr.Constant_Uint64Value#:3u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{true:1,false:2}[true]",
+    ast: "_[_](\n  {\n    true^#*expr.Constant_BoolValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    false^#*expr.Constant_BoolValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{0:b''}[0]",
+    ast: '_[_](\n  {\n    0^#*expr.Constant_Int64Value#:b""^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{0u:[1]}[0u]",
+    ast: "_[_](\n  {\n    0u^#*expr.Constant_Uint64Value#:[\n      1^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{'map': {'k': 'v'}}['map']",
+    ast: '_[_](\n  {\n    "map"^#*expr.Constant_StringValue#:{\n      "k"^#*expr.Constant_StringValue#:"v"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  "map"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'map': {'k': 'v'}, 'list': [1]}['map']",
+    ast: '_[_](\n  {\n    "map"^#*expr.Constant_StringValue#:{\n      "k"^#*expr.Constant_StringValue#:"v"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#,\n    "list"^#*expr.Constant_StringValue#:[\n      1^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  "map"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "has({'a': 1, 'b': 2}.a)",
+    ast: '{\n  "a"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n  "b"^#*expr.Constant_StringValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.a~test-only~^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "has({'a': 1, 'b': 2}.c)",
+    ast: '{\n  "a"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n  "b"^#*expr.Constant_StringValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.c~test-only~^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "has({}.a)",
+    ast: "{}^#*expr.Expr_StructExpr#.a~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "{'/api/v1': true, '/api/v2': false}.`/api/v1`",
+    error:
+      "ERROR: \u003cinput\u003e:1:37: unsupported syntax: '`'\n | {'/api/v1': true, '/api/v2': false}.`/api/v1`\n | ....................................^",
+  },
+  {
+    expr: "{'content-type': 'application/json', 'content-length': 145}.`content-type` == 'application/json'",
+    error:
+      "ERROR: \u003cinput\u003e:1:61: unsupported syntax: '`'\n | {'content-type': 'application/json', 'content-length': 145}.`content-type` == 'application/json'\n | ............................................................^",
+  },
+  {
+    expr: "{'foo.txt': 32, 'bar.csv': 1024}.`foo.txt`",
+    error:
+      "ERROR: \u003cinput\u003e:1:34: unsupported syntax: '`'\n | {'foo.txt': 32, 'bar.csv': 1024}.`foo.txt`\n | .................................^",
+  },
+  {
+    expr: "has({'/api/v1': true, '/api/v2': false}.`/api/v3`)",
+    error:
+      "ERROR: \u003cinput\u003e:1:41: unsupported syntax: '`'\n | has({'/api/v1': true, '/api/v2': false}.`/api/v3`)\n | ........................................^",
+  },
+  {
+    expr: "has({'content-type': 'application/json', 'content-length': 145}.`content-type`)",
+    error:
+      "ERROR: \u003cinput\u003e:1:65: unsupported syntax: '`'\n | has({'content-type': 'application/json', 'content-length': 145}.`content-type`)\n | ................................................................^",
+  },
+  {
+    expr: "has({'foo.txt': 32, 'bar.csv': 1024}.`foo.txt`)",
+    error:
+      "ERROR: \u003cinput\u003e:1:38: unsupported syntax: '`'\n | has({'foo.txt': 32, 'bar.csv': 1024}.`foo.txt`)\n | .....................................^",
+  },
+  {
+    expr: "a.b.c",
+    ast: "a^#*expr.Expr_IdentExpr#.b^#*expr.Expr_SelectExpr#.c^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "a.b.c",
+    ast: "a^#*expr.Expr_IdentExpr#.b^#*expr.Expr_SelectExpr#.c^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "a.b.c",
+    ast: "a^#*expr.Expr_IdentExpr#.b^#*expr.Expr_SelectExpr#.c^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "a.b.pancakes",
+    ast: "a^#*expr.Expr_IdentExpr#.b^#*expr.Expr_SelectExpr#.pancakes^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "a.pancakes",
+    ast: "a^#*expr.Expr_IdentExpr#.pancakes^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "a.b.c",
+    ast: "a^#*expr.Expr_IdentExpr#.b^#*expr.Expr_SelectExpr#.c^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "{3.3:15.15, 1.0: 5}[1.0]",
+    ast: "_[_](\n  {\n    3.3^#*expr.Constant_DoubleValue#:15.15^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n    1^#*expr.Constant_DoubleValue#:5^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{null:false}[null]",
+    ast: "_[_](\n  {\n    null^#*expr.Constant_NullValue#:false^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{true:1,false:2,true:3}[true]",
+    ast: "_[_](\n  {\n    true^#*expr.Constant_BoolValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    false^#*expr.Constant_BoolValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    true^#*expr.Constant_BoolValue#:3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{0: 1, 0u: 2}[0.0]",
+    ast: "_[_](\n  {\n    0^#*expr.Constant_Int64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    0u^#*expr.Constant_Uint64Value#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  0^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "7 in {}",
+    ast: "@in(\n  7^#*expr.Constant_Int64Value#,\n  {}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "true in {true: 1}",
+    ast: "@in(\n  true^#*expr.Constant_BoolValue#,\n  {\n    true^#*expr.Constant_BoolValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "'George' in {'John': 'smart', 'Paul': 'cute', 'George': 'quiet', 'Ringo': 'funny'}",
+    ast: '@in(\n  "George"^#*expr.Constant_StringValue#,\n  {\n    "John"^#*expr.Constant_StringValue#:"smart"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    "Paul"^#*expr.Constant_StringValue#:"cute"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    "George"^#*expr.Constant_StringValue#:"quiet"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    "Ringo"^#*expr.Constant_StringValue#:"funny"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'spider' in {'ant': 6, 'fly': 6, 'centipede': 100}",
+    ast: '@in(\n  "spider"^#*expr.Constant_StringValue#,\n  {\n    "ant"^#*expr.Constant_StringValue#:6^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    "fly"^#*expr.Constant_StringValue#:6^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    "centipede"^#*expr.Constant_StringValue#:100^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "3.0 in {1: 1, 2: 2, 3u: 3} \u0026\u0026 2u in {1u: 1, 2: 2} \u0026\u0026 1 in {1u: 1, 2: 2}",
+    ast: "_\u0026\u0026_(\n  @in(\n    3^#*expr.Constant_DoubleValue#,\n    {\n      1^#*expr.Constant_Int64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n      2^#*expr.Constant_Int64Value#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n      3u^#*expr.Constant_Uint64Value#:3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#,\n  @in(\n    2u^#*expr.Constant_Uint64Value#,\n    {\n      1u^#*expr.Constant_Uint64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n      2^#*expr.Constant_Int64Value#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#,\n  @in(\n    1^#*expr.Constant_Int64Value#,\n    {\n      1u^#*expr.Constant_Uint64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n      2^#*expr.Constant_Int64Value#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "3.1 in {1: 1, 2: 2, 3u: 3}",
+    ast: "@in(\n  3.1^#*expr.Constant_DoubleValue#,\n  {\n    1^#*expr.Constant_Int64Value#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    2^#*expr.Constant_Int64Value#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    3u^#*expr.Constant_Uint64Value#:3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "4.25 + 15.25",
+    ast: "_+_(\n  4.25^#*expr.Constant_DoubleValue#,\n  15.25^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "17.75 + (-7.75)",
+    ast: "_+_(\n  17.75^#*expr.Constant_DoubleValue#,\n  -7.75^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-4.125 + (-2.125)",
+    ast: "_+_(\n  -4.125^#*expr.Constant_DoubleValue#,\n  -2.125^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "42.0 - 12.0",
+    ast: "_-_(\n  42^#*expr.Constant_DoubleValue#,\n  12^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "42.875 - (-22.0)",
+    ast: "_-_(\n  42.875^#*expr.Constant_DoubleValue#,\n  -22^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-4.875 - (-0.125)",
+    ast: "_-_(\n  -4.875^#*expr.Constant_DoubleValue#,\n  -0.125^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "42.5 * 0.2",
+    ast: "_*_(\n  42.5^#*expr.Constant_DoubleValue#,\n  0.2^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "40.75 * (-2.25)",
+    ast: "_*_(\n  40.75^#*expr.Constant_DoubleValue#,\n  -2.25^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-3.0 * (-2.5)",
+    ast: "_*_(\n  -3^#*expr.Constant_DoubleValue#,\n  -2.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0.0625 / 0.002",
+    ast: "_/_(\n  0.0625^#*expr.Constant_DoubleValue#,\n  0.002^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-2.0 / 2.0",
+    ast: "_/_(\n  -2^#*expr.Constant_DoubleValue#,\n  2^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-8.875 / (-0.0625)",
+    ast: "_/_(\n  -8.875^#*expr.Constant_DoubleValue#,\n  -0.0625^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "47.5 % 5.5",
+    ast: "_%_(\n  47.5^#*expr.Constant_DoubleValue#,\n  5.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-(4.5)",
+    ast: "-_(\n  4.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-(-1.25)",
+    ast: "-_(\n  -1.25^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-(0.0)",
+    ast: "-_(\n  0^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "15.75 / 0.0",
+    ast: "_/_(\n  15.75^#*expr.Constant_DoubleValue#,\n  0^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "15.36 * 0.0",
+    ast: "_*_(\n  15.36^#*expr.Constant_DoubleValue#,\n  0^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0.0 + 1.75",
+    ast: "_+_(\n  0^#*expr.Constant_DoubleValue#,\n  1.75^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: " 2.5 + 0.0",
+    ast: "_+_(\n  2.5^#*expr.Constant_DoubleValue#,\n  0^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "7.5 + 1.5 == 1.5 + 7.5",
+    ast: "_==_(\n  _+_(\n    7.5^#*expr.Constant_DoubleValue#,\n    1.5^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  _+_(\n    1.5^#*expr.Constant_DoubleValue#,\n    7.5^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "5.625 + (15.75 + 2.0) == (5.625 + 15.75) + 2.0",
+    ast: "_==_(\n  _+_(\n    5.625^#*expr.Constant_DoubleValue#,\n    _+_(\n      15.75^#*expr.Constant_DoubleValue#,\n      2^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  _+_(\n    _+_(\n      5.625^#*expr.Constant_DoubleValue#,\n      15.75^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#,\n    2^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1.0 * 45.25",
+    ast: "_*_(\n  1^#*expr.Constant_DoubleValue#,\n  45.25^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-25.25 * 1.0",
+    ast: "_*_(\n  -25.25^#*expr.Constant_DoubleValue#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1.5 * 25.875 == 25.875 * 1.5",
+    ast: "_==_(\n  _*_(\n    1.5^#*expr.Constant_DoubleValue#,\n    25.875^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  _*_(\n    25.875^#*expr.Constant_DoubleValue#,\n    1.5^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1.5 * (23.625 * 0.75) == (1.5 * 23.625) * 0.75",
+    ast: "_==_(\n  _*_(\n    1.5^#*expr.Constant_DoubleValue#,\n    _*_(\n      23.625^#*expr.Constant_DoubleValue#,\n      0.75^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  _*_(\n    _*_(\n      1.5^#*expr.Constant_DoubleValue#,\n      23.625^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#,\n    0.75^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "5.75 * (1.5 + 2.5)  == 5.75 * 1.5 + 5.75 * 2.5",
+    ast: "_==_(\n  _*_(\n    5.75^#*expr.Constant_DoubleValue#,\n    _+_(\n      1.5^#*expr.Constant_DoubleValue#,\n      2.5^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  _+_(\n    _*_(\n      5.75^#*expr.Constant_DoubleValue#,\n      1.5^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#,\n    _*_(\n      5.75^#*expr.Constant_DoubleValue#,\n      2.5^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "2.0 * 8.988466e+307 ",
+    ast: "_*_(\n  2^#*expr.Constant_DoubleValue#,\n  8.988466e+307^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "2.0 * -8.988466e+307 ",
+    ast: "_*_(\n  2^#*expr.Constant_DoubleValue#,\n  -8.988466e+307^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1e-324  / 2.0",
+    ast: "_/_(\n  0^#*expr.Constant_DoubleValue#,\n  2^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "40 + 2",
+    ast: "_+_(\n  40^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "42 + (-7)",
+    ast: "_+_(\n  42^#*expr.Constant_Int64Value#,\n  -7^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-4 + (-2)",
+    ast: "_+_(\n  -4^#*expr.Constant_Int64Value#,\n  -2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "42 - 12",
+    ast: "_-_(\n  42^#*expr.Constant_Int64Value#,\n  12^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "42 - (-22)",
+    ast: "_-_(\n  42^#*expr.Constant_Int64Value#,\n  -22^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-42 - (-12)",
+    ast: "_-_(\n  -42^#*expr.Constant_Int64Value#,\n  -12^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "42 * 2",
+    ast: "_*_(\n  42^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "40 * (-2)",
+    ast: "_*_(\n  40^#*expr.Constant_Int64Value#,\n  -2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-30 * (-2)",
+    ast: "_*_(\n  -30^#*expr.Constant_Int64Value#,\n  -2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "42 / 2",
+    ast: "_/_(\n  42^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-20 / 2",
+    ast: "_/_(\n  -20^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-80 / (-2)",
+    ast: "_/_(\n  -80^#*expr.Constant_Int64Value#,\n  -2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "47 % 5",
+    ast: "_%_(\n  47^#*expr.Constant_Int64Value#,\n  5^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "43 % (-5)",
+    ast: "_%_(\n  43^#*expr.Constant_Int64Value#,\n  -5^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-42 % (-5)",
+    ast: "_%_(\n  -42^#*expr.Constant_Int64Value#,\n  -5^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-3 % 5",
+    ast: "_%_(\n  -3^#*expr.Constant_Int64Value#,\n  5^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-(42)",
+    ast: "-_(\n  42^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-(-42)",
+    ast: "-_(\n  -42^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-(42u)",
+    ast: "-_(\n  42u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-false",
+    ast: "-_(\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "34 % 0",
+    ast: "_%_(\n  34^#*expr.Constant_Int64Value#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-(0)",
+    ast: "-_(\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-(-42)",
+    ast: "-_(\n  -42^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "15 / 0",
+    ast: "_/_(\n  15^#*expr.Constant_Int64Value#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "15 * 0",
+    ast: "_*_(\n  15^#*expr.Constant_Int64Value#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0 + 17",
+    ast: "_+_(\n  0^#*expr.Constant_Int64Value#,\n  17^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: " 29 + 0",
+    ast: "_+_(\n  29^#*expr.Constant_Int64Value#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "75 + 15 == 15 + 75",
+    ast: "_==_(\n  _+_(\n    75^#*expr.Constant_Int64Value#,\n    15^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  _+_(\n    15^#*expr.Constant_Int64Value#,\n    75^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "5 + (15 + 20) == (5 + 15) + 20",
+    ast: "_==_(\n  _+_(\n    5^#*expr.Constant_Int64Value#,\n    _+_(\n      15^#*expr.Constant_Int64Value#,\n      20^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  _+_(\n    _+_(\n      5^#*expr.Constant_Int64Value#,\n      15^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    20^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1 * 45",
+    ast: "_*_(\n  1^#*expr.Constant_Int64Value#,\n  45^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-25 * 1",
+    ast: "_*_(\n  -25^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "15 * 25 == 25 * 15",
+    ast: "_==_(\n  _*_(\n    15^#*expr.Constant_Int64Value#,\n    25^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  _*_(\n    25^#*expr.Constant_Int64Value#,\n    15^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "15 * (23 * 88) == (15 * 23) * 88",
+    ast: "_==_(\n  _*_(\n    15^#*expr.Constant_Int64Value#,\n    _*_(\n      23^#*expr.Constant_Int64Value#,\n      88^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  _*_(\n    _*_(\n      15^#*expr.Constant_Int64Value#,\n      23^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    88^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "5 * (15 + 25)  == 5 * 15 + 5 * 25",
+    ast: "_==_(\n  _*_(\n    5^#*expr.Constant_Int64Value#,\n    _+_(\n      15^#*expr.Constant_Int64Value#,\n      25^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  _+_(\n    _*_(\n      5^#*expr.Constant_Int64Value#,\n      15^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _*_(\n      5^#*expr.Constant_Int64Value#,\n      25^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "9223372036854775807 + 1",
+    ast: "_+_(\n  9223372036854775807^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-9223372036854775808 - 1",
+    ast: "_-_(\n  -9223372036854775808^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-9223372036854775808 + (-1)",
+    ast: "_+_(\n  -9223372036854775808^#*expr.Constant_Int64Value#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1 - (-9223372036854775807)",
+    ast: "_-_(\n  1^#*expr.Constant_Int64Value#,\n  -9223372036854775807^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-(-9223372036854775808)",
+    ast: "-_(\n  -9223372036854775808^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "(-9223372036854775808) * -1",
+    ast: "_*_(\n  -9223372036854775808^#*expr.Constant_Int64Value#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "(-9223372036854775808)/-1",
+    ast: "_/_(\n  -9223372036854775808^#*expr.Constant_Int64Value#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "5000000000 * 5000000000",
+    ast: "_*_(\n  5000000000^#*expr.Constant_Int64Value#,\n  5000000000^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "(-5000000000) * 5000000000",
+    ast: "_*_(\n  -5000000000^#*expr.Constant_Int64Value#,\n  5000000000^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "18446744073709551615u + 1u",
+    ast: "_+_(\n  18446744073709551615u^#*expr.Constant_Uint64Value#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0u - 1u",
+    ast: "_-_(\n  0u^#*expr.Constant_Uint64Value#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "5000000000u * 5000000000u",
+    ast: "_*_(\n  5000000000u^#*expr.Constant_Uint64Value#,\n  5000000000u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "42u + 2u",
+    ast: "_+_(\n  42u^#*expr.Constant_Uint64Value#,\n  2u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "42u - 12u",
+    ast: "_-_(\n  42u^#*expr.Constant_Uint64Value#,\n  12u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "40u * 2u",
+    ast: "_*_(\n  40u^#*expr.Constant_Uint64Value#,\n  2u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "60u / 2u",
+    ast: "_/_(\n  60u^#*expr.Constant_Uint64Value#,\n  2u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "42u % 5u",
+    ast: "_%_(\n  42u^#*expr.Constant_Uint64Value#,\n  5u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "-(5u)",
+    ast: "-_(\n  5u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "34u % 0u",
+    ast: "_%_(\n  34u^#*expr.Constant_Uint64Value#,\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "15u / 0u",
+    ast: "_/_(\n  15u^#*expr.Constant_Uint64Value#,\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "15u * 0u",
+    ast: "_*_(\n  15u^#*expr.Constant_Uint64Value#,\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "0u + 17u",
+    ast: "_+_(\n  0u^#*expr.Constant_Uint64Value#,\n  17u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: " 29u + 0u",
+    ast: "_+_(\n  29u^#*expr.Constant_Uint64Value#,\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "75u + 15u == 15u + 75u",
+    ast: "_==_(\n  _+_(\n    75u^#*expr.Constant_Uint64Value#,\n    15u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  _+_(\n    15u^#*expr.Constant_Uint64Value#,\n    75u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "5u + (15u + 20u) == (5u + 15u) + 20u",
+    ast: "_==_(\n  _+_(\n    5u^#*expr.Constant_Uint64Value#,\n    _+_(\n      15u^#*expr.Constant_Uint64Value#,\n      20u^#*expr.Constant_Uint64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  _+_(\n    _+_(\n      5u^#*expr.Constant_Uint64Value#,\n      15u^#*expr.Constant_Uint64Value#\n    )^#*expr.Expr_CallExpr#,\n    20u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1u * 45u",
+    ast: "_*_(\n  1u^#*expr.Constant_Uint64Value#,\n  45u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "25u * 1u",
+    ast: "_*_(\n  25u^#*expr.Constant_Uint64Value#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "15u * 25u == 25u * 15u",
+    ast: "_==_(\n  _*_(\n    15u^#*expr.Constant_Uint64Value#,\n    25u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  _*_(\n    25u^#*expr.Constant_Uint64Value#,\n    15u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "15u * (23u * 88u) == (15u * 23u) * 88u",
+    ast: "_==_(\n  _*_(\n    15u^#*expr.Constant_Uint64Value#,\n    _*_(\n      23u^#*expr.Constant_Uint64Value#,\n      88u^#*expr.Constant_Uint64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  _*_(\n    _*_(\n      15u^#*expr.Constant_Uint64Value#,\n      23u^#*expr.Constant_Uint64Value#\n    )^#*expr.Expr_CallExpr#,\n    88u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "5u * (15u + 25u)  == 5u * 15u + 5u * 25u",
+    ast: "_==_(\n  _*_(\n    5u^#*expr.Constant_Uint64Value#,\n    _+_(\n      15u^#*expr.Constant_Uint64Value#,\n      25u^#*expr.Constant_Uint64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  _+_(\n    _*_(\n      5u^#*expr.Constant_Uint64Value#,\n      15u^#*expr.Constant_Uint64Value#\n    )^#*expr.Expr_CallExpr#,\n    _*_(\n      5u^#*expr.Constant_Uint64Value#,\n      25u^#*expr.Constant_Uint64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[0, 1, 2] + [3, 4, 5] == [0, 1, 2, 3, 4, 5]",
+    ast: "_==_(\n  _+_(\n    [\n      0^#*expr.Constant_Int64Value#,\n      1^#*expr.Constant_Int64Value#,\n      2^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#,\n    [\n      3^#*expr.Constant_Int64Value#,\n      4^#*expr.Constant_Int64Value#,\n      5^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  [\n    0^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#,\n    4^#*expr.Constant_Int64Value#,\n    5^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[0, 1, 2] + [3, 4, 5] == [3, 4, 5, 0, 1, 2]",
+    ast: "_==_(\n  _+_(\n    [\n      0^#*expr.Constant_Int64Value#,\n      1^#*expr.Constant_Int64Value#,\n      2^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#,\n    [\n      3^#*expr.Constant_Int64Value#,\n      4^#*expr.Constant_Int64Value#,\n      5^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  [\n    3^#*expr.Constant_Int64Value#,\n    4^#*expr.Constant_Int64Value#,\n    5^#*expr.Constant_Int64Value#,\n    0^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[2] + [2]",
+    ast: "_+_(\n  [\n    2^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    2^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[] + []",
+    ast: "_+_(\n  []^#*expr.Expr_ListExpr#,\n  []^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[] + [3, 4]",
+    ast: "_+_(\n  []^#*expr.Expr_ListExpr#,\n  [\n    3^#*expr.Constant_Int64Value#,\n    4^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1, 2] + []",
+    ast: "_+_(\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  []^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[7, 8, 9][0]",
+    ast: "_[_](\n  [\n    7^#*expr.Constant_Int64Value#,\n    8^#*expr.Constant_Int64Value#,\n    9^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[7, 8, 9][dyn(0.0)]",
+    ast: "_[_](\n  [\n    7^#*expr.Constant_Int64Value#,\n    8^#*expr.Constant_Int64Value#,\n    9^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  dyn(\n    0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[7, 8, 9][dyn(0.1)]",
+    ast: "_[_](\n  [\n    7^#*expr.Constant_Int64Value#,\n    8^#*expr.Constant_Int64Value#,\n    9^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  dyn(\n    0.1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[7, 8, 9][dyn(0u)]",
+    ast: "_[_](\n  [\n    7^#*expr.Constant_Int64Value#,\n    8^#*expr.Constant_Int64Value#,\n    9^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  dyn(\n    0u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "['foo'][0]",
+    ast: '_[_](\n  [\n    "foo"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[0, 1, 1, 2, 3, 5, 8, 13][4]",
+    ast: "_[_](\n  [\n    0^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#,\n    5^#*expr.Constant_Int64Value#,\n    8^#*expr.Constant_Int64Value#,\n    13^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  4^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "['George', 'John', 'Paul', 'Ringo'][3]",
+    ast: '_[_](\n  [\n    "George"^#*expr.Constant_StringValue#,\n    "John"^#*expr.Constant_StringValue#,\n    "Paul"^#*expr.Constant_StringValue#,\n    "Ringo"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#,\n  3^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[1, 2, 3][3]",
+    ast: "_[_](\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  3^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn([1, 2, 3][3]) || false",
+    ast: "_||_(\n  dyn(\n    _[_](\n      [\n        1^#*expr.Constant_Int64Value#,\n        2^#*expr.Constant_Int64Value#,\n        3^#*expr.Constant_Int64Value#\n      ]^#*expr.Expr_ListExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn([1, 2, 3][3]) || true",
+    ast: "_||_(\n  dyn(\n    _[_](\n      [\n        1^#*expr.Constant_Int64Value#,\n        2^#*expr.Constant_Int64Value#,\n        3^#*expr.Constant_Int64Value#\n      ]^#*expr.Expr_ListExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn([1, 2, 3][3]) \u0026\u0026 false",
+    ast: "_\u0026\u0026_(\n  dyn(\n    _[_](\n      [\n        1^#*expr.Constant_Int64Value#,\n        2^#*expr.Constant_Int64Value#,\n        3^#*expr.Constant_Int64Value#\n      ]^#*expr.Expr_ListExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn([1, 2, 3][3]) \u0026\u0026 true",
+    ast: "_\u0026\u0026_(\n  dyn(\n    _[_](\n      [\n        1^#*expr.Constant_Int64Value#,\n        2^#*expr.Constant_Int64Value#,\n        3^#*expr.Constant_Int64Value#\n      ]^#*expr.Expr_ListExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1, 2, 3][dyn('')]",
+    ast: '_[_](\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  dyn(\n    ""^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn([1, 2, 3][dyn('')]) || false",
+    ast: '_||_(\n  dyn(\n    _[_](\n      [\n        1^#*expr.Constant_Int64Value#,\n        2^#*expr.Constant_Int64Value#,\n        3^#*expr.Constant_Int64Value#\n      ]^#*expr.Expr_ListExpr#,\n      dyn(\n        ""^#*expr.Constant_StringValue#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn([1, 2, 3][dyn('')]) || true",
+    ast: '_||_(\n  dyn(\n    _[_](\n      [\n        1^#*expr.Constant_Int64Value#,\n        2^#*expr.Constant_Int64Value#,\n        3^#*expr.Constant_Int64Value#\n      ]^#*expr.Expr_ListExpr#,\n      dyn(\n        ""^#*expr.Constant_StringValue#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn([1, 2, 3][dyn('')]) \u0026\u0026 false",
+    ast: '_\u0026\u0026_(\n  dyn(\n    _[_](\n      [\n        1^#*expr.Constant_Int64Value#,\n        2^#*expr.Constant_Int64Value#,\n        3^#*expr.Constant_Int64Value#\n      ]^#*expr.Expr_ListExpr#,\n      dyn(\n        ""^#*expr.Constant_StringValue#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "dyn([1, 2, 3][dyn('')]) \u0026\u0026 true",
+    ast: '_\u0026\u0026_(\n  dyn(\n    _[_](\n      [\n        1^#*expr.Constant_Int64Value#,\n        2^#*expr.Constant_Int64Value#,\n        3^#*expr.Constant_Int64Value#\n      ]^#*expr.Expr_ListExpr#,\n      dyn(\n        ""^#*expr.Constant_StringValue#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "7 in []",
+    ast: "@in(\n  7^#*expr.Constant_Int64Value#,\n  []^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "4u in [4u]",
+    ast: "@in(\n  4u^#*expr.Constant_Uint64Value#,\n  [\n    4u^#*expr.Constant_Uint64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "'alpha' in ['alpha', 'beta', 'gamma']",
+    ast: '@in(\n  "alpha"^#*expr.Constant_StringValue#,\n  [\n    "alpha"^#*expr.Constant_StringValue#,\n    "beta"^#*expr.Constant_StringValue#,\n    "gamma"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "3 in [5, 4, 3, 2, 1]",
+    ast: "@in(\n  3^#*expr.Constant_Int64Value#,\n  [\n    5^#*expr.Constant_Int64Value#,\n    4^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "20u in [4u, 6u, 8u, 12u, 20u]",
+    ast: "@in(\n  20u^#*expr.Constant_Uint64Value#,\n  [\n    4u^#*expr.Constant_Uint64Value#,\n    6u^#*expr.Constant_Uint64Value#,\n    8u^#*expr.Constant_Uint64Value#,\n    12u^#*expr.Constant_Uint64Value#,\n    20u^#*expr.Constant_Uint64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(3.0) in [5, 4, 3, 2, 1]",
+    ast: "@in(\n  dyn(\n    3^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  [\n    5^#*expr.Constant_Int64Value#,\n    4^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(3u) in [5, 4, 3, 2, 1]",
+    ast: "@in(\n  dyn(\n    3u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  [\n    5^#*expr.Constant_Int64Value#,\n    4^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(3) in [5.0, 4.0, 3.0, 2.0, 1.0]",
+    ast: "@in(\n  dyn(\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  [\n    5^#*expr.Constant_DoubleValue#,\n    4^#*expr.Constant_DoubleValue#,\n    3^#*expr.Constant_DoubleValue#,\n    2^#*expr.Constant_DoubleValue#,\n    1^#*expr.Constant_DoubleValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(3u) in [5.0, 4.0, 3.0, 2.0, 1.0]",
+    ast: "@in(\n  dyn(\n    3u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  [\n    5^#*expr.Constant_DoubleValue#,\n    4^#*expr.Constant_DoubleValue#,\n    3^#*expr.Constant_DoubleValue#,\n    2^#*expr.Constant_DoubleValue#,\n    1^#*expr.Constant_DoubleValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(3) in [5u, 4u, 3u, 2u, 1u]",
+    ast: "@in(\n  dyn(\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  [\n    5u^#*expr.Constant_Uint64Value#,\n    4u^#*expr.Constant_Uint64Value#,\n    3u^#*expr.Constant_Uint64Value#,\n    2u^#*expr.Constant_Uint64Value#,\n    1u^#*expr.Constant_Uint64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "dyn(3.0) in [5u, 4u, 3u, 2u, 1u]",
+    ast: "@in(\n  dyn(\n    3^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  [\n    5u^#*expr.Constant_Uint64Value#,\n    4u^#*expr.Constant_Uint64Value#,\n    3u^#*expr.Constant_Uint64Value#,\n    2u^#*expr.Constant_Uint64Value#,\n    1u^#*expr.Constant_Uint64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "'hawaiian' in ['meat', 'veggie', 'margarita', 'cheese']",
+    ast: '@in(\n  "hawaiian"^#*expr.Constant_StringValue#,\n  [\n    "meat"^#*expr.Constant_StringValue#,\n    "veggie"^#*expr.Constant_StringValue#,\n    "margarita"^#*expr.Constant_StringValue#,\n    "cheese"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "size([])",
+    ast: "size(\n  []^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "size([1, 2, 3])",
+    ast: "size(\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "size({})",
+    ast: "size(\n  {}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "size({1: 'one', 2: 'two', 3: 'three'})",
+    ast: 'size(\n  {\n    1^#*expr.Constant_Int64Value#:"one"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    2^#*expr.Constant_Int64Value#:"two"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    3^#*expr.Constant_Int64Value#:"three"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "true ? 1 : 2",
+    ast: "_?_:_(\n  true^#*expr.Constant_BoolValue#,\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "false ? 'foo' : 'bar'",
+    ast: '_?_:_(\n  false^#*expr.Constant_BoolValue#,\n  "foo"^#*expr.Constant_StringValue#,\n  "bar"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "2 / 0 \u003e 4 ? 'baz' : 'quux'",
+    ast: '_?_:_(\n  _\u003e_(\n    _/_(\n      2^#*expr.Constant_Int64Value#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    4^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  "baz"^#*expr.Constant_StringValue#,\n  "quux"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "true ? 'cows' : 17",
+    ast: '_?_:_(\n  true^#*expr.Constant_BoolValue#,\n  "cows"^#*expr.Constant_StringValue#,\n  17^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'cows' ? false : 17",
+    ast: '_?_:_(\n  "cows"^#*expr.Constant_StringValue#,\n  false^#*expr.Constant_BoolValue#,\n  17^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "true \u0026\u0026 true",
+    ast: "_\u0026\u0026_(\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "false \u0026\u0026 false",
+    ast: "_\u0026\u0026_(\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "false \u0026\u0026 true",
+    ast: "_\u0026\u0026_(\n  false^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "true \u0026\u0026 false",
+    ast: "_\u0026\u0026_(\n  true^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "false \u0026\u0026 32",
+    ast: "_\u0026\u0026_(\n  false^#*expr.Constant_BoolValue#,\n  32^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "'horses' \u0026\u0026 false",
+    ast: '_\u0026\u0026_(\n  "horses"^#*expr.Constant_StringValue#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "false \u0026\u0026 (2 / 0 \u003e 3 ? false : true)",
+    ast: "_\u0026\u0026_(\n  false^#*expr.Constant_BoolValue#,\n  _?_:_(\n    _\u003e_(\n      _/_(\n        2^#*expr.Constant_Int64Value#,\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    false^#*expr.Constant_BoolValue#,\n    true^#*expr.Constant_BoolValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "(2 / 0 \u003e 3 ? false : true) \u0026\u0026 false",
+    ast: "_\u0026\u0026_(\n  _?_:_(\n    _\u003e_(\n      _/_(\n        2^#*expr.Constant_Int64Value#,\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    false^#*expr.Constant_BoolValue#,\n    true^#*expr.Constant_BoolValue#\n  )^#*expr.Expr_CallExpr#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "true \u0026\u0026 1/0 != 0",
+    ast: "_\u0026\u0026_(\n  true^#*expr.Constant_BoolValue#,\n  _!=_(\n    _/_(\n      1^#*expr.Constant_Int64Value#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    0^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1/0 != 0 \u0026\u0026 true",
+    ast: "_\u0026\u0026_(\n  _!=_(\n    _/_(\n      1^#*expr.Constant_Int64Value#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    0^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "'less filling' \u0026\u0026 'tastes great'",
+    ast: '_\u0026\u0026_(\n  "less filling"^#*expr.Constant_StringValue#,\n  "tastes great"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "true || true",
+    ast: "_||_(\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "false || false",
+    ast: "_||_(\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "false || true",
+    ast: "_||_(\n  false^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "true || false",
+    ast: "_||_(\n  true^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "true || 32",
+    ast: "_||_(\n  true^#*expr.Constant_BoolValue#,\n  32^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "'horses' || true",
+    ast: '_||_(\n  "horses"^#*expr.Constant_StringValue#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "true || (2 / 0 \u003e 3 ? false : true)",
+    ast: "_||_(\n  true^#*expr.Constant_BoolValue#,\n  _?_:_(\n    _\u003e_(\n      _/_(\n        2^#*expr.Constant_Int64Value#,\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    false^#*expr.Constant_BoolValue#,\n    true^#*expr.Constant_BoolValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "(2 / 0 \u003e 3 ? false : true) || true",
+    ast: "_||_(\n  _?_:_(\n    _\u003e_(\n      _/_(\n        2^#*expr.Constant_Int64Value#,\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    false^#*expr.Constant_BoolValue#,\n    true^#*expr.Constant_BoolValue#\n  )^#*expr.Expr_CallExpr#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "false || 1/0 != 0",
+    ast: "_||_(\n  false^#*expr.Constant_BoolValue#,\n  _!=_(\n    _/_(\n      1^#*expr.Constant_Int64Value#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    0^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "1/0 != 0 || false",
+    ast: "_||_(\n  _!=_(\n    _/_(\n      1^#*expr.Constant_Int64Value#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    0^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "'less filling' || 'tastes great'",
+    ast: '_||_(\n  "less filling"^#*expr.Constant_StringValue#,\n  "tastes great"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "!true",
+    ast: "!_(\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "!false",
+    ast: "!_(\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "!0",
+    ast: "!_(\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1, 2, 3].exists(e, e \u003e 0)",
+    ast: "__comprehension__(\n  // Variable\n  e,\n  // Target\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  false^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    !_(\n      __result__^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _||_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _\u003e_(\n      e^#*expr.Expr_IdentExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[1, 2, 3].exists(e, e == 2)",
+    ast: "__comprehension__(\n  // Variable\n  e,\n  // Target\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  false^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    !_(\n      __result__^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _||_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _==_(\n      e^#*expr.Expr_IdentExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[1, 2, 3].exists(e, e \u003e 3)",
+    ast: "__comprehension__(\n  // Variable\n  e,\n  // Target\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  false^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    !_(\n      __result__^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _||_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _\u003e_(\n      e^#*expr.Expr_IdentExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[1, 'foo', 3].exists(e, e != '1')",
+    ast: '__comprehension__(\n  // Variable\n  e,\n  // Target\n  [\n    1^#*expr.Constant_Int64Value#,\n    "foo"^#*expr.Constant_StringValue#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  false^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    !_(\n      __result__^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _||_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _!=_(\n      e^#*expr.Expr_IdentExpr#,\n      "1"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#',
+  },
+  {
+    expr: "[1, 'foo', 3].exists(e, e == '10')",
+    ast: '__comprehension__(\n  // Variable\n  e,\n  // Target\n  [\n    1^#*expr.Constant_Int64Value#,\n    "foo"^#*expr.Constant_StringValue#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  false^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    !_(\n      __result__^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _||_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _==_(\n      e^#*expr.Expr_IdentExpr#,\n      "10"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#',
+  },
+  {
+    expr: "[1, 2, 3].exists(e, e / 0 == 17)",
+    ast: "__comprehension__(\n  // Variable\n  e,\n  // Target\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  false^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    !_(\n      __result__^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _||_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _==_(\n      _/_(\n        e^#*expr.Expr_IdentExpr#,\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      17^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[].exists(e, e == 2)",
+    ast: "__comprehension__(\n  // Variable\n  e,\n  // Target\n  []^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  false^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    !_(\n      __result__^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _||_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _==_(\n      e^#*expr.Expr_IdentExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "{'key1':1, 'key2':2}.exists(k, k == 'key2')",
+    ast: '__comprehension__(\n  // Variable\n  k,\n  // Target\n  {\n    "key1"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    "key2"^#*expr.Constant_StringValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  false^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    !_(\n      __result__^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _||_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _==_(\n      k^#*expr.Expr_IdentExpr#,\n      "key2"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#',
+  },
+  {
+    expr: "!{'key1':1, 'key2':2}.exists(k, k == 'key3')",
+    ast: '!_(\n  __comprehension__(\n    // Variable\n    k,\n    // Target\n    {\n      "key1"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n      "key2"^#*expr.Constant_StringValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#,\n    // Accumulator\n    __result__,\n    // Init\n    false^#*expr.Constant_BoolValue#,\n    // LoopCondition\n    @not_strictly_false(\n      !_(\n        __result__^#*expr.Expr_IdentExpr#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    // LoopStep\n    _||_(\n      __result__^#*expr.Expr_IdentExpr#,\n      _==_(\n        k^#*expr.Expr_IdentExpr#,\n        "key3"^#*expr.Constant_StringValue#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    // Result\n    __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'key':1, 1:21}.exists(k, k != 2)",
+    ast: '__comprehension__(\n  // Variable\n  k,\n  // Target\n  {\n    "key"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    1^#*expr.Constant_Int64Value#:21^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  false^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    !_(\n      __result__^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _||_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _!=_(\n      k^#*expr.Expr_IdentExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#',
+  },
+  {
+    expr: "!{'key':1, 1:42}.exists(k, k == 2)",
+    ast: '!_(\n  __comprehension__(\n    // Variable\n    k,\n    // Target\n    {\n      "key"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n      1^#*expr.Constant_Int64Value#:42^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#,\n    // Accumulator\n    __result__,\n    // Init\n    false^#*expr.Constant_BoolValue#,\n    // LoopCondition\n    @not_strictly_false(\n      !_(\n        __result__^#*expr.Expr_IdentExpr#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    // LoopStep\n    _||_(\n      __result__^#*expr.Expr_IdentExpr#,\n      _==_(\n        k^#*expr.Expr_IdentExpr#,\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    // Result\n    __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[1, 2, 3].all(e, e \u003e 0)",
+    ast: "__comprehension__(\n  // Variable\n  e,\n  // Target\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  true^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _\u0026\u0026_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _\u003e_(\n      e^#*expr.Expr_IdentExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[1, 2, 3].all(e, e == 2)",
+    ast: "__comprehension__(\n  // Variable\n  e,\n  // Target\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  true^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _\u0026\u0026_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _==_(\n      e^#*expr.Expr_IdentExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[1, 2, 3].all(e, e == 17)",
+    ast: "__comprehension__(\n  // Variable\n  e,\n  // Target\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  true^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _\u0026\u0026_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _==_(\n      e^#*expr.Expr_IdentExpr#,\n      17^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[1, 'foo', 3].all(e, e == 1)",
+    ast: '__comprehension__(\n  // Variable\n  e,\n  // Target\n  [\n    1^#*expr.Constant_Int64Value#,\n    "foo"^#*expr.Constant_StringValue#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  true^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _\u0026\u0026_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _==_(\n      e^#*expr.Expr_IdentExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#',
+  },
+  {
+    expr: "[1, 'foo', 3].all(e, e % 2 == 1)",
+    ast: '__comprehension__(\n  // Variable\n  e,\n  // Target\n  [\n    1^#*expr.Constant_Int64Value#,\n    "foo"^#*expr.Constant_StringValue#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  true^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _\u0026\u0026_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _==_(\n      _%_(\n        e^#*expr.Expr_IdentExpr#,\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#',
+  },
+  {
+    expr: "[1, 2, 3].all(e, 6 / (2 - e) == 6)",
+    ast: "__comprehension__(\n  // Variable\n  e,\n  // Target\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  true^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _\u0026\u0026_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _==_(\n      _/_(\n        6^#*expr.Constant_Int64Value#,\n        _-_(\n          2^#*expr.Constant_Int64Value#,\n          e^#*expr.Expr_IdentExpr#\n        )^#*expr.Expr_CallExpr#\n      )^#*expr.Expr_CallExpr#,\n      6^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[1, 2, 3].all(e, e / 0 != 17)",
+    ast: "__comprehension__(\n  // Variable\n  e,\n  // Target\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  true^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _\u0026\u0026_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _!=_(\n      _/_(\n        e^#*expr.Expr_IdentExpr#,\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      17^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[].all(e, e \u003e 0)",
+    ast: "__comprehension__(\n  // Variable\n  e,\n  // Target\n  []^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  true^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _\u0026\u0026_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _\u003e_(\n      e^#*expr.Expr_IdentExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "{'key1':1, 'key2':2}.all(k, k == 'key2')",
+    ast: '__comprehension__(\n  // Variable\n  k,\n  // Target\n  {\n    "key1"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    "key2"^#*expr.Constant_StringValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  true^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _\u0026\u0026_(\n    __result__^#*expr.Expr_IdentExpr#,\n    _==_(\n      k^#*expr.Expr_IdentExpr#,\n      "key2"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#',
+  },
+  {
+    expr: "[].exists_one(a, a == 7)",
+    ast: "__comprehension__(\n  // Variable\n  a,\n  // Target\n  []^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  0^#*expr.Constant_Int64Value#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _?_:_(\n    _==_(\n      a^#*expr.Expr_IdentExpr#,\n      7^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  _==_(\n    __result__^#*expr.Expr_IdentExpr#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[7].exists_one(a, a == 7)",
+    ast: "__comprehension__(\n  // Variable\n  a,\n  // Target\n  [\n    7^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  0^#*expr.Constant_Int64Value#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _?_:_(\n    _==_(\n      a^#*expr.Expr_IdentExpr#,\n      7^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  _==_(\n    __result__^#*expr.Expr_IdentExpr#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[8].exists_one(a, a == 7)",
+    ast: "__comprehension__(\n  // Variable\n  a,\n  // Target\n  [\n    8^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  0^#*expr.Constant_Int64Value#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _?_:_(\n    _==_(\n      a^#*expr.Expr_IdentExpr#,\n      7^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  _==_(\n    __result__^#*expr.Expr_IdentExpr#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[1, 2, 3].exists_one(x, x \u003e 20)",
+    ast: "__comprehension__(\n  // Variable\n  x,\n  // Target\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  0^#*expr.Constant_Int64Value#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _?_:_(\n    _\u003e_(\n      x^#*expr.Expr_IdentExpr#,\n      20^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  _==_(\n    __result__^#*expr.Expr_IdentExpr#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[6, 7, 8].exists_one(foo, foo % 5 == 2)",
+    ast: "__comprehension__(\n  // Variable\n  foo,\n  // Target\n  [\n    6^#*expr.Constant_Int64Value#,\n    7^#*expr.Constant_Int64Value#,\n    8^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  0^#*expr.Constant_Int64Value#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _?_:_(\n    _==_(\n      _%_(\n        foo^#*expr.Expr_IdentExpr#,\n        5^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  _==_(\n    __result__^#*expr.Expr_IdentExpr#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[0, 1, 2, 3, 4].exists_one(n, n % 2 == 1)",
+    ast: "__comprehension__(\n  // Variable\n  n,\n  // Target\n  [\n    0^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#,\n    4^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  0^#*expr.Constant_Int64Value#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _?_:_(\n    _==_(\n      _%_(\n        n^#*expr.Expr_IdentExpr#,\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  _==_(\n    __result__^#*expr.Expr_IdentExpr#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "['foal', 'foo', 'four'].exists_one(n, n.startsWith('fo'))",
+    ast: '__comprehension__(\n  // Variable\n  n,\n  // Target\n  [\n    "foal"^#*expr.Constant_StringValue#,\n    "foo"^#*expr.Constant_StringValue#,\n    "four"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  0^#*expr.Constant_Int64Value#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _?_:_(\n    n^#*expr.Expr_IdentExpr#.startsWith(\n      "fo"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  _==_(\n    __result__^#*expr.Expr_IdentExpr#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#)^#*expr.Expr_ComprehensionExpr#',
+  },
+  {
+    expr: "[3, 2, 1, 0].exists_one(n, 12 / n \u003e 1)",
+    ast: "__comprehension__(\n  // Variable\n  n,\n  // Target\n  [\n    3^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#,\n    0^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  0^#*expr.Constant_Int64Value#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _?_:_(\n    _\u003e_(\n      _/_(\n        12^#*expr.Constant_Int64Value#,\n        n^#*expr.Expr_IdentExpr#\n      )^#*expr.Expr_CallExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  _==_(\n    __result__^#*expr.Expr_IdentExpr#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "{6: 'six', 7: 'seven', 8: 'eight'}.exists_one(foo, foo % 5 == 2)",
+    ast: '__comprehension__(\n  // Variable\n  foo,\n  // Target\n  {\n    6^#*expr.Constant_Int64Value#:"six"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    7^#*expr.Constant_Int64Value#:"seven"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    8^#*expr.Constant_Int64Value#:"eight"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  0^#*expr.Constant_Int64Value#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _?_:_(\n    _==_(\n      _%_(\n        foo^#*expr.Expr_IdentExpr#,\n        5^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  _==_(\n    __result__^#*expr.Expr_IdentExpr#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#)^#*expr.Expr_ComprehensionExpr#',
+  },
+  {
+    expr: "[].map(n, n / 2)",
+    ast: "__comprehension__(\n  // Variable\n  n,\n  // Target\n  []^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  []^#*expr.Expr_ListExpr#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _+_(\n    __result__^#*expr.Expr_IdentExpr#,\n    [\n      _/_(\n        n^#*expr.Expr_IdentExpr#,\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[3].map(n, n * n)",
+    ast: "__comprehension__(\n  // Variable\n  n,\n  // Target\n  [\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  []^#*expr.Expr_ListExpr#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _+_(\n    __result__^#*expr.Expr_IdentExpr#,\n    [\n      _*_(\n        n^#*expr.Expr_IdentExpr#,\n        n^#*expr.Expr_IdentExpr#\n      )^#*expr.Expr_CallExpr#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[2, 4, 6].map(n, n / 2)",
+    ast: "__comprehension__(\n  // Variable\n  n,\n  // Target\n  [\n    2^#*expr.Constant_Int64Value#,\n    4^#*expr.Constant_Int64Value#,\n    6^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  []^#*expr.Expr_ListExpr#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _+_(\n    __result__^#*expr.Expr_IdentExpr#,\n    [\n      _/_(\n        n^#*expr.Expr_IdentExpr#,\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[2, 1, 0].map(n, 4 / n)",
+    ast: "__comprehension__(\n  // Variable\n  n,\n  // Target\n  [\n    2^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#,\n    0^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  []^#*expr.Expr_ListExpr#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _+_(\n    __result__^#*expr.Expr_IdentExpr#,\n    [\n      _/_(\n        4^#*expr.Constant_Int64Value#,\n        n^#*expr.Expr_IdentExpr#\n      )^#*expr.Expr_CallExpr#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "{'John': 'smart'}.map(key, key) == ['John']",
+    ast: '_==_(\n  __comprehension__(\n    // Variable\n    key,\n    // Target\n    {\n      "John"^#*expr.Constant_StringValue#:"smart"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#,\n    // Accumulator\n    __result__,\n    // Init\n    []^#*expr.Expr_ListExpr#,\n    // LoopCondition\n    true^#*expr.Constant_BoolValue#,\n    // LoopStep\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      [\n        key^#*expr.Expr_IdentExpr#\n      ]^#*expr.Expr_ListExpr#\n    )^#*expr.Expr_CallExpr#,\n    // Result\n    __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#,\n  [\n    "John"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[].filter(n, n % 2 == 0)",
+    ast: "__comprehension__(\n  // Variable\n  n,\n  // Target\n  []^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  []^#*expr.Expr_ListExpr#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _?_:_(\n    _==_(\n      _%_(\n        n^#*expr.Expr_IdentExpr#,\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      [\n        n^#*expr.Expr_IdentExpr#\n      ]^#*expr.Expr_ListExpr#\n    )^#*expr.Expr_CallExpr#,\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[2].filter(n, n == 2)",
+    ast: "__comprehension__(\n  // Variable\n  n,\n  // Target\n  [\n    2^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  []^#*expr.Expr_ListExpr#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _?_:_(\n    _==_(\n      n^#*expr.Expr_IdentExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      [\n        n^#*expr.Expr_IdentExpr#\n      ]^#*expr.Expr_ListExpr#\n    )^#*expr.Expr_CallExpr#,\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[1].filter(n, n \u003e 3)",
+    ast: "__comprehension__(\n  // Variable\n  n,\n  // Target\n  [\n    1^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  []^#*expr.Expr_ListExpr#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _?_:_(\n    _\u003e_(\n      n^#*expr.Expr_IdentExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      [\n        n^#*expr.Expr_IdentExpr#\n      ]^#*expr.Expr_ListExpr#\n    )^#*expr.Expr_CallExpr#,\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[1, 2, 3].filter(e, e \u003e 3)",
+    ast: "__comprehension__(\n  // Variable\n  e,\n  // Target\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  []^#*expr.Expr_ListExpr#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _?_:_(\n    _\u003e_(\n      e^#*expr.Expr_IdentExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      [\n        e^#*expr.Expr_IdentExpr#\n      ]^#*expr.Expr_ListExpr#\n    )^#*expr.Expr_CallExpr#,\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[0, 1, 2, 3, 4].filter(x, x % 2 == 1)",
+    ast: "__comprehension__(\n  // Variable\n  x,\n  // Target\n  [\n    0^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#,\n    4^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  []^#*expr.Expr_ListExpr#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _?_:_(\n    _==_(\n      _%_(\n        x^#*expr.Expr_IdentExpr#,\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      [\n        x^#*expr.Expr_IdentExpr#\n      ]^#*expr.Expr_ListExpr#\n    )^#*expr.Expr_CallExpr#,\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[1, 2, 3].filter(n, n \u003e 0)",
+    ast: "__comprehension__(\n  // Variable\n  n,\n  // Target\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  []^#*expr.Expr_ListExpr#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _?_:_(\n    _\u003e_(\n      n^#*expr.Expr_IdentExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      [\n        n^#*expr.Expr_IdentExpr#\n      ]^#*expr.Expr_ListExpr#\n    )^#*expr.Expr_CallExpr#,\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "[3, 2, 1, 0].filter(n, 12 / n \u003e 4)",
+    ast: "__comprehension__(\n  // Variable\n  n,\n  // Target\n  [\n    3^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#,\n    0^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  []^#*expr.Expr_ListExpr#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _?_:_(\n    _\u003e_(\n      _/_(\n        12^#*expr.Constant_Int64Value#,\n        n^#*expr.Expr_IdentExpr#\n      )^#*expr.Expr_CallExpr#,\n      4^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      [\n        n^#*expr.Expr_IdentExpr#\n      ]^#*expr.Expr_ListExpr#\n    )^#*expr.Expr_CallExpr#,\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "{'John': 'smart', 'Paul': 'cute', 'George': 'quiet', 'Ringo': 'funny'}.filter(key, key == 'Ringo') == ['Ringo']",
+    ast: '_==_(\n  __comprehension__(\n    // Variable\n    key,\n    // Target\n    {\n      "John"^#*expr.Constant_StringValue#:"smart"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      "Paul"^#*expr.Constant_StringValue#:"cute"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      "George"^#*expr.Constant_StringValue#:"quiet"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      "Ringo"^#*expr.Constant_StringValue#:"funny"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#,\n    // Accumulator\n    __result__,\n    // Init\n    []^#*expr.Expr_ListExpr#,\n    // LoopCondition\n    true^#*expr.Constant_BoolValue#,\n    // LoopStep\n    _?_:_(\n      _==_(\n        key^#*expr.Expr_IdentExpr#,\n        "Ringo"^#*expr.Constant_StringValue#\n      )^#*expr.Expr_CallExpr#,\n      _+_(\n        __result__^#*expr.Expr_IdentExpr#,\n        [\n          key^#*expr.Expr_IdentExpr#\n        ]^#*expr.Expr_ListExpr#\n      )^#*expr.Expr_CallExpr#,\n      __result__^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#,\n    // Result\n    __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#,\n  [\n    "Ringo"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "['signer'].filter(signer, ['artifact'].all(artifact, true))",
+    ast: '__comprehension__(\n  // Variable\n  signer,\n  // Target\n  [\n    "signer"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  []^#*expr.Expr_ListExpr#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _?_:_(\n    __comprehension__(\n      // Variable\n      artifact,\n      // Target\n      [\n        "artifact"^#*expr.Constant_StringValue#\n      ]^#*expr.Expr_ListExpr#,\n      // Accumulator\n      __result__,\n      // Init\n      true^#*expr.Constant_BoolValue#,\n      // LoopCondition\n      @not_strictly_false(\n        __result__^#*expr.Expr_IdentExpr#\n      )^#*expr.Expr_CallExpr#,\n      // LoopStep\n      _\u0026\u0026_(\n        __result__^#*expr.Expr_IdentExpr#,\n        true^#*expr.Constant_BoolValue#\n      )^#*expr.Expr_CallExpr#,\n      // Result\n      __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#,\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      [\n        signer^#*expr.Expr_IdentExpr#\n      ]^#*expr.Expr_ListExpr#\n    )^#*expr.Expr_CallExpr#,\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#',
+  },
+  {
+    expr: "['signer'].all(signer, ['artifact'].all(artifact, true))",
+    ast: '__comprehension__(\n  // Variable\n  signer,\n  // Target\n  [\n    "signer"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  true^#*expr.Constant_BoolValue#,\n  // LoopCondition\n  @not_strictly_false(\n    __result__^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  // LoopStep\n  _\u0026\u0026_(\n    __result__^#*expr.Expr_IdentExpr#,\n    __comprehension__(\n      // Variable\n      artifact,\n      // Target\n      [\n        "artifact"^#*expr.Constant_StringValue#\n      ]^#*expr.Expr_ListExpr#,\n      // Accumulator\n      __result__,\n      // Init\n      true^#*expr.Constant_BoolValue#,\n      // LoopCondition\n      @not_strictly_false(\n        __result__^#*expr.Expr_IdentExpr#\n      )^#*expr.Expr_CallExpr#,\n      // LoopStep\n      _\u0026\u0026_(\n        __result__^#*expr.Expr_IdentExpr#,\n        true^#*expr.Constant_BoolValue#\n      )^#*expr.Expr_CallExpr#,\n      // Result\n      __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#',
+  },
+  {
+    expr: "[1, 2, 3].exists(i, v, i \u003e -1 \u0026\u0026 v \u003e 0)",
+    ast: "[\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#,\n  3^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.exists(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _\u003e_(\n      i^#*expr.Expr_IdentExpr#,\n      -1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _\u003e_(\n      v^#*expr.Expr_IdentExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1, 2, 3].exists(i, v, i == 1 \u0026\u0026 v == 2)",
+    ast: "[\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#,\n  3^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.exists(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _==_(\n      i^#*expr.Expr_IdentExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _==_(\n      v^#*expr.Expr_IdentExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1, 2, 3].exists(i, v, i \u003e 2 \u0026\u0026 v \u003e 3)",
+    ast: "[\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#,\n  3^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.exists(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _\u003e_(\n      i^#*expr.Expr_IdentExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _\u003e_(\n      v^#*expr.Expr_IdentExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1, 'foo', 3].exists(i, v, i == 1 \u0026\u0026 v != '1')",
+    ast: '[\n  1^#*expr.Constant_Int64Value#,\n  "foo"^#*expr.Constant_StringValue#,\n  3^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.exists(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _==_(\n      i^#*expr.Expr_IdentExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _!=_(\n      v^#*expr.Expr_IdentExpr#,\n      "1"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[1, 'foo', 3].exists(i, v, i == 3 || v == '10')",
+    ast: '[\n  1^#*expr.Constant_Int64Value#,\n  "foo"^#*expr.Constant_StringValue#,\n  3^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.exists(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _||_(\n    _==_(\n      i^#*expr.Expr_IdentExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _==_(\n      v^#*expr.Expr_IdentExpr#,\n      "10"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[1, 2, 3].exists(i, v, v / i == 17)",
+    ast: "[\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#,\n  3^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.exists(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _==_(\n    _/_(\n      v^#*expr.Expr_IdentExpr#,\n      i^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#,\n    17^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[].exists(i, v, i == 0 || v == 2)",
+    ast: "[]^#*expr.Expr_ListExpr#.exists(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _||_(\n    _==_(\n      i^#*expr.Expr_IdentExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _==_(\n      v^#*expr.Expr_IdentExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{'key1':1, 'key2':2}.exists(k, v, k == 'key2' \u0026\u0026 v == 2)",
+    ast: '{\n  "key1"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n  "key2"^#*expr.Constant_StringValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.exists(\n  k^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _==_(\n      k^#*expr.Expr_IdentExpr#,\n      "key2"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    _==_(\n      v^#*expr.Expr_IdentExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "!{'key1':1, 'key2':2}.exists(k, v, k == 'key3' || v == 3)",
+    ast: '!_(\n  {\n    "key1"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    "key2"^#*expr.Constant_StringValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#.exists(\n    k^#*expr.Expr_IdentExpr#,\n    v^#*expr.Expr_IdentExpr#,\n    _||_(\n      _==_(\n        k^#*expr.Expr_IdentExpr#,\n        "key3"^#*expr.Constant_StringValue#\n      )^#*expr.Expr_CallExpr#,\n      _==_(\n        v^#*expr.Expr_IdentExpr#,\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'key':1, 1:21}.exists(k, v, k != 2 \u0026\u0026 v != 22)",
+    ast: '{\n  "key"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n  1^#*expr.Constant_Int64Value#:21^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.exists(\n  k^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _!=_(\n      k^#*expr.Expr_IdentExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _!=_(\n      v^#*expr.Expr_IdentExpr#,\n      22^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "!{'key':1, 1:42}.exists(k, v, k == 2 \u0026\u0026 v == 43)",
+    ast: '!_(\n  {\n    "key"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    1^#*expr.Constant_Int64Value#:42^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#.exists(\n    k^#*expr.Expr_IdentExpr#,\n    v^#*expr.Expr_IdentExpr#,\n    _\u0026\u0026_(\n      _==_(\n        k^#*expr.Expr_IdentExpr#,\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      _==_(\n        v^#*expr.Expr_IdentExpr#,\n        43^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[1, 2, 3].all(i, v, i \u003e -1 \u0026\u0026 v \u003e 0)",
+    ast: "[\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#,\n  3^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.all(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _\u003e_(\n      i^#*expr.Expr_IdentExpr#,\n      -1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _\u003e_(\n      v^#*expr.Expr_IdentExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1, 2, 3].all(i, v, i == 1 \u0026\u0026 v == 2)",
+    ast: "[\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#,\n  3^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.all(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _==_(\n      i^#*expr.Expr_IdentExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _==_(\n      v^#*expr.Expr_IdentExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1, 2, 3].all(i, v, i == 3 || v == 4)",
+    ast: "[\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#,\n  3^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.all(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _||_(\n    _==_(\n      i^#*expr.Expr_IdentExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _==_(\n      v^#*expr.Expr_IdentExpr#,\n      4^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1, 'foo', 3].all(i, v, i == 0 || v == 1)",
+    ast: '[\n  1^#*expr.Constant_Int64Value#,\n  "foo"^#*expr.Constant_StringValue#,\n  3^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.all(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _||_(\n    _==_(\n      i^#*expr.Expr_IdentExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _==_(\n      v^#*expr.Expr_IdentExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[0, 'foo', 3].all(i, v, v % 2 == i)",
+    ast: '[\n  0^#*expr.Constant_Int64Value#,\n  "foo"^#*expr.Constant_StringValue#,\n  3^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.all(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _==_(\n    _%_(\n      v^#*expr.Expr_IdentExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    i^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[0, 'foo', 5].all(i, v, v % 3 == i)",
+    ast: '[\n  0^#*expr.Constant_Int64Value#,\n  "foo"^#*expr.Constant_StringValue#,\n  5^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.all(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _==_(\n    _%_(\n      v^#*expr.Expr_IdentExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    i^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[1, 2, 3].all(i, v, 6 / (2 - v) == i)",
+    ast: "[\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#,\n  3^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.all(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _==_(\n    _/_(\n      6^#*expr.Constant_Int64Value#,\n      _-_(\n        2^#*expr.Constant_Int64Value#,\n        v^#*expr.Expr_IdentExpr#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    i^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1, 2, 3].all(i, v, v / i != 17)",
+    ast: "[\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#,\n  3^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.all(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _!=_(\n    _/_(\n      v^#*expr.Expr_IdentExpr#,\n      i^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#,\n    17^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[].all(i, v, i \u003e -1 || v \u003e 0)",
+    ast: "[]^#*expr.Expr_ListExpr#.all(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _||_(\n    _\u003e_(\n      i^#*expr.Expr_IdentExpr#,\n      -1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _\u003e_(\n      v^#*expr.Expr_IdentExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{'key1':1, 'key2':2}.all(k, v, k == 'key2' \u0026\u0026 v == 2)",
+    ast: '{\n  "key1"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n  "key2"^#*expr.Constant_StringValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.all(\n  k^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _==_(\n      k^#*expr.Expr_IdentExpr#,\n      "key2"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    _==_(\n      v^#*expr.Expr_IdentExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[].existsOne(i, v, i == 3 || v == 7)",
+    ast: "[]^#*expr.Expr_ListExpr#.existsOne(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _||_(\n    _==_(\n      i^#*expr.Expr_IdentExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _==_(\n      v^#*expr.Expr_IdentExpr#,\n      7^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[7].existsOne(i, v, i == 0 \u0026\u0026 v == 7)",
+    ast: "[\n  7^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.existsOne(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _==_(\n      i^#*expr.Expr_IdentExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _==_(\n      v^#*expr.Expr_IdentExpr#,\n      7^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[8].existsOne(i, v, i == 0 \u0026\u0026 v == 7)",
+    ast: "[\n  8^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.existsOne(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _==_(\n      i^#*expr.Expr_IdentExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _==_(\n      v^#*expr.Expr_IdentExpr#,\n      7^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[1, 2, 3].existsOne(i, v, i \u003e 2 || v \u003e 3)",
+    ast: "[\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#,\n  3^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.existsOne(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _||_(\n    _\u003e_(\n      i^#*expr.Expr_IdentExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _\u003e_(\n      v^#*expr.Expr_IdentExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[5, 7, 8].existsOne(i, v, v % 5 == i)",
+    ast: "[\n  5^#*expr.Constant_Int64Value#,\n  7^#*expr.Constant_Int64Value#,\n  8^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.existsOne(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _==_(\n    _%_(\n      v^#*expr.Expr_IdentExpr#,\n      5^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    i^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[0, 1, 2, 3, 4].existsOne(i, v, v % 2 == i)",
+    ast: "[\n  0^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#,\n  3^#*expr.Constant_Int64Value#,\n  4^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.existsOne(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _==_(\n    _%_(\n      v^#*expr.Expr_IdentExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    i^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "['foal', 'foo', 'four'].existsOne(i, v, i \u003e -1 \u0026\u0026 v.startsWith('fo'))",
+    ast: '[\n  "foal"^#*expr.Constant_StringValue#,\n  "foo"^#*expr.Constant_StringValue#,\n  "four"^#*expr.Constant_StringValue#\n]^#*expr.Expr_ListExpr#.existsOne(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _\u003e_(\n      i^#*expr.Expr_IdentExpr#,\n      -1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    v^#*expr.Expr_IdentExpr#.startsWith(\n      "fo"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[3, 2, 1, 0].existsOne(i, v, v / i \u003e 1)",
+    ast: "[\n  3^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#,\n  0^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.existsOne(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u003e_(\n    _/_(\n      v^#*expr.Expr_IdentExpr#,\n      i^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{6: 'six', 7: 'seven', 8: 'eight'}.existsOne(k, v, k % 5 == 2 \u0026\u0026 v == 'seven')",
+    ast: '{\n  6^#*expr.Constant_Int64Value#:"six"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n  7^#*expr.Constant_Int64Value#:"seven"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n  8^#*expr.Constant_Int64Value#:"eight"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.existsOne(\n  k^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _==_(\n      _%_(\n        k^#*expr.Expr_IdentExpr#,\n        5^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _==_(\n      v^#*expr.Expr_IdentExpr#,\n      "seven"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[].transformList(i, v, i / v)",
+    ast: "[]^#*expr.Expr_ListExpr#.transformList(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _/_(\n    i^#*expr.Expr_IdentExpr#,\n    v^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[].transformList(i, v, i \u003e v, i / v)",
+    ast: "[]^#*expr.Expr_ListExpr#.transformList(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u003e_(\n    i^#*expr.Expr_IdentExpr#,\n    v^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#,\n  _/_(\n    i^#*expr.Expr_IdentExpr#,\n    v^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[3].transformList(i, v, v * v + i)",
+    ast: "[\n  3^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.transformList(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _+_(\n    _*_(\n      v^#*expr.Expr_IdentExpr#,\n      v^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#,\n    i^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[3].transformList(i, v, i == 0 \u0026\u0026 v == 3, v * v + i)",
+    ast: "[\n  3^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.transformList(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _==_(\n      i^#*expr.Expr_IdentExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _==_(\n      v^#*expr.Expr_IdentExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  _+_(\n    _*_(\n      v^#*expr.Expr_IdentExpr#,\n      v^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#,\n    i^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[2, 4, 6].transformList(i, v, v / 2 + i)",
+    ast: "[\n  2^#*expr.Constant_Int64Value#,\n  4^#*expr.Constant_Int64Value#,\n  6^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.transformList(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _+_(\n    _/_(\n      v^#*expr.Expr_IdentExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    i^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[2, 4, 6].transformList(i, v, i != 1 \u0026\u0026 v != 4, v / 2 + i)",
+    ast: "[\n  2^#*expr.Constant_Int64Value#,\n  4^#*expr.Constant_Int64Value#,\n  6^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.transformList(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _!=_(\n      i^#*expr.Expr_IdentExpr#,\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    _!=_(\n      v^#*expr.Expr_IdentExpr#,\n      4^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  _+_(\n    _/_(\n      v^#*expr.Expr_IdentExpr#,\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    i^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[2, 1, 0].transformList(i, v, v / i)",
+    ast: "[\n  2^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#,\n  0^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.transformList(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _/_(\n    v^#*expr.Expr_IdentExpr#,\n    i^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[2, 1, 0].transformList(i, v, v / i \u003e 0, v)",
+    ast: "[\n  2^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#,\n  0^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#.transformList(\n  i^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u003e_(\n    _/_(\n      v^#*expr.Expr_IdentExpr#,\n      i^#*expr.Expr_IdentExpr#\n    )^#*expr.Expr_CallExpr#,\n    0^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  v^#*expr.Expr_IdentExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{}.transformMap(k, v, k + v)",
+    ast: "{}^#*expr.Expr_StructExpr#.transformMap(\n  k^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _+_(\n    k^#*expr.Expr_IdentExpr#,\n    v^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{}.transformMap(k, v, k == 'foo' \u0026\u0026 v == 'bar', k + v)",
+    ast: '{}^#*expr.Expr_StructExpr#.transformMap(\n  k^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _==_(\n      k^#*expr.Expr_IdentExpr#,\n      "foo"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    _==_(\n      v^#*expr.Expr_IdentExpr#,\n      "bar"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  _+_(\n    k^#*expr.Expr_IdentExpr#,\n    v^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'foo': 'bar'}.transformMap(k, v, k + v)",
+    ast: '{\n  "foo"^#*expr.Constant_StringValue#:"bar"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.transformMap(\n  k^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _+_(\n    k^#*expr.Expr_IdentExpr#,\n    v^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'foo': 'bar'}.transformMap(k, v, k == 'foo' \u0026\u0026 v == 'bar', k + v)",
+    ast: '{\n  "foo"^#*expr.Constant_StringValue#:"bar"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.transformMap(\n  k^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _==_(\n      k^#*expr.Expr_IdentExpr#,\n      "foo"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    _==_(\n      v^#*expr.Expr_IdentExpr#,\n      "bar"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  _+_(\n    k^#*expr.Expr_IdentExpr#,\n    v^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'foo': 'bar', 'baz': 'bux', 'hello': 'world'}.transformMap(k, v, k + v)",
+    ast: '{\n  "foo"^#*expr.Constant_StringValue#:"bar"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n  "baz"^#*expr.Constant_StringValue#:"bux"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n  "hello"^#*expr.Constant_StringValue#:"world"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.transformMap(\n  k^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _+_(\n    k^#*expr.Expr_IdentExpr#,\n    v^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'foo': 'bar', 'baz': 'bux', 'hello': 'world'}.transformMap(k, v, k != 'baz' \u0026\u0026 v != 'bux', k + v)",
+    ast: '{\n  "foo"^#*expr.Constant_StringValue#:"bar"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n  "baz"^#*expr.Constant_StringValue#:"bux"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n  "hello"^#*expr.Constant_StringValue#:"world"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.transformMap(\n  k^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _!=_(\n      k^#*expr.Expr_IdentExpr#,\n      "baz"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    _!=_(\n      v^#*expr.Expr_IdentExpr#,\n      "bux"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  _+_(\n    k^#*expr.Expr_IdentExpr#,\n    v^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'foo': 2, 'bar': 1, 'baz': 0}.transformMap(k, v, 4 / v)",
+    ast: '{\n  "foo"^#*expr.Constant_StringValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n  "bar"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n  "baz"^#*expr.Constant_StringValue#:0^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.transformMap(\n  k^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _/_(\n    4^#*expr.Constant_Int64Value#,\n    v^#*expr.Expr_IdentExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'foo': 2, 'bar': 1, 'baz': 0}.transformMap(k, v, k == 'baz' \u0026\u0026 4 / v == 0, v)",
+    ast: '{\n  "foo"^#*expr.Constant_StringValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n  "bar"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n  "baz"^#*expr.Constant_StringValue#:0^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.transformMap(\n  k^#*expr.Expr_IdentExpr#,\n  v^#*expr.Expr_IdentExpr#,\n  _\u0026\u0026_(\n    _==_(\n      k^#*expr.Expr_IdentExpr#,\n      "baz"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    _==_(\n      _/_(\n        4^#*expr.Constant_Int64Value#,\n        v^#*expr.Expr_IdentExpr#\n      )^#*expr.Expr_CallExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  v^#*expr.Expr_IdentExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "math.greatest(-5)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  -5^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(5)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  5^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1, 1)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  1^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1, 1.0) == 1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1, 1u) == 1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1^#*expr.Constant_Int64Value#,\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(3, -3)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  3^#*expr.Constant_Int64Value#,\n  -3^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(-7, 5)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  -7^#*expr.Constant_Int64Value#,\n  5^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(9223372036854775807, 1)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  9223372036854775807^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1, 9223372036854775807)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  1^#*expr.Constant_Int64Value#,\n  9223372036854775807^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(-9223372036854775808, 1)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  -9223372036854775808^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1, -9223372036854775808)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  1^#*expr.Constant_Int64Value#,\n  -9223372036854775808^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1, 1, 1) == 1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1, 1.0, 1.0) == 1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_DoubleValue#,\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1, 1u, 1u) == 1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1^#*expr.Constant_Int64Value#,\n    1u^#*expr.Constant_Uint64Value#,\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(10, 1, 3) == 10",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    10^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  10^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1, 3, 10) == 10",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#,\n    10^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  10^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(-1, -2, -3) == -1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    -1^#*expr.Constant_Int64Value#,\n    -2^#*expr.Constant_Int64Value#,\n    -3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(9223372036854775807, 1, 5) == 9223372036854775807",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    9223372036854775807^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#,\n    5^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  9223372036854775807^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(-9223372036854775807, -1, -5) == -1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    -9223372036854775807^#*expr.Constant_Int64Value#,\n    -1^#*expr.Constant_Int64Value#,\n    -5^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(5.4, 10, 3u, -5.0, 9223372036854775807) == 9223372036854775807",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    5.4^#*expr.Constant_DoubleValue#,\n    10^#*expr.Constant_Int64Value#,\n    3u^#*expr.Constant_Uint64Value#,\n    -5^#*expr.Constant_DoubleValue#,\n    9223372036854775807^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  9223372036854775807^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest([5.4, 10, 3u, -5.0, 3.5]) == 10",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    [\n      5.4^#*expr.Constant_DoubleValue#,\n      10^#*expr.Constant_Int64Value#,\n      3u^#*expr.Constant_Uint64Value#,\n      -5^#*expr.Constant_DoubleValue#,\n      3.5^#*expr.Constant_DoubleValue#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  10^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest([dyn(5.4), dyn(10), dyn(3u), dyn(-5.0), dyn(3.5)]) == 10",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    [\n      dyn(\n        5.4^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        10^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        3u^#*expr.Constant_Uint64Value#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        -5^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        3.5^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  10^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(-5.0)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  -5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(5.0)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1.0, 1.0)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  1^#*expr.Constant_DoubleValue#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1.0, 1) == 1.0",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1^#*expr.Constant_DoubleValue#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1.0, 1u) == 1.0",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1^#*expr.Constant_DoubleValue#,\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(5.0, -7.0)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  5^#*expr.Constant_DoubleValue#,\n  -7^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(-3.0, 3.0)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  -3^#*expr.Constant_DoubleValue#,\n  3^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1.797693e308, 1)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  1.797693e+308^#*expr.Constant_DoubleValue#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1, 1.797693e308)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  1^#*expr.Constant_Int64Value#,\n  1.797693e+308^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(-1.797693e308, 1.5)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  -1.797693e+308^#*expr.Constant_DoubleValue#,\n  1.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1.5, -1.797693e308)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  1.5^#*expr.Constant_DoubleValue#,\n  -1.797693e+308^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1.0, 1.0, 1.0) == 1.0",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1^#*expr.Constant_DoubleValue#,\n    1^#*expr.Constant_DoubleValue#,\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1.0, 1, 1) == 1.0",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1^#*expr.Constant_DoubleValue#,\n    1^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1.0, 1u, 1u) == 1.0",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1^#*expr.Constant_DoubleValue#,\n    1u^#*expr.Constant_Uint64Value#,\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(10.5, 1.5, 3.5) == 10.5",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    10.5^#*expr.Constant_DoubleValue#,\n    1.5^#*expr.Constant_DoubleValue#,\n    3.5^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  10.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1.5, 3.5, 10.5) == 10.5",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1.5^#*expr.Constant_DoubleValue#,\n    3.5^#*expr.Constant_DoubleValue#,\n    10.5^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  10.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(-1.5, -2.5, -3.5) == -1.5",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    -1.5^#*expr.Constant_DoubleValue#,\n    -2.5^#*expr.Constant_DoubleValue#,\n    -3.5^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  -1.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1.797693e308, 1, 5) == 1.797693e308",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1.797693e+308^#*expr.Constant_DoubleValue#,\n    1^#*expr.Constant_Int64Value#,\n    5^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1.797693e+308^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(-1.797693e308, -1, -5) == -1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    -1.797693e+308^#*expr.Constant_DoubleValue#,\n    -1^#*expr.Constant_Int64Value#,\n    -5^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(5.4, 10, 3u, -5.0, 1.797693e308) == 1.797693e308",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    5.4^#*expr.Constant_DoubleValue#,\n    10^#*expr.Constant_Int64Value#,\n    3u^#*expr.Constant_Uint64Value#,\n    -5^#*expr.Constant_DoubleValue#,\n    1.797693e+308^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1.797693e+308^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest([5.4, 10.5, 3u, -5.0, 3.5]) == 10.5",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    [\n      5.4^#*expr.Constant_DoubleValue#,\n      10.5^#*expr.Constant_DoubleValue#,\n      3u^#*expr.Constant_Uint64Value#,\n      -5^#*expr.Constant_DoubleValue#,\n      3.5^#*expr.Constant_DoubleValue#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  10.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest([dyn(5.4), dyn(10.5), dyn(3u), dyn(-5.0), dyn(3.5)]) == 10.5",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    [\n      dyn(\n        5.4^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        10.5^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        3u^#*expr.Constant_Uint64Value#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        -5^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        3.5^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  10.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(5u)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  5u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1u, 1u)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  1u^#*expr.Constant_Uint64Value#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1u, 1.0) == 1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1u^#*expr.Constant_Uint64Value#,\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1u, 1) == 1u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1u^#*expr.Constant_Uint64Value#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(5u, -7)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  5u^#*expr.Constant_Uint64Value#,\n  -7^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(-3, 3u)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  -3^#*expr.Constant_Int64Value#,\n  3u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(18446744073709551615u, 1u)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  18446744073709551615u^#*expr.Constant_Uint64Value#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1u, 18446744073709551615u)",
+    ast: "math^#*expr.Expr_IdentExpr#.greatest(\n  1u^#*expr.Constant_Uint64Value#,\n  18446744073709551615u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1u, 1u, 1u) == 1u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1u^#*expr.Constant_Uint64Value#,\n    1u^#*expr.Constant_Uint64Value#,\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1u, 1.0, 1.0) == 1u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1u^#*expr.Constant_Uint64Value#,\n    1^#*expr.Constant_DoubleValue#,\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1u, 1, 1) == 1u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1u^#*expr.Constant_Uint64Value#,\n    1^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(10u, 1u, 3u) == 10u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    10u^#*expr.Constant_Uint64Value#,\n    1u^#*expr.Constant_Uint64Value#,\n    3u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  10u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(1u, 3u, 10u) == 10u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    1u^#*expr.Constant_Uint64Value#,\n    3u^#*expr.Constant_Uint64Value#,\n    10u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  10u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(18446744073709551615u, 1u, 5u) == 18446744073709551615u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    18446744073709551615u^#*expr.Constant_Uint64Value#,\n    1u^#*expr.Constant_Uint64Value#,\n    5u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  18446744073709551615u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest(5.4, 10, 3u, -5.0, 18446744073709551615u) == 18446744073709551615u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    5.4^#*expr.Constant_DoubleValue#,\n    10^#*expr.Constant_Int64Value#,\n    3u^#*expr.Constant_Uint64Value#,\n    -5^#*expr.Constant_DoubleValue#,\n    18446744073709551615u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  18446744073709551615u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest([5.4, 10u, 3u, -5.0, 3.5]) == 10u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    [\n      5.4^#*expr.Constant_DoubleValue#,\n      10u^#*expr.Constant_Uint64Value#,\n      3u^#*expr.Constant_Uint64Value#,\n      -5^#*expr.Constant_DoubleValue#,\n      3.5^#*expr.Constant_DoubleValue#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  10u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.greatest([dyn(5.4), dyn(10u), dyn(3u), dyn(-5.0), dyn(3.5)]) == 10u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.greatest(\n    [\n      dyn(\n        5.4^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        10u^#*expr.Constant_Uint64Value#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        3u^#*expr.Constant_Uint64Value#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        -5^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        3.5^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  10u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(-5)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  -5^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(5)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  5^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1, 1)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  1^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1, 1.0) == 1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1, 1u) == 1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1^#*expr.Constant_Int64Value#,\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(-3, 3)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  -3^#*expr.Constant_Int64Value#,\n  3^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(5, -7)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  5^#*expr.Constant_Int64Value#,\n  -7^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(9223372036854775807, 1)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  9223372036854775807^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1, 9223372036854775807)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  1^#*expr.Constant_Int64Value#,\n  9223372036854775807^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(-9223372036854775808, 1)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  -9223372036854775808^#*expr.Constant_Int64Value#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1, -9223372036854775808)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  1^#*expr.Constant_Int64Value#,\n  -9223372036854775808^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1, 1, 1) == 1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1, 1.0, 1.0) == 1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_DoubleValue#,\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1, 1u, 1u) == 1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1^#*expr.Constant_Int64Value#,\n    1u^#*expr.Constant_Uint64Value#,\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(0, 1, 3) == 0",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    0^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1, 3, 0) == 0",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#,\n    0^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(-1, -2, -3) == -3",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    -1^#*expr.Constant_Int64Value#,\n    -2^#*expr.Constant_Int64Value#,\n    -3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -3^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(9223372036854775807, 1, 5) == 1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    9223372036854775807^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#,\n    5^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(-9223372036854775808, -1, -5) == -9223372036854775808",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    -9223372036854775808^#*expr.Constant_Int64Value#,\n    -1^#*expr.Constant_Int64Value#,\n    -5^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -9223372036854775808^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(5.4, 10, 3u, -5.0, 9223372036854775807) == -5.0",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    5.4^#*expr.Constant_DoubleValue#,\n    10^#*expr.Constant_Int64Value#,\n    3u^#*expr.Constant_Uint64Value#,\n    -5^#*expr.Constant_DoubleValue#,\n    9223372036854775807^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least([5.4, 10, 3u, -5.0, 3.5]) == -5.0",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    [\n      5.4^#*expr.Constant_DoubleValue#,\n      10^#*expr.Constant_Int64Value#,\n      3u^#*expr.Constant_Uint64Value#,\n      -5^#*expr.Constant_DoubleValue#,\n      3.5^#*expr.Constant_DoubleValue#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  -5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least([dyn(5.4), dyn(10), dyn(3u), dyn(-5.0), dyn(3.5)]) == -5.0",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    [\n      dyn(\n        5.4^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        10^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        3u^#*expr.Constant_Uint64Value#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        -5^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        3.5^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  -5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(-5.5)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  -5.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(5.5)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  5.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1.5, 1.5)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  1.5^#*expr.Constant_DoubleValue#,\n  1.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1.0, 1) == 1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1^#*expr.Constant_DoubleValue#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1, 1u) == 1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1^#*expr.Constant_Int64Value#,\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(-3.5, 3.5)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  -3.5^#*expr.Constant_DoubleValue#,\n  3.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(5.5, -7.5)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  5.5^#*expr.Constant_DoubleValue#,\n  -7.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1.797693e308, 1.5)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  1.797693e+308^#*expr.Constant_DoubleValue#,\n  1.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1.5, 1.797693e308)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  1.5^#*expr.Constant_DoubleValue#,\n  1.797693e+308^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(-1.797693e308, 1.5)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  -1.797693e+308^#*expr.Constant_DoubleValue#,\n  1.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1.5, -1.797693e308)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  1.5^#*expr.Constant_DoubleValue#,\n  -1.797693e+308^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1.5, 1.5, 1.5) == 1.5",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1.5^#*expr.Constant_DoubleValue#,\n    1.5^#*expr.Constant_DoubleValue#,\n    1.5^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1.0, 1, 1) == 1.0",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1^#*expr.Constant_DoubleValue#,\n    1^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1.0, 1u, 1u) == 1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1^#*expr.Constant_DoubleValue#,\n    1u^#*expr.Constant_Uint64Value#,\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(0.5, 1.5, 3.5) == 0.5",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    0.5^#*expr.Constant_DoubleValue#,\n    1.5^#*expr.Constant_DoubleValue#,\n    3.5^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  0.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1.5, 3.5, 0.5) == 0.5",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1.5^#*expr.Constant_DoubleValue#,\n    3.5^#*expr.Constant_DoubleValue#,\n    0.5^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  0.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(-1.5, -2.5, -3.5) == -3.5",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    -1.5^#*expr.Constant_DoubleValue#,\n    -2.5^#*expr.Constant_DoubleValue#,\n    -3.5^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  -3.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1.797693e308, 1, 5) == 1",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1.797693e+308^#*expr.Constant_DoubleValue#,\n    1^#*expr.Constant_Int64Value#,\n    5^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(-1.797693e308, -1, -5) == -1.797693e308",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    -1.797693e+308^#*expr.Constant_DoubleValue#,\n    -1^#*expr.Constant_Int64Value#,\n    -5^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -1.797693e+308^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(5.4, 10, 3u, -5.0, 1.797693e308) == -5.0",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    5.4^#*expr.Constant_DoubleValue#,\n    10^#*expr.Constant_Int64Value#,\n    3u^#*expr.Constant_Uint64Value#,\n    -5^#*expr.Constant_DoubleValue#,\n    1.797693e+308^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  -5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least([5.4, 10.5, 3u, -5.0, 3.5]) == -5.0",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    [\n      5.4^#*expr.Constant_DoubleValue#,\n      10.5^#*expr.Constant_DoubleValue#,\n      3u^#*expr.Constant_Uint64Value#,\n      -5^#*expr.Constant_DoubleValue#,\n      3.5^#*expr.Constant_DoubleValue#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  -5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least([dyn(5.4), dyn(10.5), dyn(3u), dyn(-5.0), dyn(3.5)]) == -5.0",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    [\n      dyn(\n        5.4^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        10.5^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        3u^#*expr.Constant_Uint64Value#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        -5^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        3.5^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  -5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(5u)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  5u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1u, 1u)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  1u^#*expr.Constant_Uint64Value#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1u, 1.0) == 1u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1u^#*expr.Constant_Uint64Value#,\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1u, 1) == 1u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1u^#*expr.Constant_Uint64Value#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1u, 3u)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  1u^#*expr.Constant_Uint64Value#,\n  3u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(5u, 2u)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  5u^#*expr.Constant_Uint64Value#,\n  2u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(18446744073709551615u, 1u)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  18446744073709551615u^#*expr.Constant_Uint64Value#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1u, 18446744073709551615u)",
+    ast: "math^#*expr.Expr_IdentExpr#.least(\n  1u^#*expr.Constant_Uint64Value#,\n  18446744073709551615u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1u, 1u, 1u) == 1u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1u^#*expr.Constant_Uint64Value#,\n    1u^#*expr.Constant_Uint64Value#,\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1u, 1.0, 1.0) == 1u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1u^#*expr.Constant_Uint64Value#,\n    1^#*expr.Constant_DoubleValue#,\n    1^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1u, 1, 1) == 1u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1u^#*expr.Constant_Uint64Value#,\n    1^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(1u, 10u, 3u) == 1u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    1u^#*expr.Constant_Uint64Value#,\n    10u^#*expr.Constant_Uint64Value#,\n    3u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(10u, 3u, 1u) == 1u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    10u^#*expr.Constant_Uint64Value#,\n    3u^#*expr.Constant_Uint64Value#,\n    1u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(18446744073709551615u, 1u, 5u) == 1u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    18446744073709551615u^#*expr.Constant_Uint64Value#,\n    1u^#*expr.Constant_Uint64Value#,\n    5u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least(5.4, 10, 3u, 1u, 18446744073709551615u) == 1u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    5.4^#*expr.Constant_DoubleValue#,\n    10^#*expr.Constant_Int64Value#,\n    3u^#*expr.Constant_Uint64Value#,\n    1u^#*expr.Constant_Uint64Value#,\n    18446744073709551615u^#*expr.Constant_Uint64Value#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least([5.4, 10u, 3u, 1u, 3.5]) == 1u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    [\n      5.4^#*expr.Constant_DoubleValue#,\n      10u^#*expr.Constant_Uint64Value#,\n      3u^#*expr.Constant_Uint64Value#,\n      1u^#*expr.Constant_Uint64Value#,\n      3.5^#*expr.Constant_DoubleValue#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.least([dyn(5.4), dyn(10u), dyn(3u), dyn(1u), dyn(3.5)]) == 1u",
+    ast: "_==_(\n  math^#*expr.Expr_IdentExpr#.least(\n    [\n      dyn(\n        5.4^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        10u^#*expr.Constant_Uint64Value#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        3u^#*expr.Constant_Uint64Value#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        1u^#*expr.Constant_Uint64Value#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        3.5^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.ceil(-1.2)",
+    ast: "math^#*expr.Expr_IdentExpr#.ceil(\n  -1.2^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.ceil(1.2)",
+    ast: "math^#*expr.Expr_IdentExpr#.ceil(\n  1.2^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.ceil(dyn(1))",
+    ast: "math^#*expr.Expr_IdentExpr#.ceil(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.floor(-1.2)",
+    ast: "math^#*expr.Expr_IdentExpr#.floor(\n  -1.2^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.floor(1.2)",
+    ast: "math^#*expr.Expr_IdentExpr#.floor(\n  1.2^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.floor(dyn(1))",
+    ast: "math^#*expr.Expr_IdentExpr#.floor(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.round(-1.6)",
+    ast: "math^#*expr.Expr_IdentExpr#.round(\n  -1.6^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.round(-1.4)",
+    ast: "math^#*expr.Expr_IdentExpr#.round(\n  -1.4^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.round(-1.5)",
+    ast: "math^#*expr.Expr_IdentExpr#.round(\n  -1.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.round(1.2)",
+    ast: "math^#*expr.Expr_IdentExpr#.round(\n  1.2^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.round(1.5)",
+    ast: "math^#*expr.Expr_IdentExpr#.round(\n  1.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.isNaN(math.round(0.0/0.0))",
+    ast: "math^#*expr.Expr_IdentExpr#.isNaN(\n  math^#*expr.Expr_IdentExpr#.round(\n    _/_(\n      0^#*expr.Constant_DoubleValue#,\n      0^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.round(dyn(1))",
+    ast: "math^#*expr.Expr_IdentExpr#.round(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.trunc(-1.2)",
+    ast: "math^#*expr.Expr_IdentExpr#.trunc(\n  -1.2^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.trunc(1.2)",
+    ast: "math^#*expr.Expr_IdentExpr#.trunc(\n  1.2^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.isNaN(math.trunc(0.0/0.0))",
+    ast: "math^#*expr.Expr_IdentExpr#.isNaN(\n  math^#*expr.Expr_IdentExpr#.trunc(\n    _/_(\n      0^#*expr.Constant_DoubleValue#,\n      0^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.trunc(dyn(1))",
+    ast: "math^#*expr.Expr_IdentExpr#.trunc(\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.abs(1u)",
+    ast: "math^#*expr.Expr_IdentExpr#.abs(\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.abs(1)",
+    ast: "math^#*expr.Expr_IdentExpr#.abs(\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.abs(-11)",
+    ast: "math^#*expr.Expr_IdentExpr#.abs(\n  -11^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.abs(1.5)",
+    ast: "math^#*expr.Expr_IdentExpr#.abs(\n  1.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.abs(-11.5)",
+    ast: "math^#*expr.Expr_IdentExpr#.abs(\n  -11.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.abs(-9223372036854775808)",
+    ast: "math^#*expr.Expr_IdentExpr#.abs(\n  -9223372036854775808^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.sign(100u)",
+    ast: "math^#*expr.Expr_IdentExpr#.sign(\n  100u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.sign(0u)",
+    ast: "math^#*expr.Expr_IdentExpr#.sign(\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.sign(100)",
+    ast: "math^#*expr.Expr_IdentExpr#.sign(\n  100^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.sign(-11)",
+    ast: "math^#*expr.Expr_IdentExpr#.sign(\n  -11^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.sign(0)",
+    ast: "math^#*expr.Expr_IdentExpr#.sign(\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.sign(100.5)",
+    ast: "math^#*expr.Expr_IdentExpr#.sign(\n  100.5^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.sign(-32.0)",
+    ast: "math^#*expr.Expr_IdentExpr#.sign(\n  -32^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.sign(0.0)",
+    ast: "math^#*expr.Expr_IdentExpr#.sign(\n  0^#*expr.Constant_DoubleValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.sign(dyn(true))",
+    ast: "math^#*expr.Expr_IdentExpr#.sign(\n  dyn(\n    true^#*expr.Constant_BoolValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.isNaN(0.0/0.0)",
+    ast: "math^#*expr.Expr_IdentExpr#.isNaN(\n  _/_(\n    0^#*expr.Constant_DoubleValue#,\n    0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "!math.isNaN(1.0/0.0)",
+    ast: "!_(\n  math^#*expr.Expr_IdentExpr#.isNaN(\n    _/_(\n      1^#*expr.Constant_DoubleValue#,\n      0^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.isNaN(dyn(true))",
+    ast: "math^#*expr.Expr_IdentExpr#.isNaN(\n  dyn(\n    true^#*expr.Constant_BoolValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.isInf(1.0/0.0)",
+    ast: "math^#*expr.Expr_IdentExpr#.isInf(\n  _/_(\n    1^#*expr.Constant_DoubleValue#,\n    0^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "!math.isInf(0.0/0.0)",
+    ast: "!_(\n  math^#*expr.Expr_IdentExpr#.isInf(\n    _/_(\n      0^#*expr.Constant_DoubleValue#,\n      0^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.isInf(dyn(true))",
+    ast: "math^#*expr.Expr_IdentExpr#.isInf(\n  dyn(\n    true^#*expr.Constant_BoolValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.isFinite(1.0/1.5)",
+    ast: "math^#*expr.Expr_IdentExpr#.isFinite(\n  _/_(\n    1^#*expr.Constant_DoubleValue#,\n    1.5^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "!math.isFinite(0.0/0.0)",
+    ast: "!_(\n  math^#*expr.Expr_IdentExpr#.isFinite(\n    _/_(\n      0^#*expr.Constant_DoubleValue#,\n      0^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "!math.isFinite(-1.0/0.0)",
+    ast: "!_(\n  math^#*expr.Expr_IdentExpr#.isFinite(\n    _/_(\n      -1^#*expr.Constant_DoubleValue#,\n      0^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.isFinite(dyn(true))",
+    ast: "math^#*expr.Expr_IdentExpr#.isFinite(\n  dyn(\n    true^#*expr.Constant_BoolValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitAnd(1, 2)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitAnd(\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitAnd(1, 3)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitAnd(\n  1^#*expr.Constant_Int64Value#,\n  3^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitAnd(1, -1)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitAnd(\n  1^#*expr.Constant_Int64Value#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitAnd(1u, 2u)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitAnd(\n  1u^#*expr.Constant_Uint64Value#,\n  2u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitAnd(1u, 3u)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitAnd(\n  1u^#*expr.Constant_Uint64Value#,\n  3u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitAnd(2u, dyn(''))",
+    ast: 'math^#*expr.Expr_IdentExpr#.bitAnd(\n  2u^#*expr.Constant_Uint64Value#,\n  dyn(\n    ""^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "math.bitOr(1, 2)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitOr(\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitOr(4, -2)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitOr(\n  4^#*expr.Constant_Int64Value#,\n  -2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitOr(1u, 4u)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitOr(\n  1u^#*expr.Constant_Uint64Value#,\n  4u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitOr(dyn(1.2), 1)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitOr(\n  dyn(\n    1.2^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitXor(1, 3)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitXor(\n  1^#*expr.Constant_Int64Value#,\n  3^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitXor(4, -2)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitXor(\n  4^#*expr.Constant_Int64Value#,\n  -2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitXor(1u, 3u)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitXor(\n  1u^#*expr.Constant_Uint64Value#,\n  3u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitXor(dyn([]), dyn([1]))",
+    ast: "math^#*expr.Expr_IdentExpr#.bitXor(\n  dyn(\n    []^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  dyn(\n    [\n      1^#*expr.Constant_Int64Value#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitNot(1)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitNot(\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitNot(-1)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitNot(\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitNot(0)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitNot(\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitNot(1u)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitNot(\n  1u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitNot(0u)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitNot(\n  0u^#*expr.Constant_Uint64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitNot(dyn(''))",
+    ast: 'math^#*expr.Expr_IdentExpr#.bitNot(\n  dyn(\n    ""^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "math.bitShiftLeft(1, 2)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitShiftLeft(\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitShiftLeft(1, 200)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitShiftLeft(\n  1^#*expr.Constant_Int64Value#,\n  200^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitShiftLeft(-1, 200)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitShiftLeft(\n  -1^#*expr.Constant_Int64Value#,\n  200^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitShiftLeft(1u, 2)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitShiftLeft(\n  1u^#*expr.Constant_Uint64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitShiftLeft(1u, 200)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitShiftLeft(\n  1u^#*expr.Constant_Uint64Value#,\n  200^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitShiftLeft(1u, -1)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitShiftLeft(\n  1u^#*expr.Constant_Uint64Value#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitShiftLeft(dyn(4.3), 1)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitShiftLeft(\n  dyn(\n    4.3^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitShiftRight(1024, 2)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitShiftRight(\n  1024^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitShiftRight(1024, 64)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitShiftRight(\n  1024^#*expr.Constant_Int64Value#,\n  64^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitShiftRight(-1024, 3)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitShiftRight(\n  -1024^#*expr.Constant_Int64Value#,\n  3^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitShiftRight(-1024, 64)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitShiftRight(\n  -1024^#*expr.Constant_Int64Value#,\n  64^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitShiftRight(1024u, 2)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitShiftRight(\n  1024u^#*expr.Constant_Uint64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitShiftRight(1024u, 200)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitShiftRight(\n  1024u^#*expr.Constant_Uint64Value#,\n  200^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitShiftRight(1u, -1)",
+    ast: "math^#*expr.Expr_IdentExpr#.bitShiftRight(\n  1u^#*expr.Constant_Uint64Value#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "math.bitShiftRight(dyn(b'123'), 1)",
+    ast: 'math^#*expr.Expr_IdentExpr#.bitShiftRight(\n  dyn(\n    b"123"^#*expr.Constant_BytesValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  { expr: "x.y", ast: "x^#*expr.Expr_IdentExpr#.y^#*expr.Expr_SelectExpr#" },
+  { expr: "y", ast: "y^#*expr.Expr_IdentExpr#" },
+  { expr: "y", ast: "y^#*expr.Expr_IdentExpr#" },
+  {
+    expr: "optional.of(null).hasValue()",
+    ast: "optional^#*expr.Expr_IdentExpr#.of(\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#.hasValue()^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "optional.ofNonZeroValue(null).hasValue()",
+    ast: "optional^#*expr.Expr_IdentExpr#.ofNonZeroValue(\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#.hasValue()^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "optional.none().or(optional.none()).orValue(42)",
+    ast: "optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#.or(\n  optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#.orValue(\n  42^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "optional.none().optMap(y, y + 1).hasValue()",
+    ast: "optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#.optMap(\n  y^#*expr.Expr_IdentExpr#,\n  _+_(\n    y^#*expr.Expr_IdentExpr#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#.hasValue()^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{}.?key.optFlatMap(k, k.?subkey).hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:3: unsupported syntax '.?'\n | {}.?key.optFlatMap(k, k.?subkey).hasValue()\n | ..^\nERROR: \u003cinput\u003e:1:24: unsupported syntax '.?'\n | {}.?key.optFlatMap(k, k.?subkey).hasValue()\n | .......................^",
+  },
+  {
+    expr: "{'key': {}}.?key.optFlatMap(k, k.?subkey).hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:12: unsupported syntax '.?'\n | {'key': {}}.?key.optFlatMap(k, k.?subkey).hasValue()\n | ...........^\nERROR: \u003cinput\u003e:1:33: unsupported syntax '.?'\n | {'key': {}}.?key.optFlatMap(k, k.?subkey).hasValue()\n | ................................^",
+  },
+  {
+    expr: "{'null_key': dyn(null)}.?null_key.hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:24: unsupported syntax '.?'\n | {'null_key': dyn(null)}.?null_key.hasValue()\n | .......................^",
+  },
+  {
+    expr: "{'null_key': dyn(null)}.?null_key.invalid.hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:24: unsupported syntax '.?'\n | {'null_key': dyn(null)}.?null_key.invalid.hasValue()\n | .......................^",
+  },
+  {
+    expr: "{true: dyn(0)}[?false].absent.hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:15: unsupported syntax '[?'\n | {true: dyn(0)}[?false].absent.hasValue()\n | ..............^",
+  },
+  {
+    expr: "{true: dyn(0)}[?true].absent.hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:15: unsupported syntax '[?'\n | {true: dyn(0)}[?true].absent.hasValue()\n | ..............^",
+  },
+  {
+    expr: "{}.?null_key.invalid.hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:3: unsupported syntax '.?'\n | {}.?null_key.invalid.hasValue()\n | ..^",
+  },
+  {
+    expr: "{'key': {'subkey': 'subvalue'}}.?key.optFlatMap(k, k.?subkey).value()",
+    error:
+      "ERROR: \u003cinput\u003e:1:32: unsupported syntax '.?'\n | {'key': {'subkey': 'subvalue'}}.?key.optFlatMap(k, k.?subkey).value()\n | ...............................^\nERROR: \u003cinput\u003e:1:53: unsupported syntax '.?'\n | {'key': {'subkey': 'subvalue'}}.?key.optFlatMap(k, k.?subkey).value()\n | ....................................................^",
+  },
+  {
+    expr: "{'key': {'subkey': ''}}.?key.optFlatMap(k, k.?subkey).value()",
+    error:
+      "ERROR: \u003cinput\u003e:1:24: unsupported syntax '.?'\n | {'key': {'subkey': ''}}.?key.optFlatMap(k, k.?subkey).value()\n | .......................^\nERROR: \u003cinput\u003e:1:45: unsupported syntax '.?'\n | {'key': {'subkey': ''}}.?key.optFlatMap(k, k.?subkey).value()\n | ............................................^",
+  },
+  {
+    expr: "{'key': {'subkey': ''}}.?key.optFlatMap(k, optional.ofNonZeroValue(k.subkey)).hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:24: unsupported syntax '.?'\n | {'key': {'subkey': ''}}.?key.optFlatMap(k, optional.ofNonZeroValue(k.subkey)).hasValue()\n | .......................^",
+  },
+  {
+    expr: "optional.of(42).optMap(y, y + 1).value()",
+    ast: "optional^#*expr.Expr_IdentExpr#.of(\n  42^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#.optMap(\n  y^#*expr.Expr_IdentExpr#,\n  _+_(\n    y^#*expr.Expr_IdentExpr#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#.value()^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "optional.ofNonZeroValue(42).or(optional.of(20)).value() == 42",
+    ast: "_==_(\n  optional^#*expr.Expr_IdentExpr#.ofNonZeroValue(\n    42^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#.or(\n    optional^#*expr.Expr_IdentExpr#.of(\n      20^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#.value()^#*expr.Expr_CallExpr#,\n  42^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "(has({}.x) ? optional.of({}.x) : optional.none()).hasValue()",
+    ast: "_?_:_(\n  {}^#*expr.Expr_StructExpr#.x~test-only~^#*expr.Expr_SelectExpr#,\n  optional^#*expr.Expr_IdentExpr#.of(\n    {}^#*expr.Expr_StructExpr#.x^#*expr.Expr_SelectExpr#\n  )^#*expr.Expr_CallExpr#,\n  optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#.hasValue()^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{}.?x.hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:3: unsupported syntax '.?'\n | {}.?x.hasValue()\n | ..^",
+  },
+  {
+    expr: "has({}.?x.y)",
+    error:
+      "ERROR: \u003cinput\u003e:1:7: unsupported syntax '.?'\n | has({}.?x.y)\n | ......^",
+  },
+  {
+    expr: "has({'x': {'y': 'z'}}.?x.y)",
+    error:
+      "ERROR: \u003cinput\u003e:1:22: unsupported syntax '.?'\n | has({'x': {'y': 'z'}}.?x.y)\n | .....................^",
+  },
+  {
+    expr: "type(optional.none()) == optional_type",
+    ast: "_==_(\n  type(\n    optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  optional_type^#*expr.Expr_IdentExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "optional.ofNonZeroValue('').or(optional.of({'c': {'dashed-index': 'goodbye'}}.c['dashed-index'])).orValue('default value')",
+    ast: 'optional^#*expr.Expr_IdentExpr#.ofNonZeroValue(\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.or(\n  optional^#*expr.Expr_IdentExpr#.of(\n    _[_](\n      {\n        "c"^#*expr.Constant_StringValue#:{\n          "dashed-index"^#*expr.Constant_StringValue#:"goodbye"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n        }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n      }^#*expr.Expr_StructExpr#.c^#*expr.Expr_SelectExpr#,\n      "dashed-index"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#.orValue(\n  "default value"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'c': {'dashed-index': 'goodbye'}}.c[?'dashed-index'].orValue('default value')",
+    error:
+      "ERROR: \u003cinput\u003e:1:37: unsupported syntax '[?'\n | {'c': {'dashed-index': 'goodbye'}}.c[?'dashed-index'].orValue('default value')\n | ....................................^",
+  },
+  {
+    expr: "{'c': {}}.c[?'missing-index'].orValue('default value')",
+    error:
+      "ERROR: \u003cinput\u003e:1:12: unsupported syntax '[?'\n | {'c': {}}.c[?'missing-index'].orValue('default value')\n | ...........^",
+  },
+  {
+    expr: "optional.of({'c': {'index': 'goodbye'}}).c.index.orValue('default value')",
+    ast: 'optional^#*expr.Expr_IdentExpr#.of(\n  {\n    "c"^#*expr.Constant_StringValue#:{\n      "index"^#*expr.Constant_StringValue#:"goodbye"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#.c^#*expr.Expr_SelectExpr#.index^#*expr.Expr_SelectExpr#.orValue(\n  "default value"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "optional.of({'c': {}}).c.missing.or(optional.none()[0]).orValue('default value')",
+    ast: 'optional^#*expr.Expr_IdentExpr#.of(\n  {\n    "c"^#*expr.Constant_StringValue#:{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#.c^#*expr.Expr_SelectExpr#.missing^#*expr.Expr_SelectExpr#.or(\n  _[_](\n    optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#,\n    0^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#.orValue(\n  "default value"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "optional.of({'c': {}}).c.missing.or(optional.of(['list-value'])[0]).orValue('default value')",
+    ast: 'optional^#*expr.Expr_IdentExpr#.of(\n  {\n    "c"^#*expr.Constant_StringValue#:{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#.c^#*expr.Expr_SelectExpr#.missing^#*expr.Expr_SelectExpr#.or(\n  _[_](\n    optional^#*expr.Expr_IdentExpr#.of(\n      [\n        "list-value"^#*expr.Constant_StringValue#\n      ]^#*expr.Expr_ListExpr#\n    )^#*expr.Expr_CallExpr#,\n    0^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#.orValue(\n  "default value"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "optional.of({'c': {'index': 'goodbye'}}).c['index'].orValue('default value')",
+    ast: '_[_](\n  optional^#*expr.Expr_IdentExpr#.of(\n    {\n      "c"^#*expr.Constant_StringValue#:{\n        "index"^#*expr.Constant_StringValue#:"goodbye"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n      }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#.c^#*expr.Expr_SelectExpr#,\n  "index"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.orValue(\n  "default value"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "optional.of({'c': {}}).c['missing'].orValue('default value')",
+    ast: '_[_](\n  optional^#*expr.Expr_IdentExpr#.of(\n    {\n      "c"^#*expr.Constant_StringValue#:{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#.c^#*expr.Expr_SelectExpr#,\n  "missing"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.orValue(\n  "default value"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "has(optional.of({'c': {'entry': 'hello world'}}).c) \u0026\u0026 !has(optional.of({'c': {'entry': 'hello world'}}).c.missing)",
+    ast: '_\u0026\u0026_(\n  optional^#*expr.Expr_IdentExpr#.of(\n    {\n      "c"^#*expr.Constant_StringValue#:{\n        "entry"^#*expr.Constant_StringValue#:"hello world"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n      }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#.c~test-only~^#*expr.Expr_SelectExpr#,\n  !_(\n    optional^#*expr.Expr_IdentExpr#.of(\n      {\n        "c"^#*expr.Constant_StringValue#:{\n          "entry"^#*expr.Constant_StringValue#:"hello world"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n        }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n      }^#*expr.Expr_StructExpr#\n    )^#*expr.Expr_CallExpr#.c^#*expr.Expr_SelectExpr#.missing~test-only~^#*expr.Expr_SelectExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "optional.ofNonZeroValue({'c': {'dashed-index': 'goodbye'}}.a.z).orValue({'c': {'dashed-index': 'goodbye'}}.c['dashed-index'])",
+    ast: 'optional^#*expr.Expr_IdentExpr#.ofNonZeroValue(\n  {\n    "c"^#*expr.Constant_StringValue#:{\n      "dashed-index"^#*expr.Constant_StringValue#:"goodbye"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#.a^#*expr.Expr_SelectExpr#.z^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#.orValue(\n  _[_](\n    {\n      "c"^#*expr.Constant_StringValue#:{\n        "dashed-index"^#*expr.Constant_StringValue#:"goodbye"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n      }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#.c^#*expr.Expr_SelectExpr#,\n    "dashed-index"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'c': {'dashed-index': 'goodbye'}}.?c.missing.or({'c': {'dashed-index': 'goodbye'}}.?c['dashed-index']).orValue('').size()",
+    error:
+      "ERROR: \u003cinput\u003e:1:35: unsupported syntax '.?'\n | {'c': {'dashed-index': 'goodbye'}}.?c.missing.or({'c': {'dashed-index': 'goodbye'}}.?c['dashed-index']).orValue('').size()\n | ..................................^\nERROR: \u003cinput\u003e:1:84: unsupported syntax '.?'\n | {'c': {'dashed-index': 'goodbye'}}.?c.missing.or({'c': {'dashed-index': 'goodbye'}}.?c['dashed-index']).orValue('').size()\n | ...................................................................................^",
+  },
+  {
+    expr: "{?'nested_map': optional.ofNonZeroValue({?'map': {'c': {'dashed-index': 'goodbye'}}.?c})}",
+    error:
+      "ERROR: \u003cinput\u003e:1:2: unsupported syntax '?'\n | {?'nested_map': optional.ofNonZeroValue({?'map': {'c': {'dashed-index': 'goodbye'}}.?c})}\n | .^",
+  },
+  {
+    expr: "{?'nested_map': optional.ofNonZeroValue({?'map': {}.?c}), 'singleton': true}",
+    error:
+      "ERROR: \u003cinput\u003e:1:2: unsupported syntax '?'\n | {?'nested_map': optional.ofNonZeroValue({?'map': {}.?c}), 'singleton': true}\n | .^",
+  },
+  {
+    expr: "[?{}.?c, ?optional.of(42), ?optional.none()]",
+    error:
+      "ERROR: \u003cinput\u003e:1:2: unsupported syntax '?'\n | [?{}.?c, ?optional.of(42), ?optional.none()]\n | .^\nERROR: \u003cinput\u003e:1:5: unsupported syntax '.?'\n | [?{}.?c, ?optional.of(42), ?optional.none()]\n | ....^\nERROR: \u003cinput\u003e:1:10: unsupported syntax '?'\n | [?{}.?c, ?optional.of(42), ?optional.none()]\n | .........^\nERROR: \u003cinput\u003e:1:28: unsupported syntax '?'\n | [?{}.?c, ?optional.of(42), ?optional.none()]\n | ...........................^",
+  },
+  {
+    expr: "[?optional.ofNonZeroValue({'c': []}.?c.orValue(dyn({})))]",
+    error:
+      "ERROR: \u003cinput\u003e:1:2: unsupported syntax '?'\n | [?optional.ofNonZeroValue({'c': []}.?c.orValue(dyn({})))]\n | .^\nERROR: \u003cinput\u003e:1:36: unsupported syntax '.?'\n | [?optional.ofNonZeroValue({'c': []}.?c.orValue(dyn({})))]\n | ...................................^",
+  },
+  {
+    expr: "optional.ofNonZeroValue({?'nested_map': optional.ofNonZeroValue({?'map': optional.of({}).?c})}).hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:26: unsupported syntax '?'\n | optional.ofNonZeroValue({?'nested_map': optional.ofNonZeroValue({?'map': optional.of({}).?c})}).hasValue()\n | .........................^",
+  },
+  {
+    expr: "has(TestAllTypes{?single_double_wrapper: optional.ofNonZeroValue(0.0)}.single_double_wrapper)",
+    error:
+      "ERROR: \u003cinput\u003e:1:18: unsupported syntax '?'\n | has(TestAllTypes{?single_double_wrapper: optional.ofNonZeroValue(0.0)}.single_double_wrapper)\n | .................^",
+  },
+  {
+    expr: "optional.ofNonZeroValue(TestAllTypes{?single_double_wrapper: optional.ofNonZeroValue(0.0)}).hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:38: unsupported syntax '?'\n | optional.ofNonZeroValue(TestAllTypes{?single_double_wrapper: optional.ofNonZeroValue(0.0)}).hasValue()\n | .....................................^",
+  },
+  {
+    expr: "TestAllTypes{?map_string_string: {'nested': {}}[?'nested']}.map_string_string",
+    error:
+      "ERROR: \u003cinput\u003e:1:14: unsupported syntax '?'\n | TestAllTypes{?map_string_string: {'nested': {}}[?'nested']}.map_string_string\n | .............^",
+  },
+  {
+    expr: "TestAllTypes{?map_string_string: optional.ofNonZeroValue({'nested': {}}[?'nested'].orValue({}))}.map_string_string",
+    error:
+      "ERROR: \u003cinput\u003e:1:14: unsupported syntax '?'\n | TestAllTypes{?map_string_string: optional.ofNonZeroValue({'nested': {}}[?'nested'].orValue({}))}.map_string_string\n | .............^",
+  },
+  {
+    expr: "TestAllTypes{?map_string_string: {'nested': {'hello': 'world'}}[?'nested']}.map_string_string",
+    error:
+      "ERROR: \u003cinput\u003e:1:14: unsupported syntax '?'\n | TestAllTypes{?map_string_string: {'nested': {'hello': 'world'}}[?'nested']}.map_string_string\n | .............^",
+  },
+  {
+    expr: "TestAllTypes{repeated_string: ['greetings', ?{'nested': {'hello': 'world'}}.nested.?hello]}.repeated_string",
+    error:
+      "ERROR: \u003cinput\u003e:1:45: unsupported syntax '?'\n | TestAllTypes{repeated_string: ['greetings', ?{'nested': {'hello': 'world'}}.nested.?hello]}.repeated_string\n | ............................................^\nERROR: \u003cinput\u003e:1:83: unsupported syntax '.?'\n | TestAllTypes{repeated_string: ['greetings', ?{'nested': {'hello': 'world'}}.nested.?hello]}.repeated_string\n | ..................................................................................^",
+  },
+  {
+    expr: "optional.of({}).?c.hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:16: unsupported syntax '.?'\n | optional.of({}).?c.hasValue()\n | ...............^",
+  },
+  {
+    expr: "TestAllTypes{}.?repeated_string.hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:15: unsupported syntax '.?'\n | TestAllTypes{}.?repeated_string.hasValue()\n | ..............^",
+  },
+  {
+    expr: "optional.of(TestAllTypes{}).?repeated_string.hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:28: unsupported syntax '.?'\n | optional.of(TestAllTypes{}).?repeated_string.hasValue()\n | ...........................^",
+  },
+  {
+    expr: "optional.none().?repeated_string.hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:16: unsupported syntax '.?'\n | optional.none().?repeated_string.hasValue()\n | ...............^",
+  },
+  {
+    expr: "TestAllTypes{repeated_string: ['foo']}.?repeated_string.value()",
+    error:
+      "ERROR: \u003cinput\u003e:1:39: unsupported syntax '.?'\n | TestAllTypes{repeated_string: ['foo']}.?repeated_string.value()\n | ......................................^",
+  },
+  {
+    expr: "optional.of(TestAllTypes{repeated_string: ['foo']}).?repeated_string.value()",
+    error:
+      "ERROR: \u003cinput\u003e:1:52: unsupported syntax '.?'\n | optional.of(TestAllTypes{repeated_string: ['foo']}).?repeated_string.value()\n | ...................................................^",
+  },
+  {
+    expr: "optional.of(TestAllTypes{repeated_string: ['foo']}).?repeated_string[0].value()",
+    error:
+      "ERROR: \u003cinput\u003e:1:52: unsupported syntax '.?'\n | optional.of(TestAllTypes{repeated_string: ['foo']}).?repeated_string[0].value()\n | ...................................................^",
+  },
+  {
+    expr: "[][?0].hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:3: unsupported syntax '[?'\n | [][?0].hasValue()\n | ..^",
+  },
+  {
+    expr: "optional.of([])[?0].hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:16: unsupported syntax '[?'\n | optional.of([])[?0].hasValue()\n | ...............^",
+  },
+  {
+    expr: "optional.none()[?0].hasValue()",
+    error:
+      "ERROR: \u003cinput\u003e:1:16: unsupported syntax '[?'\n | optional.none()[?0].hasValue()\n | ...............^",
+  },
+  {
+    expr: "['foo'][?0].value()",
+    error:
+      "ERROR: \u003cinput\u003e:1:8: unsupported syntax '[?'\n | ['foo'][?0].value()\n | .......^",
+  },
+  {
+    expr: "optional.of(['foo'])[?0].value()",
+    error:
+      "ERROR: \u003cinput\u003e:1:21: unsupported syntax '[?'\n | optional.of(['foo'])[?0].value()\n | ....................^",
+  },
+  {
+    expr: "{true: 1, 2: 2, 5u: 3}[?true].value()",
+    error:
+      "ERROR: \u003cinput\u003e:1:23: unsupported syntax '[?'\n | {true: 1, 2: 2, 5u: 3}[?true].value()\n | ......................^",
+  },
+  {
+    expr: "{1u: 1.0, 2: 2.0, 3u: 3.0}[?3.0].value()",
+    error:
+      "ERROR: \u003cinput\u003e:1:27: unsupported syntax '[?'\n | {1u: 1.0, 2: 2.0, 3u: 3.0}[?3.0].value()\n | ..........................^",
+  },
+  {
+    expr: "{1u: 1.0, 2: 2.0, 3u: 3.0}[?2u].value()",
+    error:
+      "ERROR: \u003cinput\u003e:1:27: unsupported syntax '[?'\n | {1u: 1.0, 2: 2.0, 3u: 3.0}[?2u].value()\n | ..........................^",
+  },
+  {
+    expr: "{1u: 1.0, 2: 2.0, 3u: 3.0}[?1].value()",
+    error:
+      "ERROR: \u003cinput\u003e:1:27: unsupported syntax '[?'\n | {1u: 1.0, 2: 2.0, 3u: 3.0}[?1].value()\n | ..........................^",
+  },
+  {
+    expr: "optional.none() == optional.none()",
+    ast: "_==_(\n  optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#,\n  optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "optional.none() == optional.of(1)",
+    ast: "_==_(\n  optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#,\n  optional^#*expr.Expr_IdentExpr#.of(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "optional.of(1) == optional.none()",
+    ast: "_==_(\n  optional^#*expr.Expr_IdentExpr#.of(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "optional.of(1) == optional.of(1)",
+    ast: "_==_(\n  optional^#*expr.Expr_IdentExpr#.of(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  optional^#*expr.Expr_IdentExpr#.of(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "optional.none() != optional.none()",
+    ast: "_!=_(\n  optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#,\n  optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "optional.none() != optional.of(1)",
+    ast: "_!=_(\n  optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#,\n  optional^#*expr.Expr_IdentExpr#.of(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "optional.of(1) != optional.none()",
+    ast: "_!=_(\n  optional^#*expr.Expr_IdentExpr#.of(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "optional.of(1) != optional.of(1)",
+    ast: "_!=_(\n  optional^#*expr.Expr_IdentExpr#.of(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  optional^#*expr.Expr_IdentExpr#.of(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "has({'foo': optional.none()}.foo)",
+    ast: '{\n  "foo"^#*expr.Constant_StringValue#:optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.foo~test-only~^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "has({'foo': optional.none()}.foo.bar)",
+    ast: '{\n  "foo"^#*expr.Constant_StringValue#:optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.foo^#*expr.Expr_SelectExpr#.bar~test-only~^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "has({?'foo': optional.none()}.foo)",
+    error:
+      "ERROR: \u003cinput\u003e:1:6: unsupported syntax '?'\n | has({?'foo': optional.none()}.foo)\n | .....^",
+  },
+  {
+    expr: "a[a[a[a[a[a[a[a[a[a[a[a[0]]]]]]]]]]]]",
+    ast: "_[_](\n  a^#*expr.Expr_IdentExpr#,\n  _[_](\n    a^#*expr.Expr_IdentExpr#,\n    _[_](\n      a^#*expr.Expr_IdentExpr#,\n      _[_](\n        a^#*expr.Expr_IdentExpr#,\n        _[_](\n          a^#*expr.Expr_IdentExpr#,\n          _[_](\n            a^#*expr.Expr_IdentExpr#,\n            _[_](\n              a^#*expr.Expr_IdentExpr#,\n              _[_](\n                a^#*expr.Expr_IdentExpr#,\n                _[_](\n                  a^#*expr.Expr_IdentExpr#,\n                  _[_](\n                    a^#*expr.Expr_IdentExpr#,\n                    _[_](\n                      a^#*expr.Expr_IdentExpr#,\n                      _[_](\n                        a^#*expr.Expr_IdentExpr#,\n                        0^#*expr.Constant_Int64Value#\n                      )^#*expr.Expr_CallExpr#\n                    )^#*expr.Expr_CallExpr#\n                  )^#*expr.Expr_CallExpr#\n                )^#*expr.Expr_CallExpr#\n              )^#*expr.Expr_CallExpr#\n            )^#*expr.Expr_CallExpr#\n          )^#*expr.Expr_CallExpr#\n        )^#*expr.Expr_CallExpr#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{payload: TestAllTypes{single_int64: 137}}}}}}}}}}}}.payload.single_int64",
+    ast: "NestedTestAllTypes{\n  child:NestedTestAllTypes{\n    child:NestedTestAllTypes{\n      child:NestedTestAllTypes{\n        child:NestedTestAllTypes{\n          child:NestedTestAllTypes{\n            child:NestedTestAllTypes{\n              child:NestedTestAllTypes{\n                child:NestedTestAllTypes{\n                  child:NestedTestAllTypes{\n                    child:NestedTestAllTypes{\n                      payload:TestAllTypes{\n                        single_int64:137^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n                      }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n                    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n                  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n                }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n              }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n            }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n          }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n        }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n      }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.payload^#*expr.Expr_SelectExpr#.single_int64^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "int(uint(int(uint(int(uint(int(uint(int(uint(int(uint(7))))))))))))",
+    ast: "int(\n  uint(\n    int(\n      uint(\n        int(\n          uint(\n            int(\n              uint(\n                int(\n                  uint(\n                    int(\n                      uint(\n                        7^#*expr.Constant_Int64Value#\n                      )^#*expr.Expr_CallExpr#\n                    )^#*expr.Expr_CallExpr#\n                  )^#*expr.Expr_CallExpr#\n                )^#*expr.Expr_CallExpr#\n              )^#*expr.Expr_CallExpr#\n            )^#*expr.Expr_CallExpr#\n          )^#*expr.Expr_CallExpr#\n        )^#*expr.Expr_CallExpr#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "size([[[[[[[[[[[[0]]]]]]]]]]]])",
+    ast: "size(\n  [\n    [\n      [\n        [\n          [\n            [\n              [\n                [\n                  [\n                    [\n                      [\n                        [\n                          0^#*expr.Constant_Int64Value#\n                        ]^#*expr.Expr_ListExpr#\n                      ]^#*expr.Expr_ListExpr#\n                    ]^#*expr.Expr_ListExpr#\n                  ]^#*expr.Expr_ListExpr#\n                ]^#*expr.Expr_ListExpr#\n              ]^#*expr.Expr_ListExpr#\n            ]^#*expr.Expr_ListExpr#\n          ]^#*expr.Expr_ListExpr#\n        ]^#*expr.Expr_ListExpr#\n      ]^#*expr.Expr_ListExpr#\n    ]^#*expr.Expr_ListExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "size({0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: 'foo'}}}}}}}}}}}})",
+    ast: 'size(\n  {\n    0^#*expr.Constant_Int64Value#:{\n      0^#*expr.Constant_Int64Value#:{\n        0^#*expr.Constant_Int64Value#:{\n          0^#*expr.Constant_Int64Value#:{\n            0^#*expr.Constant_Int64Value#:{\n              0^#*expr.Constant_Int64Value#:{\n                0^#*expr.Constant_Int64Value#:{\n                  0^#*expr.Constant_Int64Value#:{\n                    0^#*expr.Constant_Int64Value#:{\n                      0^#*expr.Constant_Int64Value#:{\n                        0^#*expr.Constant_Int64Value#:{\n                          0^#*expr.Constant_Int64Value#:"foo"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n                        }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n                      }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n                    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n                  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n                }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n              }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n            }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n          }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n        }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n      }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "((((((((((((((((((((((((((((((((7))))))))))))))))))))))))))))))))",
+    error:
+      "ERROR: \u003cinput\u003e:-1:0: expression recursion limit exceeded: 32",
+  },
+  {
+    expr: "true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : false",
+    ast: "_?_:_(\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  _?_:_(\n    true^#*expr.Constant_BoolValue#,\n    true^#*expr.Constant_BoolValue#,\n    _?_:_(\n      true^#*expr.Constant_BoolValue#,\n      true^#*expr.Constant_BoolValue#,\n      _?_:_(\n        true^#*expr.Constant_BoolValue#,\n        true^#*expr.Constant_BoolValue#,\n        _?_:_(\n          true^#*expr.Constant_BoolValue#,\n          true^#*expr.Constant_BoolValue#,\n          _?_:_(\n            true^#*expr.Constant_BoolValue#,\n            true^#*expr.Constant_BoolValue#,\n            _?_:_(\n              true^#*expr.Constant_BoolValue#,\n              true^#*expr.Constant_BoolValue#,\n              _?_:_(\n                true^#*expr.Constant_BoolValue#,\n                true^#*expr.Constant_BoolValue#,\n                _?_:_(\n                  true^#*expr.Constant_BoolValue#,\n                  true^#*expr.Constant_BoolValue#,\n                  _?_:_(\n                    true^#*expr.Constant_BoolValue#,\n                    true^#*expr.Constant_BoolValue#,\n                    _?_:_(\n                      true^#*expr.Constant_BoolValue#,\n                      true^#*expr.Constant_BoolValue#,\n                      _?_:_(\n                        true^#*expr.Constant_BoolValue#,\n                        true^#*expr.Constant_BoolValue#,\n                        _?_:_(\n                          true^#*expr.Constant_BoolValue#,\n                          true^#*expr.Constant_BoolValue#,\n                          _?_:_(\n                            true^#*expr.Constant_BoolValue#,\n                            true^#*expr.Constant_BoolValue#,\n                            _?_:_(\n                              true^#*expr.Constant_BoolValue#,\n                              true^#*expr.Constant_BoolValue#,\n                              _?_:_(\n                                true^#*expr.Constant_BoolValue#,\n                                true^#*expr.Constant_BoolValue#,\n                                _?_:_(\n                                  true^#*expr.Constant_BoolValue#,\n                                  true^#*expr.Constant_BoolValue#,\n                                  _?_:_(\n                                    true^#*expr.Constant_BoolValue#,\n                                    true^#*expr.Constant_BoolValue#,\n                                    _?_:_(\n                                      true^#*expr.Constant_BoolValue#,\n                                      true^#*expr.Constant_BoolValue#,\n                                      _?_:_(\n                                        true^#*expr.Constant_BoolValue#,\n                                        true^#*expr.Constant_BoolValue#,\n                                        _?_:_(\n                                          true^#*expr.Constant_BoolValue#,\n                                          true^#*expr.Constant_BoolValue#,\n                                          _?_:_(\n                                            true^#*expr.Constant_BoolValue#,\n                                            true^#*expr.Constant_BoolValue#,\n                                            _?_:_(\n                                              true^#*expr.Constant_BoolValue#,\n                                              true^#*expr.Constant_BoolValue#,\n                                              _?_:_(\n                                                true^#*expr.Constant_BoolValue#,\n                                                true^#*expr.Constant_BoolValue#,\n                                                false^#*expr.Constant_BoolValue#\n                                              )^#*expr.Expr_CallExpr#\n                                            )^#*expr.Expr_CallExpr#\n                                          )^#*expr.Expr_CallExpr#\n                                        )^#*expr.Expr_CallExpr#\n                                      )^#*expr.Expr_CallExpr#\n                                    )^#*expr.Expr_CallExpr#\n                                  )^#*expr.Expr_CallExpr#\n                                )^#*expr.Expr_CallExpr#\n                              )^#*expr.Expr_CallExpr#\n                            )^#*expr.Expr_CallExpr#\n                          )^#*expr.Expr_CallExpr#\n                        )^#*expr.Expr_CallExpr#\n                      )^#*expr.Expr_CallExpr#\n                    )^#*expr.Expr_CallExpr#\n                  )^#*expr.Expr_CallExpr#\n                )^#*expr.Expr_CallExpr#\n              )^#*expr.Expr_CallExpr#\n            )^#*expr.Expr_CallExpr#\n          )^#*expr.Expr_CallExpr#\n        )^#*expr.Expr_CallExpr#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || true",
+    ast: "_||_(\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 true \u0026\u0026 false",
+    ast: "_\u0026\u0026_(\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  true^#*expr.Constant_BoolValue#,\n  false^#*expr.Constant_BoolValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3",
+    ast: "_+_(\n  _-_(\n    _+_(\n      _-_(\n        _+_(\n          _-_(\n            _+_(\n              _-_(\n                _+_(\n                  _-_(\n                    _+_(\n                      _-_(\n                        _+_(\n                          _-_(\n                            _+_(\n                              _-_(\n                                _+_(\n                                  _-_(\n                                    _+_(\n                                      _-_(\n                                        _+_(\n                                          _-_(\n                                            _+_(\n                                              _-_(\n                                                3^#*expr.Constant_Int64Value#,\n                                                3^#*expr.Constant_Int64Value#\n                                              )^#*expr.Expr_CallExpr#,\n                                              3^#*expr.Constant_Int64Value#\n                                            )^#*expr.Expr_CallExpr#,\n                                            3^#*expr.Constant_Int64Value#\n                                          )^#*expr.Expr_CallExpr#,\n                                          3^#*expr.Constant_Int64Value#\n                                        )^#*expr.Expr_CallExpr#,\n                                        3^#*expr.Constant_Int64Value#\n                                      )^#*expr.Expr_CallExpr#,\n                                      3^#*expr.Constant_Int64Value#\n                                    )^#*expr.Expr_CallExpr#,\n                                    3^#*expr.Constant_Int64Value#\n                                  )^#*expr.Expr_CallExpr#,\n                                  3^#*expr.Constant_Int64Value#\n                                )^#*expr.Expr_CallExpr#,\n                                3^#*expr.Constant_Int64Value#\n                              )^#*expr.Expr_CallExpr#,\n                              3^#*expr.Constant_Int64Value#\n                            )^#*expr.Expr_CallExpr#,\n                            3^#*expr.Constant_Int64Value#\n                          )^#*expr.Expr_CallExpr#,\n                          3^#*expr.Constant_Int64Value#\n                        )^#*expr.Expr_CallExpr#,\n                        3^#*expr.Constant_Int64Value#\n                      )^#*expr.Expr_CallExpr#,\n                      3^#*expr.Constant_Int64Value#\n                    )^#*expr.Expr_CallExpr#,\n                    3^#*expr.Constant_Int64Value#\n                  )^#*expr.Expr_CallExpr#,\n                  3^#*expr.Constant_Int64Value#\n                )^#*expr.Expr_CallExpr#,\n                3^#*expr.Constant_Int64Value#\n              )^#*expr.Expr_CallExpr#,\n              3^#*expr.Constant_Int64Value#\n            )^#*expr.Expr_CallExpr#,\n            3^#*expr.Constant_Int64Value#\n          )^#*expr.Expr_CallExpr#,\n          3^#*expr.Constant_Int64Value#\n        )^#*expr.Expr_CallExpr#,\n        3^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      3^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  3^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4",
+    ast: "_/_(\n  _*_(\n    _/_(\n      _*_(\n        _/_(\n          _*_(\n            _/_(\n              _*_(\n                _/_(\n                  _*_(\n                    _/_(\n                      _*_(\n                        _/_(\n                          _*_(\n                            _/_(\n                              _*_(\n                                _/_(\n                                  _*_(\n                                    _/_(\n                                      _*_(\n                                        _/_(\n                                          _*_(\n                                            _/_(\n                                              _*_(\n                                                4^#*expr.Constant_Int64Value#,\n                                                4^#*expr.Constant_Int64Value#\n                                              )^#*expr.Expr_CallExpr#,\n                                              4^#*expr.Constant_Int64Value#\n                                            )^#*expr.Expr_CallExpr#,\n                                            4^#*expr.Constant_Int64Value#\n                                          )^#*expr.Expr_CallExpr#,\n                                          4^#*expr.Constant_Int64Value#\n                                        )^#*expr.Expr_CallExpr#,\n                                        4^#*expr.Constant_Int64Value#\n                                      )^#*expr.Expr_CallExpr#,\n                                      4^#*expr.Constant_Int64Value#\n                                    )^#*expr.Expr_CallExpr#,\n                                    4^#*expr.Constant_Int64Value#\n                                  )^#*expr.Expr_CallExpr#,\n                                  4^#*expr.Constant_Int64Value#\n                                )^#*expr.Expr_CallExpr#,\n                                4^#*expr.Constant_Int64Value#\n                              )^#*expr.Expr_CallExpr#,\n                              4^#*expr.Constant_Int64Value#\n                            )^#*expr.Expr_CallExpr#,\n                            4^#*expr.Constant_Int64Value#\n                          )^#*expr.Expr_CallExpr#,\n                          4^#*expr.Constant_Int64Value#\n                        )^#*expr.Expr_CallExpr#,\n                        4^#*expr.Constant_Int64Value#\n                      )^#*expr.Expr_CallExpr#,\n                      4^#*expr.Constant_Int64Value#\n                    )^#*expr.Expr_CallExpr#,\n                    4^#*expr.Constant_Int64Value#\n                  )^#*expr.Expr_CallExpr#,\n                  4^#*expr.Constant_Int64Value#\n                )^#*expr.Expr_CallExpr#,\n                4^#*expr.Constant_Int64Value#\n              )^#*expr.Expr_CallExpr#,\n              4^#*expr.Constant_Int64Value#\n            )^#*expr.Expr_CallExpr#,\n            4^#*expr.Constant_Int64Value#\n          )^#*expr.Expr_CallExpr#,\n          4^#*expr.Constant_Int64Value#\n        )^#*expr.Expr_CallExpr#,\n        4^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      4^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    4^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  4^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!true",
+    ast: "true^#*expr.Constant_BoolValue#",
+  },
+  {
+    expr: "--------------------------------19",
+    ast: "19^#*expr.Constant_Int64Value#",
+  },
+  {
+    expr: "NestedTestAllTypes{}.child.child.child.child.child.child.child.child.child.child.payload.single_int32",
+    ast: "NestedTestAllTypes{}^#*expr.Expr_StructExpr#.child^#*expr.Expr_SelectExpr#.child^#*expr.Expr_SelectExpr#.child^#*expr.Expr_SelectExpr#.child^#*expr.Expr_SelectExpr#.child^#*expr.Expr_SelectExpr#.child^#*expr.Expr_SelectExpr#.child^#*expr.Expr_SelectExpr#.child^#*expr.Expr_SelectExpr#.child^#*expr.Expr_SelectExpr#.child^#*expr.Expr_SelectExpr#.payload^#*expr.Expr_SelectExpr#.single_int32^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "[[[[[[[[[[[['foo']]]]]]]]]]]][0][0][0][0][0][0][0][0][0][0][0][0]",
+    ast: '_[_](\n  _[_](\n    _[_](\n      _[_](\n        _[_](\n          _[_](\n            _[_](\n              _[_](\n                _[_](\n                  _[_](\n                    _[_](\n                      _[_](\n                        [\n                          [\n                            [\n                              [\n                                [\n                                  [\n                                    [\n                                      [\n                                        [\n                                          [\n                                            [\n                                              [\n                                                "foo"^#*expr.Constant_StringValue#\n                                              ]^#*expr.Expr_ListExpr#\n                                            ]^#*expr.Expr_ListExpr#\n                                          ]^#*expr.Expr_ListExpr#\n                                        ]^#*expr.Expr_ListExpr#\n                                      ]^#*expr.Expr_ListExpr#\n                                    ]^#*expr.Expr_ListExpr#\n                                  ]^#*expr.Expr_ListExpr#\n                                ]^#*expr.Expr_ListExpr#\n                              ]^#*expr.Expr_ListExpr#\n                            ]^#*expr.Expr_ListExpr#\n                          ]^#*expr.Expr_ListExpr#\n                        ]^#*expr.Expr_ListExpr#,\n                        0^#*expr.Constant_Int64Value#\n                      )^#*expr.Expr_CallExpr#,\n                      0^#*expr.Constant_Int64Value#\n                    )^#*expr.Expr_CallExpr#,\n                    0^#*expr.Constant_Int64Value#\n                  )^#*expr.Expr_CallExpr#,\n                  0^#*expr.Constant_Int64Value#\n                )^#*expr.Expr_CallExpr#,\n                0^#*expr.Constant_Int64Value#\n              )^#*expr.Expr_CallExpr#,\n              0^#*expr.Constant_Int64Value#\n            )^#*expr.Expr_CallExpr#,\n            0^#*expr.Constant_Int64Value#\n          )^#*expr.Expr_CallExpr#,\n          0^#*expr.Constant_Int64Value#\n        )^#*expr.Expr_CallExpr#,\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    0^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31][17]",
+    ast: "_[_](\n  [\n    0^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#,\n    4^#*expr.Constant_Int64Value#,\n    5^#*expr.Constant_Int64Value#,\n    6^#*expr.Constant_Int64Value#,\n    7^#*expr.Constant_Int64Value#,\n    8^#*expr.Constant_Int64Value#,\n    9^#*expr.Constant_Int64Value#,\n    10^#*expr.Constant_Int64Value#,\n    11^#*expr.Constant_Int64Value#,\n    12^#*expr.Constant_Int64Value#,\n    13^#*expr.Constant_Int64Value#,\n    14^#*expr.Constant_Int64Value#,\n    15^#*expr.Constant_Int64Value#,\n    16^#*expr.Constant_Int64Value#,\n    17^#*expr.Constant_Int64Value#,\n    18^#*expr.Constant_Int64Value#,\n    19^#*expr.Constant_Int64Value#,\n    20^#*expr.Constant_Int64Value#,\n    21^#*expr.Constant_Int64Value#,\n    22^#*expr.Constant_Int64Value#,\n    23^#*expr.Constant_Int64Value#,\n    24^#*expr.Constant_Int64Value#,\n    25^#*expr.Constant_Int64Value#,\n    26^#*expr.Constant_Int64Value#,\n    27^#*expr.Constant_Int64Value#,\n    28^#*expr.Constant_Int64Value#,\n    29^#*expr.Constant_Int64Value#,\n    30^#*expr.Constant_Int64Value#,\n    31^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#,\n  17^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "{0: 'zero', 1: 'one', 2: 'two', 3: 'three', 4: 'four', 5: 'five', 6: 'six', 7: 'seven', 8: 'eight', 9: 'nine', 10: 'ten', 11: 'eleven', 12: 'twelve', 13: 'thirteen', 14: 'fourteen', 15: 'fifteen', 16: 'sixteen', 17: 'seventeen', 18: 'eighteen', 19: 'nineteen', 20: 'twenty', 21: 'twenty-one', 22: 'twenty-two', 23: 'twenty-three', 24: 'twenty-four', 25: 'twenty-five', 26: 'twenty-six', 27: 'twenty-seven', 28: 'twenty-eight', 29: 'twenty-nine', 30: 'thirty', 31: 'thirty-one'}[17]",
+    ast: '_[_](\n  {\n    0^#*expr.Constant_Int64Value#:"zero"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    1^#*expr.Constant_Int64Value#:"one"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    2^#*expr.Constant_Int64Value#:"two"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    3^#*expr.Constant_Int64Value#:"three"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    4^#*expr.Constant_Int64Value#:"four"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    5^#*expr.Constant_Int64Value#:"five"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    6^#*expr.Constant_Int64Value#:"six"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    7^#*expr.Constant_Int64Value#:"seven"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    8^#*expr.Constant_Int64Value#:"eight"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    9^#*expr.Constant_Int64Value#:"nine"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    10^#*expr.Constant_Int64Value#:"ten"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    11^#*expr.Constant_Int64Value#:"eleven"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    12^#*expr.Constant_Int64Value#:"twelve"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    13^#*expr.Constant_Int64Value#:"thirteen"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    14^#*expr.Constant_Int64Value#:"fourteen"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    15^#*expr.Constant_Int64Value#:"fifteen"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    16^#*expr.Constant_Int64Value#:"sixteen"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    17^#*expr.Constant_Int64Value#:"seventeen"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    18^#*expr.Constant_Int64Value#:"eighteen"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    19^#*expr.Constant_Int64Value#:"nineteen"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    20^#*expr.Constant_Int64Value#:"twenty"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    21^#*expr.Constant_Int64Value#:"twenty-one"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    22^#*expr.Constant_Int64Value#:"twenty-two"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    23^#*expr.Constant_Int64Value#:"twenty-three"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    24^#*expr.Constant_Int64Value#:"twenty-four"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    25^#*expr.Constant_Int64Value#:"twenty-five"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    26^#*expr.Constant_Int64Value#:"twenty-six"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    27^#*expr.Constant_Int64Value#:"twenty-seven"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    28^#*expr.Constant_Int64Value#:"twenty-eight"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    29^#*expr.Constant_Int64Value#:"twenty-nine"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    30^#*expr.Constant_Int64Value#:"thirty"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    31^#*expr.Constant_Int64Value#:"thirty-one"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  17^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_int32: 5, single_int64: 10, single_uint32: 15u, single_uint64: 20u, single_sint32: 25, single_sint64: 30, single_fixed32: 35u, single_fixed64: 40u, single_float: 45.0, single_double: 50.0, single_bool: true, single_string: 'sixty', single_bytes: b'sixty-five', single_value: 70.0, single_int64_wrapper: 75, single_int32_wrapper: 80, single_double_wrapper: 85.0, single_float_wrapper: 90.0, single_uint64_wrapper: 95u, single_uint32_wrapper: 100u, single_string_wrapper: 'one hundred five', single_bool_wrapper: true, repeated_int32: [115], repeated_int64: [120], repeated_uint32: [125u], repeated_uint64: [130u], repeated_sint32: [135], repeated_sint64: [140], repeated_fixed32: [145u], repeated_fixed64: [150u], repeated_sfixed32: [155], repeated_float: [160.0]}.single_sint64",
+    ast: 'TestAllTypes{\n  single_int32:5^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n  single_int64:10^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n  single_uint32:15u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#,\n  single_uint64:20u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#,\n  single_sint32:25^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n  single_sint64:30^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n  single_fixed32:35u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#,\n  single_fixed64:40u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#,\n  single_float:45^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n  single_double:50^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n  single_bool:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#,\n  single_string:"sixty"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n  single_bytes:b"sixty-five"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#,\n  single_value:70^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n  single_int64_wrapper:75^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n  single_int32_wrapper:80^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n  single_double_wrapper:85^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n  single_float_wrapper:90^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#,\n  single_uint64_wrapper:95u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#,\n  single_uint32_wrapper:100u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#,\n  single_string_wrapper:"one hundred five"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n  single_bool_wrapper:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#,\n  repeated_int32:[\n    115^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#,\n  repeated_int64:[\n    120^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#,\n  repeated_uint32:[\n    125u^#*expr.Constant_Uint64Value#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#,\n  repeated_uint64:[\n    130u^#*expr.Constant_Uint64Value#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#,\n  repeated_sint32:[\n    135^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#,\n  repeated_sint64:[\n    140^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#,\n  repeated_fixed32:[\n    145u^#*expr.Constant_Uint64Value#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#,\n  repeated_fixed64:[\n    150u^#*expr.Constant_Uint64Value#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#,\n  repeated_sfixed32:[\n    155^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#,\n  repeated_float:[\n    160^#*expr.Constant_DoubleValue#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_sint64^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "[ . cel. expr .conformance. proto3. TestAllTypes { single_int64 : int ( 17 ) } . single_int64 ] [ 0 ] == ( 18 - 1 ) \u0026\u0026 ! false ? 1 : 2",
+    ast: "_?_:_(\n  _\u0026\u0026_(\n    _==_(\n      _[_](\n        [\n          .cel.expr.conformance.proto3.TestAllTypes{\n            single_int64:int(\n              17^#*expr.Constant_Int64Value#\n            )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n          }^#*expr.Expr_StructExpr#.single_int64^#*expr.Expr_SelectExpr#\n        ]^#*expr.Expr_ListExpr#,\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      _-_(\n        18^#*expr.Constant_Int64Value#,\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    !_(\n      false^#*expr.Constant_BoolValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[\t.\tcel.\texpr\t.conformance.\tproto3.\tTestAllTypes\t{\tsingle_int64\t:\tint\t(\t17\t)\t}\t.\tsingle_int64\t]\t[\t0\t]\t==\t(\t18\t-\t1\t)\t\u0026\u0026\t!\tfalse\t?\t1\t:\t2",
+    ast: "_?_:_(\n  _\u0026\u0026_(\n    _==_(\n      _[_](\n        [\n          .cel.expr.conformance.proto3.TestAllTypes{\n            single_int64:int(\n              17^#*expr.Constant_Int64Value#\n            )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n          }^#*expr.Expr_StructExpr#.single_int64^#*expr.Expr_SelectExpr#\n        ]^#*expr.Expr_ListExpr#,\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      _-_(\n        18^#*expr.Constant_Int64Value#,\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    !_(\n      false^#*expr.Constant_BoolValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[\n.\ncel.\nexpr\n.conformance.\nproto3.\nTestAllTypes\n{\nsingle_int64\n:\nint\n(\n17\n)\n}\n.\nsingle_int64\n]\n[\n0\n]\n==\n(\n18\n-\n1\n)\n\u0026\u0026\n!\nfalse\n?\n1\n:\n2",
+    ast: "_?_:_(\n  _\u0026\u0026_(\n    _==_(\n      _[_](\n        [\n          .cel.expr.conformance.proto3.TestAllTypes{\n            single_int64:int(\n              17^#*expr.Constant_Int64Value#\n            )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n          }^#*expr.Expr_StructExpr#.single_int64^#*expr.Expr_SelectExpr#\n        ]^#*expr.Expr_ListExpr#,\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      _-_(\n        18^#*expr.Constant_Int64Value#,\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    !_(\n      false^#*expr.Constant_BoolValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[\f.\fcel.\fexpr\f.conformance.\fproto3.\fTestAllTypes\f{\fsingle_int64\f:\fint\f(\f17\f)\f}\f.\fsingle_int64\f]\f[\f0\f]\f==\f(\f18\f-\f1\f)\f\u0026\u0026\f!\ffalse\f?\f1\f:\f2",
+    ast: "_?_:_(\n  _\u0026\u0026_(\n    _==_(\n      _[_](\n        [\n          .cel.expr.conformance.proto3.TestAllTypes{\n            single_int64:int(\n              17^#*expr.Constant_Int64Value#\n            )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n          }^#*expr.Expr_StructExpr#.single_int64^#*expr.Expr_SelectExpr#\n        ]^#*expr.Expr_ListExpr#,\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      _-_(\n        18^#*expr.Constant_Int64Value#,\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    !_(\n      false^#*expr.Constant_BoolValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[\r.\rcel.\rexpr\r.conformance.\rproto3.\rTestAllTypes\r{\rsingle_int64\r:\rint\r(\r17\r)\r}\r.\rsingle_int64\r]\r[\r0\r]\r==\r(\r18\r-\r1\r)\r\u0026\u0026\r!\rfalse\r?\r1\r:\r2",
+    ast: "_?_:_(\n  _\u0026\u0026_(\n    _==_(\n      _[_](\n        [\n          .cel.expr.conformance.proto3.TestAllTypes{\n            single_int64:int(\n              17^#*expr.Constant_Int64Value#\n            )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n          }^#*expr.Expr_StructExpr#.single_int64^#*expr.Expr_SelectExpr#\n        ]^#*expr.Expr_ListExpr#,\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      _-_(\n        18^#*expr.Constant_Int64Value#,\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    !_(\n      false^#*expr.Constant_BoolValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[// @\n.// @\ncel.// @\nexpr// @\n.conformance.// @\nproto3.// @\nTestAllTypes// @\n{// @\nsingle_int64// @\n:// @\nint// @\n(// @\n17// @\n)// @\n}// @\n.// @\nsingle_int64// @\n]// @\n[// @\n0// @\n]// @\n==// @\n(// @\n18// @\n-// @\n1// @\n)// @\n\u0026\u0026// @\n!// @\nfalse// @\n?// @\n1// @\n:// @\n2",
+    ast: "_?_:_(\n  _\u0026\u0026_(\n    _==_(\n      _[_](\n        [\n          .cel.expr.conformance.proto3.TestAllTypes{\n            single_int64:int(\n              17^#*expr.Constant_Int64Value#\n            )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n          }^#*expr.Expr_StructExpr#.single_int64^#*expr.Expr_SelectExpr#\n        ]^#*expr.Expr_ListExpr#,\n        0^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      _-_(\n        18^#*expr.Constant_Int64Value#,\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#,\n    !_(\n      false^#*expr.Constant_BoolValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  { expr: "17", ast: "17^#*expr.Constant_Int64Value#" },
+  {
+    expr: "1 / 0",
+    ast: "_/_(\n  1^#*expr.Constant_Int64Value#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: '{"k1":"v1","k":"v"}',
+    ast: '{\n  "k1"^#*expr.Constant_StringValue#:"v1"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n  "k"^#*expr.Constant_StringValue#:"v"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "[17, 'pancakes']",
+    ast: '[\n  17^#*expr.Constant_Int64Value#,\n  "pancakes"^#*expr.Constant_StringValue#\n]^#*expr.Expr_ListExpr#',
+  },
+  { expr: "'foo'", ast: '"foo"^#*expr.Constant_StringValue#' },
+  {
+    expr: "cel.expr.conformance.proto2.TestAllTypes{single_int64: 17}",
+    ast: "cel.expr.conformance.proto2.TestAllTypes{\n  single_int64:17^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32: -34}",
+    ast: "TestAllTypes{\n  single_int32:-34^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "Int32Value{value: 34} == dyn(UInt64Value{value: 34u})",
+    ast: "_==_(\n  Int32Value{\n    value:34^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  dyn(\n    UInt64Value{\n      value:34u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "Int32Value{value: 34} == dyn(UInt64Value{value: 18446744073709551615u})",
+    ast: "_==_(\n  Int32Value{\n    value:34^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  dyn(\n    UInt64Value{\n      value:18446744073709551615u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "Int32Value{value: 34} == dyn(DoubleValue{value: 34.0})",
+    ast: "_==_(\n  Int32Value{\n    value:34^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  dyn(\n    DoubleValue{\n      value:34^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "Int32Value{value: 34} == dyn(DoubleValue{value: -9223372036854775809.0})",
+    ast: "_==_(\n  Int32Value{\n    value:34^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  dyn(\n    DoubleValue{\n      value:-9.223372036854776e+18^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int64: 17}",
+    ast: "TestAllTypes{\n  single_int64:17^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint32: 1u}",
+    ast: "TestAllTypes{\n  single_uint32:1u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "UInt32Value{value: 34u} == dyn(Int64Value{value: 34})",
+    ast: "_==_(\n  UInt32Value{\n    value:34u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  dyn(\n    Int64Value{\n      value:34^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "UInt32Value{value: 34u} == dyn(Int64Value{value: -1})",
+    ast: "_==_(\n  UInt32Value{\n    value:34u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  dyn(\n    Int64Value{\n      value:-1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "UInt32Value{value: 34u} == dyn(DoubleValue{value: 34.0})",
+    ast: "_==_(\n  UInt32Value{\n    value:34u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  dyn(\n    DoubleValue{\n      value:34^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "UInt32Value{value: 34u} == dyn(DoubleValue{value: 18446744073709551616.0})",
+    ast: "_==_(\n  UInt32Value{\n    value:34u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  dyn(\n    DoubleValue{\n      value:1.8446744073709552e+19^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint64: 9999u}",
+    ast: "TestAllTypes{\n  single_uint64:9999u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_sint32: -3}",
+    ast: "TestAllTypes{\n  single_sint32:-3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_sint64: 255}",
+    ast: "TestAllTypes{\n  single_sint64:255^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_fixed32: 43u}",
+    ast: "TestAllTypes{\n  single_fixed32:43u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_fixed64: 1880u}",
+    ast: "TestAllTypes{\n  single_fixed64:1880u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_sfixed32: -404}",
+    ast: "TestAllTypes{\n  single_sfixed32:-404^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_sfixed64: -1}",
+    ast: "TestAllTypes{\n  single_sfixed64:-1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float: 3.1416}",
+    ast: "TestAllTypes{\n  single_float:3.1416^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "FloatValue{value: 3.0} == dyn(Int64Value{value: 3})",
+    ast: "_==_(\n  FloatValue{\n    value:3^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  dyn(\n    Int64Value{\n      value:3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "FloatValue{value: -1.14} == dyn(Int64Value{value: -1})",
+    ast: "_==_(\n  FloatValue{\n    value:-1.14^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  dyn(\n    Int64Value{\n      value:-1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "FloatValue{value: 34.0} == dyn(UInt64Value{value: 34u})",
+    ast: "_==_(\n  FloatValue{\n    value:34^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  dyn(\n    UInt64Value{\n      value:34u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "FloatValue{value: -1.0} == dyn(UInt64Value{value: 18446744073709551615u})",
+    ast: "_==_(\n  FloatValue{\n    value:-1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  dyn(\n    UInt64Value{\n      value:18446744073709551615u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_double: 6.022e23}",
+    ast: "TestAllTypes{\n  single_double:6.022e+23^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_bool: true}",
+    ast: "TestAllTypes{\n  single_bool:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_string: 'foo'}",
+    ast: 'TestAllTypes{\n  single_string:"foo"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_bytes: b'\\377'}",
+    ast: 'TestAllTypes{\n  single_bytes:b"\\xff"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_any: TestAllTypes{single_int32: 1}}",
+    ast: "TestAllTypes{\n  single_any:TestAllTypes{\n    single_int32:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_duration: duration('123s')}",
+    ast: 'TestAllTypes{\n  single_duration:duration(\n    "123s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_timestamp: timestamp('2009-02-13T23:31:30Z')}",
+    ast: 'TestAllTypes{\n  single_timestamp:timestamp(\n    "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_struct: {'one': 1, 'two': 2}}",
+    ast: 'TestAllTypes{\n  single_struct:{\n    "one"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    "two"^#*expr.Constant_StringValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: 'foo'}",
+    ast: 'TestAllTypes{\n  single_value:"foo"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_int64_wrapper: -321}",
+    ast: "TestAllTypes{\n  single_int64_wrapper:-321^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: -456}",
+    ast: "TestAllTypes{\n  single_int32_wrapper:-456^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_double_wrapper: 2.71828}",
+    ast: "TestAllTypes{\n  single_double_wrapper:2.71828^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float_wrapper: 2.99792e8}",
+    ast: "TestAllTypes{\n  single_float_wrapper:2.99792e+08^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint64_wrapper: 8675309u}",
+    ast: "TestAllTypes{\n  single_uint64_wrapper:8675309u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint32_wrapper: 987u}",
+    ast: "TestAllTypes{\n  single_uint32_wrapper:987u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_string_wrapper: 'hubba'}",
+    ast: 'TestAllTypes{\n  single_string_wrapper:"hubba"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_bool_wrapper: true}",
+    ast: "TestAllTypes{\n  single_bool_wrapper:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_bytes_wrapper: b'\\301\\103'}",
+    ast: 'TestAllTypes{\n  single_bytes_wrapper:b"\\xc1C"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "x.single_int32",
+    ast: "x^#*expr.Expr_IdentExpr#.single_int32^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "x.single_int64",
+    ast: "x^#*expr.Expr_IdentExpr#.single_int64^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_int32",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_int32^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_fixed32",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_fixed32^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_nested_message",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_nested_message^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_nested_message.bb",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_nested_message^#*expr.Expr_SelectExpr#.bb^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_int64_wrapper",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_int64_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.repeated_int64",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.repeated_int64^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.repeated_nested_enum",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.repeated_nested_enum^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.repeated_nested_message",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.repeated_nested_message^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.map_string_string",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.map_string_string^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{}.no_such_field)",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.no_such_field~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{}.repeated_int32)",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.repeated_int32~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{repeated_int32: []}.repeated_int32)",
+    ast: "TestAllTypes{\n  repeated_int32:[]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.repeated_int32~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{repeated_int32: [1]}.repeated_int32)",
+    ast: "TestAllTypes{\n  repeated_int32:[\n    1^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.repeated_int32~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{repeated_int32: [1, 2, 3]}.repeated_int32)",
+    ast: "TestAllTypes{\n  repeated_int32:[\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.repeated_int32~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{}.map_string_string)",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.map_string_string~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{map_string_string: {}}.map_string_string)",
+    ast: "TestAllTypes{\n  map_string_string:{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.map_string_string~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{map_string_string: {'MT': ''}}.map_string_string)",
+    ast: 'TestAllTypes{\n  map_string_string:{\n    "MT"^#*expr.Constant_StringValue#:""^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.map_string_string~test-only~^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "has(TestAllTypes{map_string_string: {'one': 'uno'}}.map_string_string)",
+    ast: 'TestAllTypes{\n  map_string_string:{\n    "one"^#*expr.Constant_StringValue#:"uno"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.map_string_string~test-only~^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "has(TestAllTypes{map_string_string: {'one': 'uno', 'two': 'dos'}}.map_string_string)",
+    ast: 'TestAllTypes{\n  map_string_string:{\n    "one"^#*expr.Constant_StringValue#:"uno"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    "two"^#*expr.Constant_StringValue#:"dos"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.map_string_string~test-only~^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "has(TestRequired{required_int32: 4}.required_int32)",
+    ast: "TestRequired{\n  required_int32:4^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.required_int32~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{}.single_sint32)",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_sint32~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{single_sint32: -4}.single_sint32)",
+    ast: "TestAllTypes{\n  single_sint32:-4^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_sint32~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{}.single_int32)",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_int32~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{single_int32: 16}.single_int32)",
+    ast: "TestAllTypes{\n  single_int32:16^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_int32~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{single_int32: -32}.single_int32)",
+    ast: "TestAllTypes{\n  single_int32:-32^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_int32~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{}.standalone_message)",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.standalone_message~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{standalone_message: TestAllTypes.NestedMessage{}}.standalone_message)",
+    ast: "TestAllTypes{\n  standalone_message:TestAllTypes.NestedMessage{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.standalone_message~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{}.standalone_enum)",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.standalone_enum~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.BAR}.standalone_enum)",
+    ast: "TestAllTypes{\n  standalone_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAR^#*expr.Expr_SelectExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.standalone_enum~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.FOO}.standalone_enum)",
+    ast: "TestAllTypes{\n  standalone_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.FOO^#*expr.Expr_SelectExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.standalone_enum~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{}.single_nested_message)",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_nested_message~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{single_nested_enum: TestAllTypes.NestedEnum.BAZ}.single_nested_message)",
+    ast: "TestAllTypes{\n  single_nested_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAZ^#*expr.Expr_SelectExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_nested_message~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{single_nested_message: TestAllTypes.NestedMessage{}}.single_nested_message)",
+    ast: "TestAllTypes{\n  single_nested_message:TestAllTypes.NestedMessage{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_nested_message~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{single_nested_enum: TestAllTypes.NestedEnum.FOO}.single_nested_enum)",
+    ast: "TestAllTypes{\n  single_nested_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.FOO^#*expr.Expr_SelectExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_nested_enum~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_nested_message: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_nested_message:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: null}.single_any",
+    ast: "TestAllTypes{\n  single_any:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_any^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: null}.single_value",
+    ast: "TestAllTypes{\n  single_value:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_duration: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_duration:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_timestamp: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_timestamp:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_bool: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_bool:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{repeated_int32: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    repeated_int32:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{map_string_string: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    map_string_string:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{list_value: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    list_value:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_struct: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_struct:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{`in`: true} == TestAllTypes{}",
+    error:
+      "ERROR: \u003cinput\u003e:1:14: unsupported syntax: '`'\n | TestAllTypes{`in`: true} == TestAllTypes{}\n | .............^",
+  },
+  {
+    expr: "TestAllTypes{`in`: true}.`in`",
+    error:
+      "ERROR: \u003cinput\u003e:1:14: unsupported syntax: '`'\n | TestAllTypes{`in`: true}.`in`\n | .............^\nERROR: \u003cinput\u003e:1:26: unsupported syntax: '`'\n | TestAllTypes{`in`: true}.`in`\n | .........................^",
+  },
+  {
+    expr: "has(msg.`cel.expr.conformance.proto2.int32_ext`)",
+    error:
+      "ERROR: \u003cinput\u003e:1:9: unsupported syntax: '`'\n | has(msg.`cel.expr.conformance.proto2.int32_ext`)\n | ........^",
+  },
+  {
+    expr: "has(msg.`cel.expr.conformance.proto2.nested_ext`)",
+    error:
+      "ERROR: \u003cinput\u003e:1:9: unsupported syntax: '`'\n | has(msg.`cel.expr.conformance.proto2.nested_ext`)\n | ........^",
+  },
+  {
+    expr: "has(msg.`cel.expr.conformance.proto2.test_all_types_ext`)",
+    error:
+      "ERROR: \u003cinput\u003e:1:9: unsupported syntax: '`'\n | has(msg.`cel.expr.conformance.proto2.test_all_types_ext`)\n | ........^",
+  },
+  {
+    expr: "has(msg.`cel.expr.conformance.proto2.nested_enum_ext`)",
+    error:
+      "ERROR: \u003cinput\u003e:1:9: unsupported syntax: '`'\n | has(msg.`cel.expr.conformance.proto2.nested_enum_ext`)\n | ........^",
+  },
+  {
+    expr: "has(msg.`cel.expr.conformance.proto2.repeated_test_all_types`)",
+    error:
+      "ERROR: \u003cinput\u003e:1:9: unsupported syntax: '`'\n | has(msg.`cel.expr.conformance.proto2.repeated_test_all_types`)\n | ........^",
+  },
+  {
+    expr: "has(msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.int64_ext`)",
+    error:
+      "ERROR: \u003cinput\u003e:1:9: unsupported syntax: '`'\n | has(msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.int64_ext`)\n | ........^",
+  },
+  {
+    expr: "has(msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_nested_ext`)",
+    error:
+      "ERROR: \u003cinput\u003e:1:9: unsupported syntax: '`'\n | has(msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_nested_ext`)\n | ........^",
+  },
+  {
+    expr: "has(msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.nested_enum_ext`)",
+    error:
+      "ERROR: \u003cinput\u003e:1:9: unsupported syntax: '`'\n | has(msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.nested_enum_ext`)\n | ........^",
+  },
+  {
+    expr: "has(msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_repeated_test_all_types`)",
+    error:
+      "ERROR: \u003cinput\u003e:1:9: unsupported syntax: '`'\n | has(msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_repeated_test_all_types`)\n | ........^",
+  },
+  {
+    expr: "msg.`cel.expr.conformance.proto2.int32_ext` == 42",
+    error:
+      "ERROR: \u003cinput\u003e:1:5: unsupported syntax: '`'\n | msg.`cel.expr.conformance.proto2.int32_ext` == 42\n | ....^",
+  },
+  {
+    expr: "msg.`cel.expr.conformance.proto2.nested_ext` == cel.expr.conformance.proto2.TestAllTypes{}",
+    error:
+      "ERROR: \u003cinput\u003e:1:5: unsupported syntax: '`'\n | msg.`cel.expr.conformance.proto2.nested_ext` == cel.expr.conformance.proto2.TestAllTypes{}\n | ....^",
+  },
+  {
+    expr: "msg.`cel.expr.conformance.proto2.test_all_types_ext` == cel.expr.conformance.proto2.TestAllTypes{}",
+    error:
+      "ERROR: \u003cinput\u003e:1:5: unsupported syntax: '`'\n | msg.`cel.expr.conformance.proto2.test_all_types_ext` == cel.expr.conformance.proto2.TestAllTypes{}\n | ....^",
+  },
+  {
+    expr: "msg.`cel.expr.conformance.proto2.nested_enum_ext` == cel.expr.conformance.proto2.TestAllTypes.NestedEnum.BAR",
+    error:
+      "ERROR: \u003cinput\u003e:1:5: unsupported syntax: '`'\n | msg.`cel.expr.conformance.proto2.nested_enum_ext` == cel.expr.conformance.proto2.TestAllTypes.NestedEnum.BAR\n | ....^",
+  },
+  {
+    expr: "msg.`cel.expr.conformance.proto2.repeated_test_all_types` == [cel.expr.conformance.proto2.TestAllTypes{single_int64: 1}, cel.expr.conformance.proto2.TestAllTypes{single_bool: true}]",
+    error:
+      "ERROR: \u003cinput\u003e:1:5: unsupported syntax: '`'\n | msg.`cel.expr.conformance.proto2.repeated_test_all_types` == [cel.expr.conformance.proto2.TestAllTypes{single_int64: 1}, cel.expr.conformance.proto2.TestAllTypes{single_bool: true}]\n | ....^",
+  },
+  {
+    expr: "msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.int64_ext` == 42",
+    error:
+      "ERROR: \u003cinput\u003e:1:5: unsupported syntax: '`'\n | msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.int64_ext` == 42\n | ....^",
+  },
+  {
+    expr: "msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_nested_ext` == cel.expr.conformance.proto2.TestAllTypes{}",
+    error:
+      "ERROR: \u003cinput\u003e:1:5: unsupported syntax: '`'\n | msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_nested_ext` == cel.expr.conformance.proto2.TestAllTypes{}\n | ....^",
+  },
+  {
+    expr: "msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.nested_enum_ext` == cel.expr.conformance.proto2.TestAllTypes.NestedEnum.BAR",
+    error:
+      "ERROR: \u003cinput\u003e:1:5: unsupported syntax: '`'\n | msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.nested_enum_ext` == cel.expr.conformance.proto2.TestAllTypes.NestedEnum.BAR\n | ....^",
+  },
+  {
+    expr: "msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_repeated_test_all_types` == [cel.expr.conformance.proto2.TestAllTypes{single_int64: 1}, cel.expr.conformance.proto2.TestAllTypes{single_bool: true}]",
+    error:
+      "ERROR: \u003cinput\u003e:1:5: unsupported syntax: '`'\n | msg.`cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_repeated_test_all_types` == [cel.expr.conformance.proto2.TestAllTypes{single_int64: 1}, cel.expr.conformance.proto2.TestAllTypes{single_bool: true}]\n | ....^",
+  },
+  {
+    expr: "proto.hasExt(msg, cel.expr.conformance.proto2.int32_ext)",
+    ast: "proto^#*expr.Expr_IdentExpr#.hasExt(\n  msg^#*expr.Expr_IdentExpr#,\n  cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.int32_ext^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "proto.hasExt(msg, cel.expr.conformance.proto2.nested_ext)",
+    ast: "proto^#*expr.Expr_IdentExpr#.hasExt(\n  msg^#*expr.Expr_IdentExpr#,\n  cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.nested_ext^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "proto.hasExt(msg, cel.expr.conformance.proto2.test_all_types_ext)",
+    ast: "proto^#*expr.Expr_IdentExpr#.hasExt(\n  msg^#*expr.Expr_IdentExpr#,\n  cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.test_all_types_ext^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "proto.hasExt(msg, cel.expr.conformance.proto2.nested_enum_ext)",
+    ast: "proto^#*expr.Expr_IdentExpr#.hasExt(\n  msg^#*expr.Expr_IdentExpr#,\n  cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.nested_enum_ext^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "proto.hasExt(msg, cel.expr.conformance.proto2.repeated_test_all_types)",
+    ast: "proto^#*expr.Expr_IdentExpr#.hasExt(\n  msg^#*expr.Expr_IdentExpr#,\n  cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.repeated_test_all_types^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "proto.hasExt(msg, cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.int64_ext)",
+    ast: "proto^#*expr.Expr_IdentExpr#.hasExt(\n  msg^#*expr.Expr_IdentExpr#,\n  cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.Proto2ExtensionScopedMessage^#*expr.Expr_SelectExpr#.int64_ext^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "proto.hasExt(msg, cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_nested_ext)",
+    ast: "proto^#*expr.Expr_IdentExpr#.hasExt(\n  msg^#*expr.Expr_IdentExpr#,\n  cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.Proto2ExtensionScopedMessage^#*expr.Expr_SelectExpr#.message_scoped_nested_ext^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "proto.hasExt(msg, cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.nested_enum_ext)",
+    ast: "proto^#*expr.Expr_IdentExpr#.hasExt(\n  msg^#*expr.Expr_IdentExpr#,\n  cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.Proto2ExtensionScopedMessage^#*expr.Expr_SelectExpr#.nested_enum_ext^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "proto.hasExt(msg, cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_repeated_test_all_types)",
+    ast: "proto^#*expr.Expr_IdentExpr#.hasExt(\n  msg^#*expr.Expr_IdentExpr#,\n  cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.Proto2ExtensionScopedMessage^#*expr.Expr_SelectExpr#.message_scoped_repeated_test_all_types^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "proto.getExt(msg, cel.expr.conformance.proto2.int32_ext) == 42",
+    ast: "_==_(\n  proto^#*expr.Expr_IdentExpr#.getExt(\n    msg^#*expr.Expr_IdentExpr#,\n    cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.int32_ext^#*expr.Expr_SelectExpr#\n  )^#*expr.Expr_CallExpr#,\n  42^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "proto.getExt(msg, cel.expr.conformance.proto2.nested_ext) == cel.expr.conformance.proto2.TestAllTypes{}",
+    ast: "_==_(\n  proto^#*expr.Expr_IdentExpr#.getExt(\n    msg^#*expr.Expr_IdentExpr#,\n    cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.nested_ext^#*expr.Expr_SelectExpr#\n  )^#*expr.Expr_CallExpr#,\n  cel.expr.conformance.proto2.TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "proto.getExt(msg, cel.expr.conformance.proto2.test_all_types_ext) == cel.expr.conformance.proto2.TestAllTypes{}",
+    ast: "_==_(\n  proto^#*expr.Expr_IdentExpr#.getExt(\n    msg^#*expr.Expr_IdentExpr#,\n    cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.test_all_types_ext^#*expr.Expr_SelectExpr#\n  )^#*expr.Expr_CallExpr#,\n  cel.expr.conformance.proto2.TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "proto.getExt(msg, cel.expr.conformance.proto2.nested_enum_ext) == cel.expr.conformance.proto2.TestAllTypes.NestedEnum.BAR",
+    ast: "_==_(\n  proto^#*expr.Expr_IdentExpr#.getExt(\n    msg^#*expr.Expr_IdentExpr#,\n    cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.nested_enum_ext^#*expr.Expr_SelectExpr#\n  )^#*expr.Expr_CallExpr#,\n  cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.TestAllTypes^#*expr.Expr_SelectExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAR^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "proto.getExt(msg, cel.expr.conformance.proto2.repeated_test_all_types) == [cel.expr.conformance.proto2.TestAllTypes{single_int64: 1}, cel.expr.conformance.proto2.TestAllTypes{single_bool: true}]",
+    ast: "_==_(\n  proto^#*expr.Expr_IdentExpr#.getExt(\n    msg^#*expr.Expr_IdentExpr#,\n    cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.repeated_test_all_types^#*expr.Expr_SelectExpr#\n  )^#*expr.Expr_CallExpr#,\n  [\n    cel.expr.conformance.proto2.TestAllTypes{\n      single_int64:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#,\n    cel.expr.conformance.proto2.TestAllTypes{\n      single_bool:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "proto.getExt(msg, cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.int64_ext) == 42",
+    ast: "_==_(\n  proto^#*expr.Expr_IdentExpr#.getExt(\n    msg^#*expr.Expr_IdentExpr#,\n    cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.Proto2ExtensionScopedMessage^#*expr.Expr_SelectExpr#.int64_ext^#*expr.Expr_SelectExpr#\n  )^#*expr.Expr_CallExpr#,\n  42^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "proto.getExt(msg, cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_nested_ext) == cel.expr.conformance.proto2.TestAllTypes{}",
+    ast: "_==_(\n  proto^#*expr.Expr_IdentExpr#.getExt(\n    msg^#*expr.Expr_IdentExpr#,\n    cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.Proto2ExtensionScopedMessage^#*expr.Expr_SelectExpr#.message_scoped_nested_ext^#*expr.Expr_SelectExpr#\n  )^#*expr.Expr_CallExpr#,\n  cel.expr.conformance.proto2.TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "proto.getExt(msg, cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.nested_enum_ext) == cel.expr.conformance.proto2.TestAllTypes.NestedEnum.BAR",
+    ast: "_==_(\n  proto^#*expr.Expr_IdentExpr#.getExt(\n    msg^#*expr.Expr_IdentExpr#,\n    cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.Proto2ExtensionScopedMessage^#*expr.Expr_SelectExpr#.nested_enum_ext^#*expr.Expr_SelectExpr#\n  )^#*expr.Expr_CallExpr#,\n  cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.TestAllTypes^#*expr.Expr_SelectExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAR^#*expr.Expr_SelectExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "proto.getExt(msg, cel.expr.conformance.proto2.Proto2ExtensionScopedMessage.message_scoped_repeated_test_all_types) == [cel.expr.conformance.proto2.TestAllTypes{single_int64: 1}, cel.expr.conformance.proto2.TestAllTypes{single_bool: true}]",
+    ast: "_==_(\n  proto^#*expr.Expr_IdentExpr#.getExt(\n    msg^#*expr.Expr_IdentExpr#,\n    cel^#*expr.Expr_IdentExpr#.expr^#*expr.Expr_SelectExpr#.conformance^#*expr.Expr_SelectExpr#.proto2^#*expr.Expr_SelectExpr#.Proto2ExtensionScopedMessage^#*expr.Expr_SelectExpr#.message_scoped_repeated_test_all_types^#*expr.Expr_SelectExpr#\n  )^#*expr.Expr_CallExpr#,\n  [\n    cel.expr.conformance.proto2.TestAllTypes{\n      single_int64:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#,\n    cel.expr.conformance.proto2.TestAllTypes{\n      single_bool:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "cel.expr.conformance.proto3.TestAllTypes{single_int64: 17}",
+    ast: "cel.expr.conformance.proto3.TestAllTypes{\n  single_int64:17^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32: -34}",
+    ast: "TestAllTypes{\n  single_int32:-34^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int64: 17}",
+    ast: "TestAllTypes{\n  single_int64:17^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint32: 1u}",
+    ast: "TestAllTypes{\n  single_uint32:1u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint64: 9999u}",
+    ast: "TestAllTypes{\n  single_uint64:9999u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_sint32: -3}",
+    ast: "TestAllTypes{\n  single_sint32:-3^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_sint64: 255}",
+    ast: "TestAllTypes{\n  single_sint64:255^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_fixed32: 43u}",
+    ast: "TestAllTypes{\n  single_fixed32:43u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_fixed64: 1880u}",
+    ast: "TestAllTypes{\n  single_fixed64:1880u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_sfixed32: -404}",
+    ast: "TestAllTypes{\n  single_sfixed32:-404^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_sfixed64: -1}",
+    ast: "TestAllTypes{\n  single_sfixed64:-1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float: 3.1416}",
+    ast: "TestAllTypes{\n  single_float:3.1416^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_double: 6.022e23}",
+    ast: "TestAllTypes{\n  single_double:6.022e+23^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_bool: true}",
+    ast: "TestAllTypes{\n  single_bool:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_string: 'foo'}",
+    ast: 'TestAllTypes{\n  single_string:"foo"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_bytes: b'\\377'}",
+    ast: 'TestAllTypes{\n  single_bytes:b"\\xff"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_any: TestAllTypes{single_int32: 1}}",
+    ast: "TestAllTypes{\n  single_any:TestAllTypes{\n    single_int32:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_duration: duration('123s')}",
+    ast: 'TestAllTypes{\n  single_duration:duration(\n    "123s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_timestamp: timestamp('2009-02-13T23:31:30Z')}",
+    ast: 'TestAllTypes{\n  single_timestamp:timestamp(\n    "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_struct: {'one': 1, 'two': 2}}",
+    ast: 'TestAllTypes{\n  single_struct:{\n    "one"^#*expr.Constant_StringValue#:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#,\n    "two"^#*expr.Constant_StringValue#:2^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: 'foo'}",
+    ast: 'TestAllTypes{\n  single_value:"foo"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_int64_wrapper: -321}",
+    ast: "TestAllTypes{\n  single_int64_wrapper:-321^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: -456}",
+    ast: "TestAllTypes{\n  single_int32_wrapper:-456^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_double_wrapper: 2.71828}",
+    ast: "TestAllTypes{\n  single_double_wrapper:2.71828^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float_wrapper: 2.99792e8}",
+    ast: "TestAllTypes{\n  single_float_wrapper:2.99792e+08^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint64_wrapper: 8675309u}",
+    ast: "TestAllTypes{\n  single_uint64_wrapper:8675309u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint32_wrapper: 987u}",
+    ast: "TestAllTypes{\n  single_uint32_wrapper:987u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_string_wrapper: 'hubba'}",
+    ast: 'TestAllTypes{\n  single_string_wrapper:"hubba"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_bool_wrapper: true}",
+    ast: "TestAllTypes{\n  single_bool_wrapper:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_bytes_wrapper: b'\\301\\103'}",
+    ast: 'TestAllTypes{\n  single_bytes_wrapper:b"\\xc1C"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "x.single_int32",
+    ast: "x^#*expr.Expr_IdentExpr#.single_int32^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "x.single_int64",
+    ast: "x^#*expr.Expr_IdentExpr#.single_int64^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_fixed32",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_fixed32^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_nested_message",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_nested_message^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_nested_message.bb",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_nested_message^#*expr.Expr_SelectExpr#.bb^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.single_int64_wrapper",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_int64_wrapper^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.repeated_int64",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.repeated_int64^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.repeated_nested_enum",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.repeated_nested_enum^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.repeated_nested_message",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.repeated_nested_message^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.map_string_string",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.map_string_string^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{}.no_such_field)",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.no_such_field~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{}.repeated_int32)",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.repeated_int32~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{repeated_int32: []}.repeated_int32)",
+    ast: "TestAllTypes{\n  repeated_int32:[]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.repeated_int32~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{repeated_int32: [1]}.repeated_int32)",
+    ast: "TestAllTypes{\n  repeated_int32:[\n    1^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.repeated_int32~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{repeated_int32: [1, 2, 3]}.repeated_int32)",
+    ast: "TestAllTypes{\n  repeated_int32:[\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.repeated_int32~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{}.map_string_string)",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.map_string_string~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{map_string_string: {}}.map_string_string)",
+    ast: "TestAllTypes{\n  map_string_string:{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.map_string_string~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{map_string_string: {'MT': ''}}.map_string_string)",
+    ast: 'TestAllTypes{\n  map_string_string:{\n    "MT"^#*expr.Constant_StringValue#:""^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.map_string_string~test-only~^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "has(TestAllTypes{map_string_string: {'one': 'uno'}}.map_string_string)",
+    ast: 'TestAllTypes{\n  map_string_string:{\n    "one"^#*expr.Constant_StringValue#:"uno"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.map_string_string~test-only~^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "has(TestAllTypes{map_string_string: {'one': 'uno', 'two': 'dos'}}.map_string_string)",
+    ast: 'TestAllTypes{\n  map_string_string:{\n    "one"^#*expr.Constant_StringValue#:"uno"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n    "two"^#*expr.Constant_StringValue#:"dos"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.map_string_string~test-only~^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "has(TestAllTypes{}.single_int32)",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_int32~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{single_int32: 16}.single_int32)",
+    ast: "TestAllTypes{\n  single_int32:16^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_int32~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{single_int32: 0}.single_int32)",
+    ast: "TestAllTypes{\n  single_int32:0^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_int32~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{}.standalone_message)",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.standalone_message~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{standalone_message: TestAllTypes.NestedMessage{bb: 123}}.standalone_message)",
+    ast: "TestAllTypes{\n  standalone_message:TestAllTypes.NestedMessage{\n    bb:123^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.standalone_message~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{standalone_message: TestAllTypes.NestedMessage{}}.standalone_message)",
+    ast: "TestAllTypes{\n  standalone_message:TestAllTypes.NestedMessage{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.standalone_message~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{}.standalone_enum)",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.standalone_enum~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.BAR}.standalone_enum)",
+    ast: "TestAllTypes{\n  standalone_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAR^#*expr.Expr_SelectExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.standalone_enum~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.FOO}.standalone_enum)",
+    ast: "TestAllTypes{\n  standalone_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.FOO^#*expr.Expr_SelectExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.standalone_enum~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{}.single_nested_message)",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.single_nested_message~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{single_nested_enum: TestAllTypes.NestedEnum.BAZ}.single_nested_message)",
+    ast: "TestAllTypes{\n  single_nested_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.BAZ^#*expr.Expr_SelectExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_nested_message~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{single_nested_message: TestAllTypes.NestedMessage{}}.single_nested_message)",
+    ast: "TestAllTypes{\n  single_nested_message:TestAllTypes.NestedMessage{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_nested_message~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "has(TestAllTypes{single_nested_enum: TestAllTypes.NestedEnum.FOO}.single_nested_enum)",
+    ast: "TestAllTypes{\n  single_nested_enum:TestAllTypes^#*expr.Expr_IdentExpr#.NestedEnum^#*expr.Expr_SelectExpr#.FOO^#*expr.Expr_SelectExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_nested_enum~test-only~^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_nested_message: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_nested_message:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: null}.single_any",
+    ast: "TestAllTypes{\n  single_any:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_any^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: null}.single_value",
+    ast: "TestAllTypes{\n  single_value:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_duration: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_duration:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_timestamp: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_timestamp:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_bool: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_bool:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{repeated_int32: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    repeated_int32:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{map_string_string: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    map_string_string:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{list_value: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    list_value:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_struct: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_struct:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{`in`: true} == TestAllTypes{}",
+    error:
+      "ERROR: \u003cinput\u003e:1:14: unsupported syntax: '`'\n | TestAllTypes{`in`: true} == TestAllTypes{}\n | .............^",
+  },
+  {
+    expr: "TestAllTypes{`in`: true}.`in`",
+    error:
+      "ERROR: \u003cinput\u003e:1:14: unsupported syntax: '`'\n | TestAllTypes{`in`: true}.`in`\n | .............^\nERROR: \u003cinput\u003e:1:26: unsupported syntax: '`'\n | TestAllTypes{`in`: true}.`in`\n | .........................^",
+  },
+  {
+    expr: "size('')",
+    ast: 'size(\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "size('A')",
+    ast: 'size(\n  "A"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "size('ÿ')",
+    ast: 'size(\n  "ÿ"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "size('four')",
+    ast: 'size(\n  "four"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "size('πέντε')",
+    ast: 'size(\n  "πέντε"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "size(b'')",
+    ast: 'size(\n  b""^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "size(b'abc')",
+    ast: 'size(\n  b"abc"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'foobar'.startsWith('foo')",
+    ast: '"foobar"^#*expr.Constant_StringValue#.startsWith(\n  "foo"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'foobar'.startsWith('bar')",
+    ast: '"foobar"^#*expr.Constant_StringValue#.startsWith(\n  "bar"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "''.startsWith('foo')",
+    ast: '""^#*expr.Constant_StringValue#.startsWith(\n  "foo"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'foobar'.startsWith('')",
+    ast: '"foobar"^#*expr.Constant_StringValue#.startsWith(\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "''.startsWith('')",
+    ast: '""^#*expr.Constant_StringValue#.startsWith(\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'завтра'.startsWith('за')",
+    ast: '"завтра"^#*expr.Constant_StringValue#.startsWith(\n  "за"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'🐱😀😛'.startsWith('🐱')",
+    ast: '"🐱😀😛"^#*expr.Constant_StringValue#.startsWith(\n  "🐱"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'foobar'.endsWith('bar')",
+    ast: '"foobar"^#*expr.Constant_StringValue#.endsWith(\n  "bar"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'foobar'.endsWith('foo')",
+    ast: '"foobar"^#*expr.Constant_StringValue#.endsWith(\n  "foo"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "''.endsWith('foo')",
+    ast: '""^#*expr.Constant_StringValue#.endsWith(\n  "foo"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'foobar'.endsWith('')",
+    ast: '"foobar"^#*expr.Constant_StringValue#.endsWith(\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "''.endsWith('')",
+    ast: '""^#*expr.Constant_StringValue#.endsWith(\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'forté'.endsWith('té')",
+    ast: '"forté"^#*expr.Constant_StringValue#.endsWith(\n  "té"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'🐱😀😛'.endsWith('😛')",
+    ast: '"🐱😀😛"^#*expr.Constant_StringValue#.endsWith(\n  "😛"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hubba'.matches('ubb')",
+    ast: '"hubba"^#*expr.Constant_StringValue#.matches(\n  "ubb"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "''.matches('foo|bar')",
+    ast: '""^#*expr.Constant_StringValue#.matches(\n  "foo|bar"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'cows'.matches('')",
+    ast: '"cows"^#*expr.Constant_StringValue#.matches(\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "''.matches('')",
+    ast: '""^#*expr.Constant_StringValue#.matches(\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'abcd'.matches('bc')",
+    ast: '"abcd"^#*expr.Constant_StringValue#.matches(\n  "bc"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'grey'.matches('gr(a|e)y')",
+    ast: '"grey"^#*expr.Constant_StringValue#.matches(\n  "gr(a|e)y"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'banana'.matches('ba(na)*')",
+    ast: '"banana"^#*expr.Constant_StringValue#.matches(\n  "ba(na)*"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'mañana'.matches('a+ñ+a+')",
+    ast: '"mañana"^#*expr.Constant_StringValue#.matches(\n  "a+ñ+a+"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'🐱😀😀'.matches('(a|😀){2}')",
+    ast: '"🐱😀😀"^#*expr.Constant_StringValue#.matches(\n  "(a|😀){2}"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'he' + 'llo'",
+    ast: '_+_(\n  "he"^#*expr.Constant_StringValue#,\n  "llo"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hello' + ' ' == 'hello'",
+    ast: '_==_(\n  _+_(\n    "hello"^#*expr.Constant_StringValue#,\n    " "^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "hello"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'' + 'abc'",
+    ast: '_+_(\n  ""^#*expr.Constant_StringValue#,\n  "abc"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'abc' + ''",
+    ast: '_+_(\n  "abc"^#*expr.Constant_StringValue#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'' + ''",
+    ast: '_+_(\n  ""^#*expr.Constant_StringValue#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'¢' + 'ÿ' + 'Ȁ'",
+    ast: '_+_(\n  _+_(\n    "¢"^#*expr.Constant_StringValue#,\n    "ÿ"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "Ȁ"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'r' + 'ô' + 'le'",
+    ast: '_+_(\n  _+_(\n    "r"^#*expr.Constant_StringValue#,\n    "ô"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "le"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'a' + 'ÿ' + '🐱'",
+    ast: '_+_(\n  _+_(\n    "a"^#*expr.Constant_StringValue#,\n    "ÿ"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "🐱"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'' + 'Ω' + ''",
+    ast: '_+_(\n  _+_(\n    ""^#*expr.Constant_StringValue#,\n    "Ω"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hello'.contains('he')",
+    ast: '"hello"^#*expr.Constant_StringValue#.contains(\n  "he"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hello'.contains('')",
+    ast: '"hello"^#*expr.Constant_StringValue#.contains(\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hello'.contains('ol')",
+    ast: '"hello"^#*expr.Constant_StringValue#.contains(\n  "ol"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'abababc'.contains('ababc')",
+    ast: '"abababc"^#*expr.Constant_StringValue#.contains(\n  "ababc"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'Straße'.contains('aß')",
+    ast: '"Straße"^#*expr.Constant_StringValue#.contains(\n  "aß"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'🐱😀😁'.contains('😀')",
+    ast: '"🐱😀😁"^#*expr.Constant_StringValue#.contains(\n  "😀"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "''.contains('something')",
+    ast: '""^#*expr.Constant_StringValue#.contains(\n  "something"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "''.contains('')",
+    ast: '""^#*expr.Constant_StringValue#.contains(\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'abc' + b'def'",
+    ast: '_+_(\n  b"abc"^#*expr.Constant_BytesValue#,\n  b"def"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'' + b'\\xffoo'",
+    ast: '_+_(\n  b""^#*expr.Constant_BytesValue#,\n  b"\\xffoo"^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'zxy' + b''",
+    ast: '_+_(\n  b"zxy"^#*expr.Constant_BytesValue#,\n  b""^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "b'' + b''",
+    ast: '_+_(\n  b""^#*expr.Constant_BytesValue#,\n  b""^#*expr.Constant_BytesValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.charAt(3)",
+    ast: '"tacocat"^#*expr.Constant_StringValue#.charAt(\n  3^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.charAt(7)",
+    ast: '"tacocat"^#*expr.Constant_StringValue#.charAt(\n  7^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'©αT'.charAt(0) == '©' \u0026\u0026 '©αT'.charAt(1) == 'α' \u0026\u0026 '©αT'.charAt(2) == 'T'",
+    ast: '_\u0026\u0026_(\n  _==_(\n    "©αT"^#*expr.Constant_StringValue#.charAt(\n      0^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    "©"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  _==_(\n    "©αT"^#*expr.Constant_StringValue#.charAt(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    "α"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  _==_(\n    "©αT"^#*expr.Constant_StringValue#.charAt(\n      2^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    "T"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.indexOf('')",
+    ast: '"tacocat"^#*expr.Constant_StringValue#.indexOf(\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.indexOf('ac')",
+    ast: '"tacocat"^#*expr.Constant_StringValue#.indexOf(\n  "ac"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.indexOf('none') == -1",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.indexOf(\n    "none"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.indexOf('', 3) == 3",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.indexOf(\n    ""^#*expr.Constant_StringValue#,\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  3^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.indexOf('a', 3) == 5",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.indexOf(\n    "a"^#*expr.Constant_StringValue#,\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  5^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.indexOf('at', 3) == 5",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.indexOf(\n    "at"^#*expr.Constant_StringValue#,\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  5^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'ta©o©αT'.indexOf('©') == 2",
+    ast: '_==_(\n  "ta©o©αT"^#*expr.Constant_StringValue#.indexOf(\n    "©"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'ta©o©αT'.indexOf('©', 3) == 4",
+    ast: '_==_(\n  "ta©o©αT"^#*expr.Constant_StringValue#.indexOf(\n    "©"^#*expr.Constant_StringValue#,\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  4^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'ta©o©αT'.indexOf('©αT', 3) == 4",
+    ast: '_==_(\n  "ta©o©αT"^#*expr.Constant_StringValue#.indexOf(\n    "©αT"^#*expr.Constant_StringValue#,\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  4^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'ta©o©αT'.indexOf('©α', 5) == -1",
+    ast: '_==_(\n  "ta©o©αT"^#*expr.Constant_StringValue#.indexOf(\n    "©α"^#*expr.Constant_StringValue#,\n    5^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'ijk'.indexOf('k') == 2",
+    ast: '_==_(\n  "ijk"^#*expr.Constant_StringValue#.indexOf(\n    "k"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hello wello'.indexOf('hello wello') == 0",
+    ast: '_==_(\n  "hello wello"^#*expr.Constant_StringValue#.indexOf(\n    "hello wello"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hello wello'.indexOf('ello', 6) == 7",
+    ast: '_==_(\n  "hello wello"^#*expr.Constant_StringValue#.indexOf(\n    "ello"^#*expr.Constant_StringValue#,\n    6^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  7^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hello wello'.indexOf('elbo room!!') == -1",
+    ast: '_==_(\n  "hello wello"^#*expr.Constant_StringValue#.indexOf(\n    "elbo room!!"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.lastIndexOf('') == 7",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.lastIndexOf(\n    ""^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  7^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.lastIndexOf('at') == 5",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.lastIndexOf(\n    "at"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  5^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.lastIndexOf('none') == -1",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.lastIndexOf(\n    "none"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.lastIndexOf('', 3) == 3",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.lastIndexOf(\n    ""^#*expr.Constant_StringValue#,\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  3^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.lastIndexOf('a', 3) == 1",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.lastIndexOf(\n    "a"^#*expr.Constant_StringValue#,\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'ta©o©αT'.lastIndexOf('©') == 4",
+    ast: '_==_(\n  "ta©o©αT"^#*expr.Constant_StringValue#.lastIndexOf(\n    "©"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  4^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'ta©o©αT'.lastIndexOf('©', 3) == 2",
+    ast: '_==_(\n  "ta©o©αT"^#*expr.Constant_StringValue#.lastIndexOf(\n    "©"^#*expr.Constant_StringValue#,\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  2^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'ta©o©αT'.lastIndexOf('©α', 4) == 4",
+    ast: '_==_(\n  "ta©o©αT"^#*expr.Constant_StringValue#.lastIndexOf(\n    "©α"^#*expr.Constant_StringValue#,\n    4^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  4^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hello wello'.lastIndexOf('ello', 6) == 1",
+    ast: '_==_(\n  "hello wello"^#*expr.Constant_StringValue#.lastIndexOf(\n    "ello"^#*expr.Constant_StringValue#,\n    6^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hello wello'.lastIndexOf('low') == -1",
+    ast: '_==_(\n  "hello wello"^#*expr.Constant_StringValue#.lastIndexOf(\n    "low"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hello wello'.lastIndexOf('elbo room!!') == -1",
+    ast: '_==_(\n  "hello wello"^#*expr.Constant_StringValue#.lastIndexOf(\n    "elbo room!!"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hello wello'.lastIndexOf('hello wello') == 0",
+    ast: '_==_(\n  "hello wello"^#*expr.Constant_StringValue#.lastIndexOf(\n    "hello wello"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'bananananana'.lastIndexOf('nana', 7) == 6",
+    ast: '_==_(\n  "bananananana"^#*expr.Constant_StringValue#.lastIndexOf(\n    "nana"^#*expr.Constant_StringValue#,\n    7^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  6^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'TacoCat'.lowerAscii() == 'tacocat'",
+    ast: '_==_(\n  "TacoCat"^#*expr.Constant_StringValue#.lowerAscii()^#*expr.Expr_CallExpr#,\n  "tacocat"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'TacoCÆt'.lowerAscii() == 'tacocÆt'",
+    ast: '_==_(\n  "TacoCÆt"^#*expr.Constant_StringValue#.lowerAscii()^#*expr.Expr_CallExpr#,\n  "tacocÆt"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'TacoCÆt Xii'.lowerAscii() == 'tacocÆt xii'",
+    ast: '_==_(\n  "TacoCÆt Xii"^#*expr.Constant_StringValue#.lowerAscii()^#*expr.Expr_CallExpr#,\n  "tacocÆt xii"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacoCat'.upperAscii() == 'TACOCAT'",
+    ast: '_==_(\n  "tacoCat"^#*expr.Constant_StringValue#.upperAscii()^#*expr.Expr_CallExpr#,\n  "TACOCAT"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacoCαt'.upperAscii() == 'TACOCαT'",
+    ast: '_==_(\n  "tacoCαt"^#*expr.Constant_StringValue#.upperAscii()^#*expr.Expr_CallExpr#,\n  "TACOCαT"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'TacoCÆt Xii'.upperAscii() == 'TACOCÆT XII'",
+    ast: '_==_(\n  "TacoCÆt Xii"^#*expr.Constant_StringValue#.upperAscii()^#*expr.Expr_CallExpr#,\n  "TACOCÆT XII"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'12 days 12 hours'.replace('{0}', '2') == '12 days 12 hours'",
+    ast: '_==_(\n  "12 days 12 hours"^#*expr.Constant_StringValue#.replace(\n    "{0}"^#*expr.Constant_StringValue#,\n    "2"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "12 days 12 hours"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'{0} days {0} hours'.replace('{0}', '2') == '2 days 2 hours'",
+    ast: '_==_(\n  "{0} days {0} hours"^#*expr.Constant_StringValue#.replace(\n    "{0}"^#*expr.Constant_StringValue#,\n    "2"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "2 days 2 hours"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'{0} days {0} hours'.replace('{0}', '2', 1).replace('{0}', '23') == '2 days 23 hours'",
+    ast: '_==_(\n  "{0} days {0} hours"^#*expr.Constant_StringValue#.replace(\n    "{0}"^#*expr.Constant_StringValue#,\n    "2"^#*expr.Constant_StringValue#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#.replace(\n    "{0}"^#*expr.Constant_StringValue#,\n    "23"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "2 days 23 hours"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'1 ©αT taco'.replace('αT', 'o©α') == '1 ©o©α taco'",
+    ast: '_==_(\n  "1 ©αT taco"^#*expr.Constant_StringValue#.replace(\n    "αT"^#*expr.Constant_StringValue#,\n    "o©α"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "1 ©o©α taco"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hello world'.split(' ') == ['hello', 'world']",
+    ast: '_==_(\n  "hello world"^#*expr.Constant_StringValue#.split(\n    " "^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  [\n    "hello"^#*expr.Constant_StringValue#,\n    "world"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hello world events!'.split(' ', 0) == []",
+    ast: '_==_(\n  "hello world events!"^#*expr.Constant_StringValue#.split(\n    " "^#*expr.Constant_StringValue#,\n    0^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  []^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hello world events!'.split(' ', 1) == ['hello world events!']",
+    ast: '_==_(\n  "hello world events!"^#*expr.Constant_StringValue#.split(\n    " "^#*expr.Constant_StringValue#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  [\n    "hello world events!"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'o©o©o©o'.split('©', -1) == ['o', 'o', 'o', 'o']",
+    ast: '_==_(\n  "o©o©o©o"^#*expr.Constant_StringValue#.split(\n    "©"^#*expr.Constant_StringValue#,\n    -1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  [\n    "o"^#*expr.Constant_StringValue#,\n    "o"^#*expr.Constant_StringValue#,\n    "o"^#*expr.Constant_StringValue#,\n    "o"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.substring(4) == 'cat'",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.substring(\n    4^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  "cat"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.substring(7) == ''",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.substring(\n    7^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.substring(0, 4) == 'taco'",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.substring(\n    0^#*expr.Constant_Int64Value#,\n    4^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  "taco"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.substring(4, 4) == ''",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.substring(\n    4^#*expr.Constant_Int64Value#,\n    4^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'ta©o©αT'.substring(2, 6) == '©o©α'",
+    ast: '_==_(\n  "ta©o©αT"^#*expr.Constant_StringValue#.substring(\n    2^#*expr.Constant_Int64Value#,\n    6^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  "©o©α"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'ta©o©αT'.substring(7, 7) == ''",
+    ast: '_==_(\n  "ta©o©αT"^#*expr.Constant_StringValue#.substring(\n    7^#*expr.Constant_Int64Value#,\n    7^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "' \\f\\n\\r\\t\\vtext  '.trim() == 'text'",
+    ast: '_==_(\n  " \\f\\n\\r\\t\\vtext  "^#*expr.Constant_StringValue#.trim()^#*expr.Expr_CallExpr#,\n  "text"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'\\u0085\\u00a0\\u1680text'.trim() == 'text'",
+    ast: '_==_(\n  "\\u0085\\u00a0\\u1680text"^#*expr.Constant_StringValue#.trim()^#*expr.Expr_CallExpr#,\n  "text"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'text\\u2000\\u2001\\u2002\\u2003\\u2004\\u2004\\u2006\\u2007\\u2008\\u2009'.trim() == 'text'",
+    ast: '_==_(\n  "text\\u2000\\u2001\\u2002\\u2003\\u2004\\u2004\\u2006\\u2007\\u2008\\u2009"^#*expr.Constant_StringValue#.trim()^#*expr.Expr_CallExpr#,\n  "text"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'\\u200atext\\u2028\\u2029\\u202F\\u205F\\u3000'.trim() == 'text'",
+    ast: '_==_(\n  "\\u200atext\\u2028\\u2029\\u202f\\u205f\\u3000"^#*expr.Constant_StringValue#.trim()^#*expr.Expr_CallExpr#,\n  "text"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'\\u180etext\\u200b\\u200c\\u200d\\u2060\\ufeff'.trim() == '\\u180etext\\u200b\\u200c\\u200d\\u2060\\ufeff'",
+    ast: '_==_(\n  "\\u180etext\\u200b\\u200c\\u200d\\u2060\\ufeff"^#*expr.Constant_StringValue#.trim()^#*expr.Expr_CallExpr#,\n  "\\u180etext\\u200b\\u200c\\u200d\\u2060\\ufeff"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "['x', 'y'].join() == 'xy'",
+    ast: '_==_(\n  [\n    "x"^#*expr.Constant_StringValue#,\n    "y"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#.join()^#*expr.Expr_CallExpr#,\n  "xy"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "['x', 'y'].join('-') == 'x-y'",
+    ast: '_==_(\n  [\n    "x"^#*expr.Constant_StringValue#,\n    "y"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#.join(\n    "-"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "x-y"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[].join() == ''",
+    ast: '_==_(\n  []^#*expr.Expr_ListExpr#.join()^#*expr.Expr_CallExpr#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[].join('-') == ''",
+    ast: '_==_(\n  []^#*expr.Expr_ListExpr#.join(\n    "-"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("first\\nsecond") == "\\"first\\\\nsecond\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "first\\nsecond"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"first\\\\nsecond\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("bell\\a") == "\\"bell\\\\a\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "bell\\a"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"bell\\\\a\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("\\bbackspace") == "\\"\\\\bbackspace\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "\\bbackspace"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"\\\\bbackspace\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("\\fform feed") == "\\"\\\\fform feed\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "\\fform feed"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"\\\\fform feed\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("carriage \\r return") == "\\"carriage \\\\r return\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "carriage \\r return"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"carriage \\\\r return\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("horizontal tab\\t") == "\\"horizontal tab\\\\t\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "horizontal tab\\t"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"horizontal tab\\\\t\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("vertical \\v tab") == "\\"vertical \\\\v tab\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "vertical \\v tab"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"vertical \\\\v tab\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("double \\\\\\\\ slash") == "\\"double \\\\\\\\\\\\\\\\ slash\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "double \\\\\\\\ slash"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"double \\\\\\\\\\\\\\\\ slash\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("two escape sequences \\\\a\\\\n") == "\\"two escape sequences \\\\\\\\a\\\\\\\\n\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "two escape sequences \\\\a\\\\n"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"two escape sequences \\\\\\\\a\\\\\\\\n\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("verbatim") == "\\"verbatim\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "verbatim"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"verbatim\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("ends with \\\\") == "\\"ends with \\\\\\\\\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "ends with \\\\"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"ends with \\\\\\\\\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("\\\\ starts with") == "\\"\\\\\\\\ starts with\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "\\\\ starts with"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"\\\\\\\\ starts with\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("printable unicode😀") == "\\"printable unicode😀\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "printable unicode😀"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"printable unicode😀\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("mid string \\" quote") == "\\"mid string \\\\\\" quote\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "mid string \\" quote"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"mid string \\\\\\" quote\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote(\'single-quote with "double quote"\') == "\\"single-quote with \\\\\\"double quote\\\\\\"\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "single-quote with \\"double quote\\""^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"single-quote with \\\\\\"double quote\\\\\\"\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("size(\'ÿ\')") == "\\"size(\'ÿ\')\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "size(\'ÿ\')"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"size(\'ÿ\')\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("size(\'πέντε\')") == "\\"size(\'πέντε\')\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "size(\'πέντε\')"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"size(\'πέντε\')\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("завтра") == "\\"завтра\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "завтра"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"завтра\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("\\U0001F431\\U0001F600\\U0001F61B")',
+    ast: 'strings^#*expr.Expr_IdentExpr#.quote(\n  "🐱😀😛"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("ta©o©αT") == "\\"ta©o©αT\\""',
+    ast: '_==_(\n  strings^#*expr.Expr_IdentExpr#.quote(\n    "ta©o©αT"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "\\"ta©o©αT\\""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'strings.quote("")',
+    ast: 'strings^#*expr.Expr_IdentExpr#.quote(\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"no substitution".format([])',
+    ast: '"no substitution"^#*expr.Constant_StringValue#.format(\n  []^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"str is %s and some more".format(["filler"])',
+    ast: '"str is %s and some more"^#*expr.Constant_StringValue#.format(\n  [\n    "filler"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%% and also %%".format([])',
+    ast: '"%% and also %%"^#*expr.Constant_StringValue#.format(\n  []^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%%%s%%".format(["text"])',
+    ast: '"%%%s%%"^#*expr.Constant_StringValue#.format(\n  [\n    "text"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s%%".format(["percent on the right"])',
+    ast: '"%s%%"^#*expr.Constant_StringValue#.format(\n  [\n    "percent on the right"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%%%s".format(["percent on the left"])',
+    ast: '"%%%s"^#*expr.Constant_StringValue#.format(\n  [\n    "percent on the left"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%d %d %d, %s %s %s, %d %d %d, %s %s %s".format([1, 2, 3, "A", "B", "C", 4, 5, 6, "D", "E", "F"])',
+    ast: '"%d %d %d, %s %s %s, %d %d %d, %s %s %s"^#*expr.Constant_StringValue#.format(\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#,\n    "A"^#*expr.Constant_StringValue#,\n    "B"^#*expr.Constant_StringValue#,\n    "C"^#*expr.Constant_StringValue#,\n    4^#*expr.Constant_Int64Value#,\n    5^#*expr.Constant_Int64Value#,\n    6^#*expr.Constant_Int64Value#,\n    "D"^#*expr.Constant_StringValue#,\n    "E"^#*expr.Constant_StringValue#,\n    "F"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%%escaped %s%%".format(["percent"])',
+    ast: '"%%escaped %s%%"^#*expr.Constant_StringValue#.format(\n  [\n    "percent"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%.3f".format([1.2345])',
+    ast: '"%.3f"^#*expr.Constant_StringValue#.format(\n  [\n    1.2345^#*expr.Constant_DoubleValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"this is 5 in binary: %b".format([5])',
+    ast: '"this is 5 in binary: %b"^#*expr.Constant_StringValue#.format(\n  [\n    5^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"unsigned 64 in binary: %b".format([uint(64)])',
+    ast: '"unsigned 64 in binary: %b"^#*expr.Constant_StringValue#.format(\n  [\n    uint(\n      64^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"bit set from bool: %b".format([true])',
+    ast: '"bit set from bool: %b"^#*expr.Constant_StringValue#.format(\n  [\n    true^#*expr.Constant_BoolValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%o".format([11])',
+    ast: '"%o"^#*expr.Constant_StringValue#.format(\n  [\n    11^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"this is an unsigned octal: %o".format([uint(65535)])',
+    ast: '"this is an unsigned octal: %o"^#*expr.Constant_StringValue#.format(\n  [\n    uint(\n      65535^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%x is 20 in hexadecimal".format([30])',
+    ast: '"%x is 20 in hexadecimal"^#*expr.Constant_StringValue#.format(\n  [\n    30^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%X is 20 in hexadecimal".format([30])',
+    ast: '"%X is 20 in hexadecimal"^#*expr.Constant_StringValue#.format(\n  [\n    30^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%X is 6000 in hexadecimal".format([uint(6000)])',
+    ast: '"%X is 6000 in hexadecimal"^#*expr.Constant_StringValue#.format(\n  [\n    uint(\n      6000^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%x".format(["Hello world!"])',
+    ast: '"%x"^#*expr.Constant_StringValue#.format(\n  [\n    "Hello world!"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%X".format(["Hello world!"])',
+    ast: '"%X"^#*expr.Constant_StringValue#.format(\n  [\n    "Hello world!"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%x".format([b"byte string"])',
+    ast: '"%x"^#*expr.Constant_StringValue#.format(\n  [\n    b"byte string"^#*expr.Constant_BytesValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%X".format([b"byte string"])',
+    ast: '"%X"^#*expr.Constant_StringValue#.format(\n  [\n    b"byte string"^#*expr.Constant_BytesValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%.6e".format([1052.032911275])',
+    ast: '"%.6e"^#*expr.Constant_StringValue#.format(\n  [\n    1052.032911275^#*expr.Constant_DoubleValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%f".format([2.71828])',
+    ast: '"%f"^#*expr.Constant_StringValue#.format(\n  [\n    2.71828^#*expr.Constant_DoubleValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%e".format([2.71828])',
+    ast: '"%e"^#*expr.Constant_StringValue#.format(\n  [\n    2.71828^#*expr.Constant_DoubleValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%e".format([double("NaN")])',
+    ast: '"%e"^#*expr.Constant_StringValue#.format(\n  [\n    double(\n      "NaN"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%e".format([double("Infinity")])',
+    ast: '"%e"^#*expr.Constant_StringValue#.format(\n  [\n    double(\n      "Infinity"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%e".format([double("-Infinity")])',
+    ast: '"%e"^#*expr.Constant_StringValue#.format(\n  [\n    double(\n      "-Infinity"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%d".format([double("NaN")])',
+    ast: '"%d"^#*expr.Constant_StringValue#.format(\n  [\n    double(\n      "NaN"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%d".format([double("Infinity")])',
+    ast: '"%d"^#*expr.Constant_StringValue#.format(\n  [\n    double(\n      "Infinity"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%d".format([double("-Infinity")])',
+    ast: '"%d"^#*expr.Constant_StringValue#.format(\n  [\n    double(\n      "-Infinity"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%f".format([double("NaN")])',
+    ast: '"%f"^#*expr.Constant_StringValue#.format(\n  [\n    double(\n      "NaN"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%f".format([double("Infinity")])',
+    ast: '"%f"^#*expr.Constant_StringValue#.format(\n  [\n    double(\n      "Infinity"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%f".format([double("-Infinity")])',
+    ast: '"%f"^#*expr.Constant_StringValue#.format(\n  [\n    double(\n      "-Infinity"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%d".format([uint(64)])',
+    ast: '"%d"^#*expr.Constant_StringValue#.format(\n  [\n    uint(\n      64^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s".format([null])',
+    ast: '"%s"^#*expr.Constant_StringValue#.format(\n  [\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s".format([999999999999])',
+    ast: '"%s"^#*expr.Constant_StringValue#.format(\n  [\n    999999999999^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s".format([b"xyz"])',
+    ast: '"%s"^#*expr.Constant_StringValue#.format(\n  [\n    b"xyz"^#*expr.Constant_BytesValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s".format([type("test string")])',
+    ast: '"%s"^#*expr.Constant_StringValue#.format(\n  [\n    type(\n      "test string"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s".format([timestamp("2023-02-03T23:31:20+00:00")])',
+    ast: '"%s"^#*expr.Constant_StringValue#.format(\n  [\n    timestamp(\n      "2023-02-03T23:31:20+00:00"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s".format([duration("1h45m47s")])',
+    ast: '"%s"^#*expr.Constant_StringValue#.format(\n  [\n    duration(\n      "1h45m47s"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s".format([["abc", 3.14, null, [9, 8, 7, 6], timestamp("2023-02-03T23:31:20Z")]])',
+    ast: '"%s"^#*expr.Constant_StringValue#.format(\n  [\n    [\n      "abc"^#*expr.Constant_StringValue#,\n      3.14^#*expr.Constant_DoubleValue#,\n      null^#*expr.Constant_NullValue#,\n      [\n        9^#*expr.Constant_Int64Value#,\n        8^#*expr.Constant_Int64Value#,\n        7^#*expr.Constant_Int64Value#,\n        6^#*expr.Constant_Int64Value#\n      ]^#*expr.Expr_ListExpr#,\n      timestamp(\n        "2023-02-03T23:31:20Z"^#*expr.Constant_StringValue#\n      )^#*expr.Expr_CallExpr#\n    ]^#*expr.Expr_ListExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s".format([{"key1": b"xyz", "key5": null, "key2": duration("2h"), "key4": true, "key3": 2.71828}])',
+    ast: '"%s"^#*expr.Constant_StringValue#.format(\n  [\n    {\n      "key1"^#*expr.Constant_StringValue#:b"xyz"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#,\n      "key5"^#*expr.Constant_StringValue#:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#,\n      "key2"^#*expr.Constant_StringValue#:duration(\n        "2h"^#*expr.Constant_StringValue#\n      )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#,\n      "key4"^#*expr.Constant_StringValue#:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#,\n      "key3"^#*expr.Constant_StringValue#:2.71828^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s".format([{1: "value1", uint(2): "value2", true: double("NaN")}])',
+    ast: '"%s"^#*expr.Constant_StringValue#.format(\n  [\n    {\n      1^#*expr.Constant_Int64Value#:"value1"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      uint(\n        2^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#:"value2"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      true^#*expr.Constant_BoolValue#:double(\n        "NaN"^#*expr.Constant_StringValue#\n      )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s, %s".format([true, false])',
+    ast: '"%s, %s"^#*expr.Constant_StringValue#.format(\n  [\n    true^#*expr.Constant_BoolValue#,\n    false^#*expr.Constant_BoolValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s".format([dyn("a string")])',
+    ast: '"%s"^#*expr.Constant_StringValue#.format(\n  [\n    dyn(\n      "a string"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s, %s".format([dyn(32), dyn(56.8)])',
+    ast: '"%s, %s"^#*expr.Constant_StringValue#.format(\n  [\n    dyn(\n      32^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    dyn(\n      56.8^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%d".format([dyn(128)])',
+    ast: '"%d"^#*expr.Constant_StringValue#.format(\n  [\n    dyn(\n      128^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%d".format([dyn(256u)])',
+    ast: '"%d"^#*expr.Constant_StringValue#.format(\n  [\n    dyn(\n      256u^#*expr.Constant_Uint64Value#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%x".format([dyn(22)])',
+    ast: '"%x"^#*expr.Constant_StringValue#.format(\n  [\n    dyn(\n      22^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%X".format([dyn(26)])',
+    ast: '"%X"^#*expr.Constant_StringValue#.format(\n  [\n    dyn(\n      26^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%x".format([dyn(500u)])',
+    ast: '"%x"^#*expr.Constant_StringValue#.format(\n  [\n    dyn(\n      500u^#*expr.Constant_Uint64Value#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%.3f".format([dyn(4.5)])',
+    ast: '"%.3f"^#*expr.Constant_StringValue#.format(\n  [\n    dyn(\n      4.5^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%e".format([dyn(2.71828)])',
+    ast: '"%e"^#*expr.Constant_StringValue#.format(\n  [\n    dyn(\n      2.71828^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s".format([[double("NaN"), double("Infinity"), double("-Infinity")]])',
+    ast: '"%s"^#*expr.Constant_StringValue#.format(\n  [\n    [\n      double(\n        "NaN"^#*expr.Constant_StringValue#\n      )^#*expr.Expr_CallExpr#,\n      double(\n        "Infinity"^#*expr.Constant_StringValue#\n      )^#*expr.Expr_CallExpr#,\n      double(\n        "-Infinity"^#*expr.Constant_StringValue#\n      )^#*expr.Expr_CallExpr#\n    ]^#*expr.Expr_ListExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s".format([dyn(timestamp("2009-11-10T23:00:00Z"))])',
+    ast: '"%s"^#*expr.Constant_StringValue#.format(\n  [\n    dyn(\n      timestamp(\n        "2009-11-10T23:00:00Z"^#*expr.Constant_StringValue#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s".format([dyn(duration("8747s"))])',
+    ast: '"%s"^#*expr.Constant_StringValue#.format(\n  [\n    dyn(\n      duration(\n        "8747s"^#*expr.Constant_StringValue#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s".format([dyn([6, 4.2, "a string"])])',
+    ast: '"%s"^#*expr.Constant_StringValue#.format(\n  [\n    dyn(\n      [\n        6^#*expr.Constant_Int64Value#,\n        4.2^#*expr.Constant_DoubleValue#,\n        "a string"^#*expr.Constant_StringValue#\n      ]^#*expr.Expr_ListExpr#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s".format([{"strKey":"x", 6:duration("422s"), true:42}])',
+    ast: '"%s"^#*expr.Constant_StringValue#.format(\n  [\n    {\n      "strKey"^#*expr.Constant_StringValue#:"x"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      6^#*expr.Constant_Int64Value#:duration(\n        "422s"^#*expr.Constant_StringValue#\n      )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#,\n      true^#*expr.Constant_BoolValue#:42^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'str_var.format(["filler"])',
+    ast: 'str_var^#*expr.Expr_IdentExpr#.format(\n  [\n    "filler"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'str_var.format([1, 2, 3, "A", "B", "C", 4, 5, 6, "D", "E", "F"])',
+    ast: 'str_var^#*expr.Expr_IdentExpr#.format(\n  [\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#,\n    "A"^#*expr.Constant_StringValue#,\n    "B"^#*expr.Constant_StringValue#,\n    "C"^#*expr.Constant_StringValue#,\n    4^#*expr.Constant_Int64Value#,\n    5^#*expr.Constant_Int64Value#,\n    6^#*expr.Constant_Int64Value#,\n    "D"^#*expr.Constant_StringValue#,\n    "E"^#*expr.Constant_StringValue#,\n    "F"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: 'str_var.format(["text"])',
+    ast: 'str_var^#*expr.Expr_IdentExpr#.format(\n  [\n    "text"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "str_var.format([1.2345])",
+    ast: "str_var^#*expr.Expr_IdentExpr#.format(\n  [\n    1.2345^#*expr.Constant_DoubleValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "str_var.format([5])",
+    ast: "str_var^#*expr.Expr_IdentExpr#.format(\n  [\n    5^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "str_var.format([1052.032911275])",
+    ast: "str_var^#*expr.Expr_IdentExpr#.format(\n  [\n    1052.032911275^#*expr.Constant_DoubleValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "str_var.format([2.71828])",
+    ast: "str_var^#*expr.Expr_IdentExpr#.format(\n  [\n    2.71828^#*expr.Constant_DoubleValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: '"%a".format([1])',
+    ast: '"%a"^#*expr.Constant_StringValue#.format(\n  [\n    1^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%d %d %d".format([0, 1])',
+    ast: '"%d %d %d"^#*expr.Constant_StringValue#.format(\n  [\n    0^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"string is %b".format(["abc"])',
+    ast: '"string is %b"^#*expr.Constant_StringValue#.format(\n  [\n    "abc"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%d".format([duration("30m2s")])',
+    ast: '"%d"^#*expr.Constant_StringValue#.format(\n  [\n    duration(\n      "30m2s"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"octal: %o".format(["a string"])',
+    ast: '"octal: %o"^#*expr.Constant_StringValue#.format(\n  [\n    "a string"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"double is %x".format([0.5])',
+    ast: '"double is %x"^#*expr.Constant_StringValue#.format(\n  [\n    0.5^#*expr.Constant_DoubleValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"double is %E".format([0.5])',
+    ast: '"double is %E"^#*expr.Constant_StringValue#.format(\n  [\n    0.5^#*expr.Constant_DoubleValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"object is %s".format([cel.expr.conformance.proto3.TestAllTypes{}])',
+    ast: '"object is %s"^#*expr.Constant_StringValue#.format(\n  [\n    cel.expr.conformance.proto3.TestAllTypes{}^#*expr.Expr_StructExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s".format([[1, 2, cel.expr.conformance.proto3.TestAllTypes{}]])',
+    ast: '"%s"^#*expr.Constant_StringValue#.format(\n  [\n    [\n      1^#*expr.Constant_Int64Value#,\n      2^#*expr.Constant_Int64Value#,\n      cel.expr.conformance.proto3.TestAllTypes{}^#*expr.Expr_StructExpr#\n    ]^#*expr.Expr_ListExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"%s".format([{1: "a", 2: cel.expr.conformance.proto3.TestAllTypes{}}])',
+    ast: '"%s"^#*expr.Constant_StringValue#.format(\n  [\n    {\n      1^#*expr.Constant_Int64Value#:"a"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#,\n      2^#*expr.Constant_Int64Value#:cel.expr.conformance.proto3.TestAllTypes{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n    }^#*expr.Expr_StructExpr#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"null: %d".format([null])',
+    ast: '"null: %d"^#*expr.Constant_StringValue#.format(\n  [\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"null: %e".format([null])',
+    ast: '"null: %e"^#*expr.Constant_StringValue#.format(\n  [\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"null: %f".format([null])',
+    ast: '"null: %f"^#*expr.Constant_StringValue#.format(\n  [\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"null: %x".format([null])',
+    ast: '"null: %x"^#*expr.Constant_StringValue#.format(\n  [\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"null: %X".format([null])',
+    ast: '"null: %X"^#*expr.Constant_StringValue#.format(\n  [\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"null: %b".format([null])',
+    ast: '"null: %b"^#*expr.Constant_StringValue#.format(\n  [\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: '"null: %o".format([null])',
+    ast: '"null: %o"^#*expr.Constant_StringValue#.format(\n  [\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.charAt(30) == ''",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.charAt(\n    30^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.indexOf('a', 30) == -1",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.indexOf(\n    "a"^#*expr.Constant_StringValue#,\n    30^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.lastIndexOf('a', -1) == -1",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.lastIndexOf(\n    "a"^#*expr.Constant_StringValue#,\n    -1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.lastIndexOf('a', 30) == -1",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.lastIndexOf(\n    "a"^#*expr.Constant_StringValue#,\n    30^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  -1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.substring(40) == 'cat'",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.substring(\n    40^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  "cat"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.substring(-1) == 'cat'",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.substring(\n    -1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  "cat"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.substring(1, 50) == 'cat'",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.substring(\n    1^#*expr.Constant_Int64Value#,\n    50^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  "cat"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.substring(49, 50) == 'cat'",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.substring(\n    49^#*expr.Constant_Int64Value#,\n    50^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  "cat"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.substring(4, 3) == ''",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.substring(\n    4^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "42.charAt(2) == ''",
+    ast: '_==_(\n  42^#*expr.Constant_Int64Value#.charAt(\n    2^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hello'.charAt(true) == ''",
+    ast: '_==_(\n  "hello"^#*expr.Constant_StringValue#.charAt(\n    true^#*expr.Constant_BoolValue#\n  )^#*expr.Expr_CallExpr#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "24.indexOf('2') == 0",
+    ast: '_==_(\n  24^#*expr.Constant_Int64Value#.indexOf(\n    "2"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hello'.indexOf(true) == 1",
+    ast: '_==_(\n  "hello"^#*expr.Constant_StringValue#.indexOf(\n    true^#*expr.Constant_BoolValue#\n  )^#*expr.Expr_CallExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "42.indexOf('4', 0) == 0",
+    ast: '_==_(\n  42^#*expr.Constant_Int64Value#.indexOf(\n    "4"^#*expr.Constant_StringValue#,\n    0^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'42'.indexOf(4, 0) == 0",
+    ast: '_==_(\n  "42"^#*expr.Constant_StringValue#.indexOf(\n    4^#*expr.Constant_Int64Value#,\n    0^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'42'.indexOf('4', '0') == 0",
+    ast: '_==_(\n  "42"^#*expr.Constant_StringValue#.indexOf(\n    "4"^#*expr.Constant_StringValue#,\n    "0"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'42'.indexOf('4', 0, 1) == 0",
+    ast: '_==_(\n  "42"^#*expr.Constant_StringValue#.indexOf(\n    "4"^#*expr.Constant_StringValue#,\n    0^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "42.split('2') == ['4']",
+    ast: '_==_(\n  42^#*expr.Constant_Int64Value#.split(\n    "2"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  [\n    "4"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "42.replace(2, 1) == '41'",
+    ast: '_==_(\n  42^#*expr.Constant_Int64Value#.replace(\n    2^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  "41"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'42'.replace(2, 1) == '41'",
+    ast: '_==_(\n  "42"^#*expr.Constant_StringValue#.replace(\n    2^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  "41"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'42'.replace('2', 1) == '41'",
+    ast: '_==_(\n  "42"^#*expr.Constant_StringValue#.replace(\n    "2"^#*expr.Constant_StringValue#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  "41"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "42.replace('2', '1', 1) == '41'",
+    ast: '_==_(\n  42^#*expr.Constant_Int64Value#.replace(\n    "2"^#*expr.Constant_StringValue#,\n    "1"^#*expr.Constant_StringValue#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  "41"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'42'.replace(2, '1', 1) == '41'",
+    ast: '_==_(\n  "42"^#*expr.Constant_StringValue#.replace(\n    2^#*expr.Constant_Int64Value#,\n    "1"^#*expr.Constant_StringValue#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  "41"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'42'.replace('2', 1, 1) == '41'",
+    ast: '_==_(\n  "42"^#*expr.Constant_StringValue#.replace(\n    "2"^#*expr.Constant_StringValue#,\n    1^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  "41"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'42'.replace('2', '1', '1') == '41'",
+    ast: '_==_(\n  "42"^#*expr.Constant_StringValue#.replace(\n    "2"^#*expr.Constant_StringValue#,\n    "1"^#*expr.Constant_StringValue#,\n    "1"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  "41"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'42'.replace('2', '1', 1, false) == '41'",
+    ast: '_==_(\n  "42"^#*expr.Constant_StringValue#.replace(\n    "2"^#*expr.Constant_StringValue#,\n    "1"^#*expr.Constant_StringValue#,\n    1^#*expr.Constant_Int64Value#,\n    false^#*expr.Constant_BoolValue#\n  )^#*expr.Expr_CallExpr#,\n  "41"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "42.split('') == ['4', '2']",
+    ast: '_==_(\n  42^#*expr.Constant_Int64Value#.split(\n    ""^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  [\n    "4"^#*expr.Constant_StringValue#,\n    "2"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'42'.split(2) == ['4']",
+    ast: '_==_(\n  "42"^#*expr.Constant_StringValue#.split(\n    2^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  [\n    "4"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "42.split('2', '1') == ['4']",
+    ast: '_==_(\n  42^#*expr.Constant_Int64Value#.split(\n    "2"^#*expr.Constant_StringValue#,\n    "1"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  [\n    "4"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'42'.split(2, 1) == ['4']",
+    ast: '_==_(\n  "42"^#*expr.Constant_StringValue#.split(\n    2^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  [\n    "4"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'42'.split('2', '1') == ['4']",
+    ast: '_==_(\n  "42"^#*expr.Constant_StringValue#.split(\n    "2"^#*expr.Constant_StringValue#,\n    "1"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  [\n    "4"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'42'.split('2', 1, 1) == ['4']",
+    ast: '_==_(\n  "42"^#*expr.Constant_StringValue#.split(\n    "2"^#*expr.Constant_StringValue#,\n    1^#*expr.Constant_Int64Value#,\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  [\n    "4"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'hello'.substring(1, 2, 3) == ''",
+    ast: '_==_(\n  "hello"^#*expr.Constant_StringValue#.substring(\n    1^#*expr.Constant_Int64Value#,\n    2^#*expr.Constant_Int64Value#,\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "30.substring(true, 3) == ''",
+    ast: '_==_(\n  30^#*expr.Constant_Int64Value#.substring(\n    true^#*expr.Constant_BoolValue#,\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.substring(true, 3) == ''",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.substring(\n    true^#*expr.Constant_BoolValue#,\n    3^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "'tacocat'.substring(0, false) == ''",
+    ast: '_==_(\n  "tacocat"^#*expr.Constant_StringValue#.substring(\n    0^#*expr.Constant_Int64Value#,\n    false^#*expr.Constant_BoolValue#\n  )^#*expr.Expr_CallExpr#,\n  ""^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "int(timestamp('2009-02-13T23:31:30Z'))",
+    ast: 'int(\n  timestamp(\n    "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "string(timestamp('2009-02-13T23:31:30Z'))",
+    ast: 'string(\n  timestamp(\n    "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "string(timestamp('9999-12-31T23:59:59.999999999Z'))",
+    ast: 'string(\n  timestamp(\n    "9999-12-31T23:59:59.999999999Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "type(timestamp('2009-02-13T23:31:30Z'))",
+    ast: 'type(\n  timestamp(\n    "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "google.protobuf.Timestamp == type(timestamp('2009-02-13T23:31:30Z'))",
+    ast: '_==_(\n  google^#*expr.Expr_IdentExpr#.protobuf^#*expr.Expr_SelectExpr#.Timestamp^#*expr.Expr_SelectExpr#,\n  type(\n    timestamp(\n      "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "string(duration('1000000s'))",
+    ast: 'string(\n  duration(\n    "1000000s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "type(duration('1000000s'))",
+    ast: 'type(\n  duration(\n    "1000000s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "google.protobuf.Duration == type(duration('1000000s'))",
+    ast: '_==_(\n  google^#*expr.Expr_IdentExpr#.protobuf^#*expr.Expr_SelectExpr#.Duration^#*expr.Expr_SelectExpr#,\n  type(\n    duration(\n      "1000000s"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getDate()",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getDate()^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getDayOfMonth()",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getDayOfMonth()^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getDayOfWeek()",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getDayOfWeek()^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getDayOfYear()",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getDayOfYear()^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getFullYear()",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getFullYear()^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getHours()",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getHours()^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:20.123456789Z').getMilliseconds()",
+    ast: 'timestamp(\n  "2009-02-13T23:31:20.123456789Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getMilliseconds()^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getMinutes()",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getMinutes()^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getMonth()",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getMonth()^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getSeconds()",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getSeconds()^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getDate('Australia/Sydney')",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getDate(\n  "Australia/Sydney"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getDayOfMonth('US/Central')",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getDayOfMonth(\n  "US/Central"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getDayOfMonth('+11:00')",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getDayOfMonth(\n  "+11:00"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T02:00:00Z').getDayOfMonth('-02:30')",
+    ast: 'timestamp(\n  "2009-02-13T02:00:00Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getDayOfMonth(\n  "-02:30"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T02:00:00Z').getDayOfMonth('America/St_Johns')",
+    ast: 'timestamp(\n  "2009-02-13T02:00:00Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getDayOfMonth(\n  "America/St_Johns"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getDayOfWeek('UTC')",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getDayOfWeek(\n  "UTC"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getDayOfYear('US/Central')",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getDayOfYear(\n  "US/Central"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getFullYear('-09:30')",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getFullYear(\n  "-09:30"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getHours('02:00')",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getHours(\n  "02:00"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getMinutes('Asia/Kathmandu')",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getMinutes(\n  "Asia/Kathmandu"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getMonth('UTC')",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getMonth(\n  "UTC"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z').getSeconds('-00:00')",
+    ast: 'timestamp(\n  "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getSeconds(\n  "-00:00"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:30Z') == timestamp('2009-02-13T23:31:30Z')",
+    ast: '_==_(\n  timestamp(\n    "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:29Z') == timestamp('2009-02-13T23:31:30Z')",
+    ast: '_==_(\n  timestamp(\n    "2009-02-13T23:31:29Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    "2009-02-13T23:31:30Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('1945-05-07T02:41:00Z') != timestamp('1945-05-07T02:41:00Z')",
+    ast: '_!=_(\n  timestamp(\n    "1945-05-07T02:41:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    "1945-05-07T02:41:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2000-01-01T00:00:00Z') != timestamp('2001-01-01T00:00:00Z')",
+    ast: '_!=_(\n  timestamp(\n    "2000-01-01T00:00:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    "2001-01-01T00:00:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('123s') == duration('123s')",
+    ast: '_==_(\n  duration(\n    "123s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "123s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('60s') == duration('3600s')",
+    ast: '_==_(\n  duration(\n    "60s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "3600s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('604800s') != duration('604800s')",
+    ast: '_!=_(\n  duration(\n    "604800s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "604800s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('86400s') != duration('86164s')",
+    ast: '_!=_(\n  duration(\n    "86400s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "86164s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:00:00Z') + duration('240s') == timestamp('2009-02-13T23:04:00Z')",
+    ast: '_==_(\n  _+_(\n    timestamp(\n      "2009-02-13T23:00:00Z"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    duration(\n      "240s"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    "2009-02-13T23:04:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('120s') + timestamp('2009-02-13T23:01:00Z') == timestamp('2009-02-13T23:03:00Z')",
+    ast: '_==_(\n  _+_(\n    duration(\n      "120s"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    timestamp(\n      "2009-02-13T23:01:00Z"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    "2009-02-13T23:03:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('600s') + duration('50s') == duration('650s')",
+    ast: '_==_(\n  _+_(\n    duration(\n      "600s"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    duration(\n      "50s"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "650s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('0001-01-01T00:00:01.000000001Z') + duration('-999999999ns') == timestamp('0001-01-01T00:00:00.000000002Z')",
+    ast: '_==_(\n  _+_(\n    timestamp(\n      "0001-01-01T00:00:01.000000001Z"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    duration(\n      "-999999999ns"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    "0001-01-01T00:00:00.000000002Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('0001-01-01T00:00:01.999999999Z') + duration('999999999ns') == timestamp('0001-01-01T00:00:02.999999998Z')",
+    ast: '_==_(\n  _+_(\n    timestamp(\n      "0001-01-01T00:00:01.999999999Z"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    duration(\n      "999999999ns"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    "0001-01-01T00:00:02.999999998Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:10:00Z') - duration('600s') == timestamp('2009-02-13T23:00:00Z')",
+    ast: '_==_(\n  _-_(\n    timestamp(\n      "2009-02-13T23:10:00Z"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    duration(\n      "600s"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    "2009-02-13T23:00:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:31:00Z') - timestamp('2009-02-13T23:29:00Z') == duration('120s')",
+    ast: '_==_(\n  _-_(\n    timestamp(\n      "2009-02-13T23:31:00Z"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    timestamp(\n      "2009-02-13T23:29:00Z"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "120s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('900s') - duration('42s') == duration('858s')",
+    ast: '_==_(\n  _-_(\n    duration(\n      "900s"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#,\n    duration(\n      "42s"^#*expr.Constant_StringValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "858s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:00:00Z') \u003c= timestamp('2009-02-13T23:00:00Z')",
+    ast: '_\u003c=_(\n  timestamp(\n    "2009-02-13T23:00:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    "2009-02-13T23:00:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:00:00Z') \u003c= timestamp('2009-02-13T22:59:59Z')",
+    ast: '_\u003c=_(\n  timestamp(\n    "2009-02-13T23:00:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    "2009-02-13T22:59:59Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('200s') \u003c= duration('200s')",
+    ast: '_\u003c=_(\n  duration(\n    "200s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "200s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('300s') \u003c= duration('200s')",
+    ast: '_\u003c=_(\n  duration(\n    "300s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "200s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:00:00Z') \u003c timestamp('2009-03-13T23:00:00Z')",
+    ast: '_\u003c_(\n  timestamp(\n    "2009-02-13T23:00:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    "2009-03-13T23:00:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('200s') \u003c duration('300s')",
+    ast: '_\u003c_(\n  duration(\n    "200s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "300s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:00:00Z') \u003e= timestamp('2009-02-13T23:00:00Z')",
+    ast: '_\u003e=_(\n  timestamp(\n    "2009-02-13T23:00:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    "2009-02-13T23:00:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T22:58:00Z') \u003e= timestamp('2009-02-13T23:00:00Z')",
+    ast: '_\u003e=_(\n  timestamp(\n    "2009-02-13T22:58:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    "2009-02-13T23:00:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('200s') \u003e= duration('200s')",
+    ast: '_\u003e=_(\n  duration(\n    "200s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "200s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('120s') \u003e= duration('200s')",
+    ast: '_\u003e=_(\n  duration(\n    "120s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "200s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('2009-02-13T23:59:00Z') \u003e timestamp('2009-02-13T23:00:00Z')",
+    ast: '_\u003e_(\n  timestamp(\n    "2009-02-13T23:59:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    "2009-02-13T23:00:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('300s') \u003e duration('200s')",
+    ast: '_\u003e_(\n  duration(\n    "300s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "200s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('10000s').getHours()",
+    ast: 'duration(\n  "10000s"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getHours()^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "x.getMilliseconds()",
+    ast: "x^#*expr.Expr_IdentExpr#.getMilliseconds()^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "duration('3730s').getMinutes()",
+    ast: 'duration(\n  "3730s"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getMinutes()^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('3730s').getSeconds()",
+    ast: 'duration(\n  "3730s"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.getSeconds()^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('0000-01-01T00:00:00Z')",
+    ast: 'timestamp(\n  "0000-01-01T00:00:00Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('10000-01-01T00:00:00Z')",
+    ast: 'timestamp(\n  "10000-01-01T00:00:00Z"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('0001-01-01T00:00:00Z') + duration('-1s')",
+    ast: '_+_(\n  timestamp(\n    "0001-01-01T00:00:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "-1s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('9999-12-31T23:59:59Z') + duration('1s')",
+    ast: '_+_(\n  timestamp(\n    "9999-12-31T23:59:59Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "1s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('9999-12-31T23:59:59.999999999Z') + duration('1ns')",
+    ast: '_+_(\n  timestamp(\n    "9999-12-31T23:59:59.999999999Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "1ns"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('0001-01-01T00:00:00Z') + duration('-1ns')",
+    ast: '_+_(\n  timestamp(\n    "0001-01-01T00:00:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "-1ns"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('9999-12-31T23:59:59Z') - timestamp('0001-01-01T00:00:00Z')",
+    ast: '_-_(\n  timestamp(\n    "9999-12-31T23:59:59Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    "0001-01-01T00:00:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "timestamp('0001-01-01T00:00:00Z') - timestamp('9999-12-31T23:59:59Z')",
+    ast: '_-_(\n  timestamp(\n    "0001-01-01T00:00:00Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  timestamp(\n    "9999-12-31T23:59:59Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('-320000000000s')",
+    ast: 'duration(\n  "-320000000000s"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('320000000000s')",
+    ast: 'duration(\n  "320000000000s"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('-200000000000s') + duration('-200000000000s')",
+    ast: '_+_(\n  duration(\n    "-200000000000s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "-200000000000s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('200000000000s') + duration('200000000000s')",
+    ast: '_+_(\n  duration(\n    "200000000000s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "200000000000s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('-200000000000s') - duration('200000000000s')",
+    ast: '_-_(\n  duration(\n    "-200000000000s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "200000000000s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "duration('200000000000s') - duration('-200000000000s')",
+    ast: '_-_(\n  duration(\n    "200000000000s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#,\n  duration(\n    "-200000000000s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#',
+  },
+  { expr: "true", ast: "true^#*expr.Constant_BoolValue#" },
+  { expr: "42", ast: "42^#*expr.Constant_Int64Value#" },
+  { expr: "42u", ast: "42u^#*expr.Constant_Uint64Value#" },
+  { expr: "0.1", ast: "0.1^#*expr.Constant_DoubleValue#" },
+  { expr: '"test"', ast: '"test"^#*expr.Constant_StringValue#' },
+  { expr: 'b"test"', ast: 'b"test"^#*expr.Constant_BytesValue#' },
+  { expr: "null", ast: "null^#*expr.Constant_NullValue#" },
+  {
+    expr: "[1]",
+    ast: "[\n  1^#*expr.Constant_Int64Value#\n]^#*expr.Expr_ListExpr#",
+  },
+  {
+    expr: "{'abc': 123}",
+    ast: '{\n  "abc"^#*expr.Constant_StringValue#:123^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_int64: 1}",
+    ast: "TestAllTypes{\n  single_int64:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int64: 1}.single_int64",
+    ast: "TestAllTypes{\n  single_int64:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_int64^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.repeated_int64",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.repeated_int64^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.map_bool_int64",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.map_bool_int64^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.standalone_enum",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.standalone_enum^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.repeated_nested_enum",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.repeated_nested_enum^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{}.map_int32_enum",
+    ast: "TestAllTypes{}^#*expr.Expr_StructExpr#.map_int32_enum^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "['foo'][0]",
+    ast: '_[_](\n  [\n    "foo"^#*expr.Constant_StringValue#\n  ]^#*expr.Expr_ListExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "{'abc': 123}['abc']",
+    ast: '_[_](\n  {\n    "abc"^#*expr.Constant_StringValue#:123^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  "abc"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "('foo' + 'bar').startsWith('foo')",
+    ast: '_+_(\n  "foo"^#*expr.Constant_StringValue#,\n  "bar"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#.startsWith(\n  "foo"^#*expr.Constant_StringValue#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "fn('abc', 123)",
+    ast: 'fn(\n  "abc"^#*expr.Constant_StringValue#,\n  123^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#',
+  },
+  {
+    expr: "[[], [[]], [[[]]], [[[[]]]]]",
+    ast: "[\n  []^#*expr.Expr_ListExpr#,\n  [\n    []^#*expr.Expr_ListExpr#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    [\n      []^#*expr.Expr_ListExpr#\n    ]^#*expr.Expr_ListExpr#\n  ]^#*expr.Expr_ListExpr#,\n  [\n    [\n      [\n        []^#*expr.Expr_ListExpr#\n      ]^#*expr.Expr_ListExpr#\n    ]^#*expr.Expr_ListExpr#\n  ]^#*expr.Expr_ListExpr#\n]^#*expr.Expr_ListExpr#",
+  },
+  {
+    expr: "[[[[[]]]], [], [[[]]]]",
+    ast: "[\n  [\n    [\n      [\n        []^#*expr.Expr_ListExpr#\n      ]^#*expr.Expr_ListExpr#\n    ]^#*expr.Expr_ListExpr#\n  ]^#*expr.Expr_ListExpr#,\n  []^#*expr.Expr_ListExpr#,\n  [\n    [\n      []^#*expr.Expr_ListExpr#\n    ]^#*expr.Expr_ListExpr#\n  ]^#*expr.Expr_ListExpr#\n]^#*expr.Expr_ListExpr#",
+  },
+  {
+    expr: "msg.repeated_nested_message.map(x, x).map(y, y.bb)",
+    ast: "__comprehension__(\n  // Variable\n  y,\n  // Target\n  __comprehension__(\n    // Variable\n    x,\n    // Target\n    msg^#*expr.Expr_IdentExpr#.repeated_nested_message^#*expr.Expr_SelectExpr#,\n    // Accumulator\n    __result__,\n    // Init\n    []^#*expr.Expr_ListExpr#,\n    // LoopCondition\n    true^#*expr.Constant_BoolValue#,\n    // LoopStep\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      [\n        x^#*expr.Expr_IdentExpr#\n      ]^#*expr.Expr_ListExpr#\n    )^#*expr.Expr_CallExpr#,\n    // Result\n    __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#,\n  // Accumulator\n  __result__,\n  // Init\n  []^#*expr.Expr_ListExpr#,\n  // LoopCondition\n  true^#*expr.Constant_BoolValue#,\n  // LoopStep\n  _+_(\n    __result__^#*expr.Expr_IdentExpr#,\n    [\n      y^#*expr.Expr_IdentExpr#.bb^#*expr.Expr_SelectExpr#\n    ]^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  // Result\n  __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#",
+  },
+  {
+    expr: "([] + msg.repeated_nested_message + [])[0].bb",
+    ast: "_[_](\n  _+_(\n    _+_(\n      []^#*expr.Expr_ListExpr#,\n      msg^#*expr.Expr_IdentExpr#.repeated_nested_message^#*expr.Expr_SelectExpr#\n    )^#*expr.Expr_CallExpr#,\n    []^#*expr.Expr_ListExpr#\n  )^#*expr.Expr_CallExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#.bb^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "([].map(x,x))[0].foo",
+    ast: "_[_](\n  __comprehension__(\n    // Variable\n    x,\n    // Target\n    []^#*expr.Expr_ListExpr#,\n    // Accumulator\n    __result__,\n    // Init\n    []^#*expr.Expr_ListExpr#,\n    // LoopCondition\n    true^#*expr.Constant_BoolValue#,\n    // LoopStep\n    _+_(\n      __result__^#*expr.Expr_IdentExpr#,\n      [\n        x^#*expr.Expr_IdentExpr#\n      ]^#*expr.Expr_ListExpr#\n    )^#*expr.Expr_CallExpr#,\n    // Result\n    __result__^#*expr.Expr_IdentExpr#)^#*expr.Expr_ComprehensionExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#.foo^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "[msg.single_int64_wrapper, msg.single_string_wrapper]",
+    ast: "[\n  msg^#*expr.Expr_IdentExpr#.single_int64_wrapper^#*expr.Expr_SelectExpr#,\n  msg^#*expr.Expr_IdentExpr#.single_string_wrapper^#*expr.Expr_SelectExpr#\n]^#*expr.Expr_ListExpr#",
+  },
+  {
+    expr: "[optional.none(), optional.of(1)]",
+    ast: "[\n  optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#,\n  optional^#*expr.Expr_IdentExpr#.of(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n]^#*expr.Expr_ListExpr#",
+  },
+  {
+    expr: "[optional.of(1), optional.none()]",
+    ast: "[\n  optional^#*expr.Expr_IdentExpr#.of(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  optional^#*expr.Expr_IdentExpr#.none()^#*expr.Expr_CallExpr#\n]^#*expr.Expr_ListExpr#",
+  },
+  {
+    expr: "[optional.of(1), optional.of(dyn(1))]",
+    ast: "[\n  optional^#*expr.Expr_IdentExpr#.of(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  optional^#*expr.Expr_IdentExpr#.of(\n    dyn(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n]^#*expr.Expr_ListExpr#",
+  },
+  {
+    expr: "[optional.of(dyn(1)), optional.of(1)]",
+    ast: "[\n  optional^#*expr.Expr_IdentExpr#.of(\n    dyn(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  optional^#*expr.Expr_IdentExpr#.of(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n]^#*expr.Expr_ListExpr#",
+  },
+  {
+    expr: "true ? optional.of(dyn(1)) : optional.of(1)",
+    ast: "_?_:_(\n  true^#*expr.Constant_BoolValue#,\n  optional^#*expr.Expr_IdentExpr#.of(\n    dyn(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#,\n  optional^#*expr.Expr_IdentExpr#.of(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[msg.single_int64_wrapper, msg.single_int64]",
+    ast: "[\n  msg^#*expr.Expr_IdentExpr#.single_int64_wrapper^#*expr.Expr_SelectExpr#,\n  msg^#*expr.Expr_IdentExpr#.single_int64^#*expr.Expr_SelectExpr#\n]^#*expr.Expr_ListExpr#",
+  },
+  {
+    expr: "[msg.single_int64, msg.single_int64_wrapper]",
+    ast: "[\n  msg^#*expr.Expr_IdentExpr#.single_int64^#*expr.Expr_SelectExpr#,\n  msg^#*expr.Expr_IdentExpr#.single_int64_wrapper^#*expr.Expr_SelectExpr#\n]^#*expr.Expr_ListExpr#",
+  },
+  {
+    expr: "[msg.single_int64_wrapper, msg.single_int64, dyn(1)]",
+    ast: "[\n  msg^#*expr.Expr_IdentExpr#.single_int64_wrapper^#*expr.Expr_SelectExpr#,\n  msg^#*expr.Expr_IdentExpr#.single_int64^#*expr.Expr_SelectExpr#,\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#\n]^#*expr.Expr_ListExpr#",
+  },
+  {
+    expr: "[dyn(1), msg.single_int64_wrapper, msg.single_int64]",
+    ast: "[\n  dyn(\n    1^#*expr.Constant_Int64Value#\n  )^#*expr.Expr_CallExpr#,\n  msg^#*expr.Expr_IdentExpr#.single_int64_wrapper^#*expr.Expr_SelectExpr#,\n  msg^#*expr.Expr_IdentExpr#.single_int64^#*expr.Expr_SelectExpr#\n]^#*expr.Expr_ListExpr#",
+  },
+  {
+    expr: "msg.single_int64_wrapper + 1",
+    ast: "_+_(\n  msg^#*expr.Expr_IdentExpr#.single_int64_wrapper^#*expr.Expr_SelectExpr#,\n  1^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "msg.single_int64_wrapper == null",
+    ast: "_==_(\n  msg^#*expr.Expr_IdentExpr#.single_int64_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "false ? msg.single_int64_wrapper : null",
+    ast: "_?_:_(\n  false^#*expr.Constant_BoolValue#,\n  msg^#*expr.Expr_IdentExpr#.single_int64_wrapper^#*expr.Expr_SelectExpr#,\n  null^#*expr.Constant_NullValue#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "true ? msg.single_int64_wrapper : 42",
+    ast: "_?_:_(\n  true^#*expr.Constant_BoolValue#,\n  msg^#*expr.Expr_IdentExpr#.single_int64_wrapper^#*expr.Expr_SelectExpr#,\n  42^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[tuple(1, 2u, 3.0), tuple(dyn(1), dyn(2u), dyn(3.0))][0]",
+    ast: "_[_](\n  [\n    tuple(\n      1^#*expr.Constant_Int64Value#,\n      2u^#*expr.Constant_Uint64Value#,\n      3^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#,\n    tuple(\n      dyn(\n        1^#*expr.Constant_Int64Value#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        2u^#*expr.Constant_Uint64Value#\n      )^#*expr.Expr_CallExpr#,\n      dyn(\n        3^#*expr.Constant_DoubleValue#\n      )^#*expr.Expr_CallExpr#\n    )^#*expr.Expr_CallExpr#\n  ]^#*expr.Expr_ListExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "sort(tuple(dyn(1), 2u, 3.0))",
+    ast: "sort(\n  tuple(\n    dyn(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    2u^#*expr.Constant_Uint64Value#,\n    3^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "tuple(1, 2u, 3.0) == tuple(1, dyn(2u), dyn(3.0))",
+    ast: "_==_(\n  tuple(\n    1^#*expr.Constant_Int64Value#,\n    2u^#*expr.Constant_Uint64Value#,\n    3^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  tuple(\n    1^#*expr.Constant_Int64Value#,\n    dyn(\n      2u^#*expr.Constant_Uint64Value#\n    )^#*expr.Expr_CallExpr#,\n    dyn(\n      3^#*expr.Constant_DoubleValue#\n    )^#*expr.Expr_CallExpr#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "tuple(dyn(1), dyn(2u), 3.0) == tuple(1, 2u, 3.0)",
+    ast: "_==_(\n  tuple(\n    dyn(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    dyn(\n      2u^#*expr.Constant_Uint64Value#\n    )^#*expr.Expr_CallExpr#,\n    3^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#,\n  tuple(\n    1^#*expr.Constant_Int64Value#,\n    2u^#*expr.Constant_Uint64Value#,\n    3^#*expr.Constant_DoubleValue#\n  )^#*expr.Expr_CallExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[msg, null][0]",
+    ast: "_[_](\n  [\n    msg^#*expr.Expr_IdentExpr#,\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[msg.single_duration, null][0]",
+    ast: "_[_](\n  [\n    msg^#*expr.Expr_IdentExpr#.single_duration^#*expr.Expr_SelectExpr#,\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[msg.single_timestamp, null][0]",
+    ast: "_[_](\n  [\n    msg^#*expr.Expr_IdentExpr#.single_timestamp^#*expr.Expr_SelectExpr#,\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "[optional.of(1), null][0]",
+    ast: "_[_](\n  [\n    optional^#*expr.Expr_IdentExpr#.of(\n      1^#*expr.Constant_Int64Value#\n    )^#*expr.Expr_CallExpr#,\n    null^#*expr.Constant_NullValue#\n  ]^#*expr.Expr_ListExpr#,\n  0^#*expr.Constant_Int64Value#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.BoolValue{value: true}}.single_any",
+    ast: "TestAllTypes{\n  single_any:google.protobuf.BoolValue{\n    value:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_any^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: google.protobuf.BoolValue{value: true}}.single_value",
+    ast: "TestAllTypes{\n  single_value:google.protobuf.BoolValue{\n    value:true^#*expr.Constant_BoolValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_bool_wrapper: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_bool_wrapper:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.Int32Value{value: 1}}.single_any",
+    ast: "TestAllTypes{\n  single_any:google.protobuf.Int32Value{\n    value:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_any^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: google.protobuf.Int32Value{value: 1}}.single_value",
+    ast: "TestAllTypes{\n  single_value:google.protobuf.Int32Value{\n    value:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int32_wrapper: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_int32_wrapper:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.Int64Value{value: 1}}.single_any",
+    ast: "TestAllTypes{\n  single_any:google.protobuf.Int64Value{\n    value:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_any^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: google.protobuf.Int64Value{value: 1}}.single_value",
+    ast: "TestAllTypes{\n  single_value:google.protobuf.Int64Value{\n    value:1^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: google.protobuf.Int64Value{value: 9223372036854775807}}.single_value",
+    ast: "TestAllTypes{\n  single_value:google.protobuf.Int64Value{\n    value:9223372036854775807^#*expr.Constant_Int64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_int64_wrapper: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_int64_wrapper:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.UInt32Value{value: 1u}}.single_any",
+    ast: "TestAllTypes{\n  single_any:google.protobuf.UInt32Value{\n    value:1u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_any^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: google.protobuf.UInt32Value{value: 1u}}.single_value",
+    ast: "TestAllTypes{\n  single_value:google.protobuf.UInt32Value{\n    value:1u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint32_wrapper: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_uint32_wrapper:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.UInt64Value{value: 1u}}.single_any",
+    ast: "TestAllTypes{\n  single_any:google.protobuf.UInt64Value{\n    value:1u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_any^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: google.protobuf.UInt64Value{value: 1u}}.single_value",
+    ast: "TestAllTypes{\n  single_value:google.protobuf.UInt64Value{\n    value:1u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: google.protobuf.UInt64Value{value: 18446744073709551615u}}.single_value",
+    ast: "TestAllTypes{\n  single_value:google.protobuf.UInt64Value{\n    value:18446744073709551615u^#*expr.Constant_Uint64Value#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_uint64_wrapper: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_uint64_wrapper:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.FloatValue{value: 1.0}}.single_any",
+    ast: "TestAllTypes{\n  single_any:google.protobuf.FloatValue{\n    value:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_any^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: google.protobuf.FloatValue{value: 1.0}}.single_value",
+    ast: "TestAllTypes{\n  single_value:google.protobuf.FloatValue{\n    value:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_float_wrapper: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_float_wrapper:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.DoubleValue{value: 1.0}}.single_any",
+    ast: "TestAllTypes{\n  single_any:google.protobuf.DoubleValue{\n    value:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_any^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: google.protobuf.DoubleValue{value: 1.0}}.single_value",
+    ast: "TestAllTypes{\n  single_value:google.protobuf.DoubleValue{\n    value:1^#*expr.Constant_DoubleValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_double_wrapper: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_double_wrapper:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.BytesValue{value: b'foo'}}.single_any",
+    ast: 'TestAllTypes{\n  single_any:google.protobuf.BytesValue{\n    value:b"foo"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_any^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: google.protobuf.BytesValue{value: b'foo'}}.single_value",
+    ast: 'TestAllTypes{\n  single_value:google.protobuf.BytesValue{\n    value:b"foo"^#*expr.Constant_BytesValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_bytes_wrapper: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_bytes_wrapper:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: google.protobuf.StringValue{value: 'foo'}}.single_any",
+    ast: 'TestAllTypes{\n  single_any:google.protobuf.StringValue{\n    value:"foo"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_any^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: google.protobuf.StringValue{value: 'foo'}}.single_value",
+    ast: 'TestAllTypes{\n  single_value:google.protobuf.StringValue{\n    value:"foo"^#*expr.Constant_StringValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_string_wrapper: null} == TestAllTypes{}",
+    ast: "_==_(\n  TestAllTypes{\n    single_string_wrapper:null^#*expr.Constant_NullValue#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#,\n  TestAllTypes{}^#*expr.Expr_StructExpr#\n)^#*expr.Expr_CallExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: TestAllTypes{}.single_value}.single_any",
+    ast: "TestAllTypes{\n  single_any:TestAllTypes{}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_any^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: []}.single_any",
+    ast: "TestAllTypes{\n  single_any:[]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_any^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_any: {}}.single_any",
+    ast: "TestAllTypes{\n  single_any:{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_any^#*expr.Expr_SelectExpr#",
+  },
+  {
+    expr: "TestAllTypes{single_value: google.protobuf.FieldMask{paths: ['foo', 'bar']}}.single_value",
+    ast: 'TestAllTypes{\n  single_value:google.protobuf.FieldMask{\n    paths:[\n      "foo"^#*expr.Constant_StringValue#,\n      "bar"^#*expr.Constant_StringValue#\n    ]^#*expr.Expr_ListExpr#^#*expr.Expr_CreateStruct_Entry#\n  }^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: duration('1000000s')}.single_value",
+    ast: 'TestAllTypes{\n  single_value:duration(\n    "1000000s"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: timestamp('9999-12-31T23:59:59.999999999Z')}.single_value",
+    ast: 'TestAllTypes{\n  single_value:timestamp(\n    "9999-12-31T23:59:59.999999999Z"^#*expr.Constant_StringValue#\n  )^#*expr.Expr_CallExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#',
+  },
+  {
+    expr: "TestAllTypes{single_value: google.protobuf.Empty{}}.single_value",
+    ast: "TestAllTypes{\n  single_value:google.protobuf.Empty{}^#*expr.Expr_StructExpr#^#*expr.Expr_CreateStruct_Entry#\n}^#*expr.Expr_StructExpr#.single_value^#*expr.Expr_SelectExpr#",
+  },
+] as const;

--- a/packages/cel-spec/src/testdata/simple.ts
+++ b/packages/cel-spec/src/testdata/simple.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { testdataJson } from "../testdata-json.js";
+import { testdata } from "./conformance.js";
 import { fromJson, type JsonObject } from "@bufbuild/protobuf";
 import { SimpleTestFileSchema } from "../gen/cel/expr/conformance/test/simple_pb.js";
 import type { SimpleTestFile } from "../gen/cel/expr/conformance/test/simple_pb.js";
@@ -25,9 +25,9 @@ import { getTestRegistry } from "./registry.js";
 export function getSimpleTestFiles(): SimpleTestFile[] {
   const files: SimpleTestFile[] = [];
   const registry = getTestRegistry();
-  for (const json of testdataJson) {
+  for (const file of testdata) {
     files.push(
-      fromJson(SimpleTestFileSchema, json as JsonObject, { registry }),
+      fromJson(SimpleTestFileSchema, file as JsonObject, { registry }),
     );
   }
   return files;
@@ -59,4 +59,4 @@ type TestNameTuples<FN, S> = S extends {
     : never
   : never;
 
-type file = (typeof testdataJson)[number];
+type file = (typeof testdata)[number];

--- a/packages/cel-spec/turbo.json
+++ b/packages/cel-spec/turbo.json
@@ -10,7 +10,7 @@
     },
     "fetch-testdata": {
       "inputs": ["scripts/fetch-testdata.js", "package.json"],
-      "outputs": ["src/testdata-json.ts"],
+      "outputs": ["src/testdata/conformance.ts", "src/testdata/json/*.json"],
       "dependsOn": ["fetch-proto"],
       "outputLogs": "new-only"
     },
@@ -23,6 +23,17 @@
     "fetch-parser-comprehensions": {
       "inputs": ["scripts/*.go", "scripts/go.*", "package.json"],
       "outputs": ["src/testdata/parser-comprehensions.ts"],
+      "env": ["GO*"],
+      "outputLogs": "new-only"
+    },
+    "fetch-parser-conformance": {
+      "inputs": [
+        "scripts/*.go",
+        "scripts/go.*",
+        "package.json",
+        "src/testdata/json/*.json"
+      ],
+      "outputs": ["src/testdata/parser-conformance.ts"],
       "env": ["GO*"],
       "outputLogs": "new-only"
     },

--- a/packages/cel/src/parser-conformance.test.ts
+++ b/packages/cel/src/parser-conformance.test.ts
@@ -1,0 +1,52 @@
+// Copyright 2024-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "node:assert/strict";
+import { suite, test } from "node:test";
+import {
+  toDebugString,
+  KindAdorner,
+} from "@bufbuild/cel-spec/testdata/to-debug-string.js";
+import { parserTests } from "@bufbuild/cel-spec/testdata/parser-conformance.js";
+import { parse } from "./parser.js";
+
+const skip: string[] = [
+  // should fail
+  "cel.block([[1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) > 0), size([cel.index(0)]), [2].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) > 1), size([cel.index(2)])], cel.index(1) + cel.index(1) + cel.index(3) + cel.index(3))",
+  "cel.block([[1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) > 0), [cel.index(0)], ['a'].exists(cel.iterVar(0, 1), cel.iterVar(0, 1) == 'a'), [cel.index(2)]], cel.index(1) + cel.index(1) + cel.index(3) + cel.index(3))",
+  "cel.block([[1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) > 0)], cel.index(0) && cel.index(0) && [1].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) > 1) && [2].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) > 1))",
+  "cel.block([[1, 2, 3]], cel.index(0).map(cel.iterVar(0, 0), cel.index(0).map(cel.iterVar(1, 0), cel.iterVar(1, 0) + 1)))",
+  "[1, 2].map(cel.iterVar(0, 0), [1, 2, 3].filter(cel.iterVar(1, 0), cel.iterVar(1, 0) == cel.iterVar(0, 0)))",
+  "cel.block([[1, 2, 3], cel.index(0).map(cel.iterVar(0, 0), cel.index(0).map(cel.iterVar(1, 0), cel.iterVar(1, 0) + 1))], cel.index(1) == cel.index(1))",
+  "cel.block([x - 1, cel.index(0) > 3], [cel.index(1) ? cel.index(0) : 5].exists(cel.iterVar(0, 0), cel.iterVar(0, 0) - 1 > 3) || cel.index(1))",
+  "['foo', 'bar'].map(cel.iterVar(1, 0), [cel.iterVar(1, 0) + cel.iterVar(1, 0), cel.iterVar(1, 0) + cel.iterVar(1, 0)]).map(cel.iterVar(0, 0), [cel.iterVar(0, 0) + cel.iterVar(0, 0), cel.iterVar(0, 0) + cel.iterVar(0, 0)])",
+  "((((((((((((((((((((((((((((((((7))))))))))))))))))))))))))))))))",
+
+  // bug in `cel-go`
+  "[// @\r.// @\rcel.// @\rexpr// @\r.conformance.// @\rproto3.// @\rTestAllTypes// @\r{// @\rsingle_int64// @\r:// @\rint// @\r(// @\r17// @\r)// @\r}// @\r.// @\rsingle_int64// @\r]// @\r[// @\r0// @\r]// @\r==// @\r(// @\r18// @\r-// @\r1// @\r)// @\r\u0026\u0026// @\r!// @\rfalse// @\r?// @\r1// @\r:// @\r2",
+];
+
+void suite("parser conformance tests", () => {
+  for (const t of parserTests) {
+    void test(t.expr, { skip: skip.includes(t.expr) }, () => {
+      if ("ast" in t && t.ast !== undefined) {
+        const actual = toDebugString(parse(t.expr), KindAdorner.singleton);
+        const expected = t.ast;
+        assert.deepStrictEqual(actual, expected);
+      } else {
+        assert.throws(() => parse(t.expr));
+      }
+    });
+  }
+});


### PR DESCRIPTION
I'm not _thrilled_ with the scripts here, but I had a couple of false starts that were worse. I really didn't want to pull the testdata twice and risk there being some subtle inconsistency between the conformance tests when applied end-to-end and when applied only to the parser.

I think there's likely more refinement we could bring to this, but honestly I hope we can clean some of this stuff up by upstream (e.g., by doing away with `textproto`).

Anyway, this certainly resolves #135 as written.