### PR TITLE
Add dependabot-automerge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -1,0 +1,24 @@
+# Automatically merge Dependabot PRs that pass CI and aren't major version bumps.
+name: dependabot-automerge
+on:
+  pull_request:
+  workflow_run:
+    # Name of workflows whose jobs run on Dependabot PRs.
+    # Each successful completion on a dependabot/** branch wakes the sweep.
+    # The cron below is the backstop.
+    workflows:
+      - "ci"
+    types: [completed]
+    branches: ["dependabot/**"]
+  schedule:
+    - cron: "0 13 * * *" # 13:00 UTC weekdays (8am EST / 9am EDT)
+  workflow_dispatch:
+permissions: {}
+jobs:
+  automerge:
+    uses: bufbuild/base-workflows/.github/workflows/dependabot-automerge.yaml@d80278db600dfe9e959ba815200b38a9c3d9e78c # main
+    secrets:
+      DEPENDENCY_AUTOMERGE_APP_ID: ${{ secrets.DEPENDENCY_AUTOMERGE_APP_ID }}
+      DEPENDENCY_AUTOMERGE_APP_PRIVATE_KEY: ${{ secrets.DEPENDENCY_AUTOMERGE_APP_PRIVATE_KEY }}
+    with:
+      github-auto-merge: false


### PR DESCRIPTION
Automatically merge Dependabot PRs that pass CI and aren't major version bumps.