### PR TITLE
Split publish workflow into discrete steps

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ on:
       - "v*"
 
 permissions:
-  id-token: write # Required for OIDC
+  id-token: write # Required for OIDC, see https://docs.npmjs.com/trusted-publishers
   contents: read
 
 jobs:
@@ -18,10 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
-      - run: npm run release
+      - run: npm run all
+      - run: node scripts/gh-diffcheck.js
+      - run: node scripts/release.js

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "all": "turbo run --ui tui build format lint test attw license-header update-readme",
     "setversion": "node scripts/set-workspace-version.js",
     "postsetversion": "npm run all",
-    "release": "npm run all && node scripts/release.js",
     "format": "biome format --write",
     "license-header": "license-header --ignore 'packages/**'",
     "lint": "biome lint --error-on-warnings"

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -25,8 +25,6 @@ import { execSync } from "node:child_process";
  *    publish workflow that runs this script.
  */
 
-gitCheckUncommitted();
-
 const packages = discoverPackages();
 validatePackages(packages);
 
@@ -61,18 +59,6 @@ function validatePackages(packages) {
         `Inconsistent workspace versions: ${packages[0].name}@${version} vs ${pkg.name}@${pkg.version}`,
       );
     }
-  }
-}
-
-/**
- * Throws if there are uncommitted changes in the working tree.
- */
-function gitCheckUncommitted() {
-  const out = execSync("git status --short", {
-    encoding: "utf-8",
-  });
-  if (out.trim().length > 0) {
-    throw new Error("Uncommitted changes found: \n" + out);
   }
 }
 


### PR DESCRIPTION
This replaces the npm "release" script with discrete workflow steps in publish.yaml.

The workflow calling npm, npm calling a node script, and the node script calling npm again seemed a bit much. This peels off one layer of the onion. This change also allows us to reuse scripts/gh-diffcheck.js instead of reimplementing the same check in release.js.