### PR TITLE
Fix set-workspace-version.js

### DIFF
--- a/scripts/set-workspace-version.js
+++ b/scripts/set-workspace-version.js
@@ -25,10 +25,9 @@ if (
     [
       `USAGE: ${process.argv[1]} <new-version>`,
       "",
-      "Walks through all workspace packages and sets the version of each ",
-      "package to the given version.",
-      "If a package depends on another package from the workspace, the",
-      "dependency version is updated as well.",
+      "Sets the version across all workspace packages. For example 1.2.3, or 2.0.0-alpha.0.",
+      "",
+      "This script exists because `npm version` does not update cross-workspace dependency entries.",
       "",
     ].join("\n"),
   );

--- a/scripts/set-workspace-version.js
+++ b/scripts/set-workspace-version.js
@@ -187,10 +187,6 @@ function readPackage(path) {
   if (typeof json !== "object" || json === null) {
     throw new Error(`Failed to parse ${path}`);
   }
-  const lock = JSON.parse(readFileSync(path, "utf-8"));
-  if (typeof lock !== "object" || lock === null) {
-    throw new Error(`Failed to parse ${path}`);
-  }
   if (!("name" in json) || typeof json.name != "string") {
     throw new Error(`Missing "name" in ${path}`);
   }
@@ -201,7 +197,7 @@ function readPackage(path) {
   } else if (!("private" in json) || json.private !== true) {
     throw new Error(`Need either "version" or "private":true in ${path}`);
   }
-  return lock;
+  return json;
 }
 
 /**

--- a/scripts/set-workspace-version.js
+++ b/scripts/set-workspace-version.js
@@ -17,7 +17,10 @@
 import { readFileSync, writeFileSync, existsSync, globSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-if (process.argv.length !== 3 || !/^\d+\.\d+\.\d+$/.test(process.argv[2])) {
+if (
+  process.argv.length !== 3 ||
+  !/^\d+\.\d+\.\d+(-(?:alpha|beta|rc).*)?$/.test(process.argv[2])
+) {
   process.stderr.write(
     [
       `USAGE: ${process.argv[1]} <new-version>`,


### PR DESCRIPTION
Fixes a small issue with a double read, relaxes the regex to accept pre-release versions, and tightens up comments.