### PR TITLE
Handle private packages in publish script

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -30,14 +30,20 @@ validatePackages(packages);
 
 const version = packages[0].version;
 gitCheckReleaseTag(version);
-npmPublish(version);
+
+const pkgNames = packages.map((pkg) => pkg.name);
+npmPublish(pkgNames, version);
 
 /**
+ * Publish each workspace package by name.
+ *
+ * @param {string[]} pkgNames
  * @param {string} version
  */
-function npmPublish(version) {
+function npmPublish(pkgNames, version) {
   const tag = determinePublishTag(version);
-  execSync(`npm publish --tag ${tag} --workspaces`, {
+  const workspaceArgs = pkgNames.map((name) => `--workspace=${name}`).join(" ");
+  execSync(`npm publish --tag ${tag} ${workspaceArgs}`, {
     stdio: "inherit",
   });
 }


### PR DESCRIPTION
`npm publish --workspaces` tries to publish all packages in a workspace (even private packages). This causes the release script to fail if the workspace contains private packages.

This is currently not an issue for cel-es, but I've fixed it here for uniformity with our other repositories.